### PR TITLE
Query history panel with click-to-reopen (closes #6)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import { ConnectionManager, type ConnectionForm } from './components/ConnectionM
 import { api } from './api';
 import type { SchemaData } from './api';
 import { saveConnection } from './savedConnections';
+import { addHistoryEntry, listHistory, deleteHistoryEntry, clearHistory, type HistoryEntry } from './queryHistory';
 
 interface Tab {
   id: string;
@@ -30,6 +31,7 @@ export default function App() {
   const [connectionError, setConnectionError] = useState<string | null>(null);
   const [connectionName, setConnectionName] = useState('Not connected');
   const [connectionHost, setConnectionHost] = useState<string | null>(null);
+  const [history, setHistory] = useState<HistoryEntry[]>([]);
 
   const [schemas, setSchemas] = useState<string[]>([]);
   const [activeSchema, setActiveSchema] = useState('');
@@ -75,6 +77,7 @@ export default function App() {
       const friendly = form.name.trim();
       setConnectionName(friendly || res.connectionName);
       setConnectionHost(res.connectionName);
+      setHistory(listHistory(res.connectionName));
       setSchemas(list);
       setActiveSchema(initial);
       setConnected(true);
@@ -103,6 +106,7 @@ export default function App() {
     setConnected(false);
     setConnectionName('Not connected');
     setConnectionHost(null);
+    setHistory([]);
     setConnectionError(null);
     setSchemas([]);
     setActiveSchema('');
@@ -165,15 +169,46 @@ export default function App() {
     setQueryError(null);
     setExecTime(null);
 
+    const started = Date.now();
     try {
       const res = await api.query(sql, activeSchema);
       setResults({ columns: res.columns, columnMeta: res.columnMeta, rows: res.rows });
       setExecTime(res.executionTime);
+      if (connectionHost) {
+        const entry = addHistoryEntry(connectionHost, {
+          sql, schema: activeSchema, executedAt: started,
+          durationMs: res.executionTime, status: 'ok', rowCount: res.rows.length,
+        });
+        if (entry) setHistory(prev => [entry, ...prev].slice(0, 100));
+      }
     } catch (err) {
-      setQueryError(err instanceof Error ? err.message : String(err));
+      const message = err instanceof Error ? err.message : String(err);
+      setQueryError(message);
+      if (connectionHost) {
+        const entry = addHistoryEntry(connectionHost, {
+          sql, schema: activeSchema, executedAt: started,
+          durationMs: Date.now() - started, status: 'error', error: message,
+        });
+        if (entry) setHistory(prev => [entry, ...prev].slice(0, 100));
+      }
     } finally {
       setIsRunning(false);
     }
+  };
+
+  const handleReopenHistory = (entry: HistoryEntry) => {
+    addTab(`history_${entry.id.slice(0, 8)}.sql`, entry.sql);
+  };
+
+  const handleDeleteHistoryEntry = (id: string) => {
+    if (!connectionHost) return;
+    setHistory(deleteHistoryEntry(connectionHost, id));
+  };
+
+  const handleClearHistory = () => {
+    if (!connectionHost) return;
+    clearHistory(connectionHost);
+    setHistory([]);
   };
 
   const handleQueryChange = (val: string) => {
@@ -267,6 +302,10 @@ export default function App() {
               onRun={handleRun}
               isRunning={isRunning}
               activeSchema={activeSchema}
+              history={history}
+              onReopenHistory={handleReopenHistory}
+              onDeleteHistoryEntry={handleDeleteHistoryEntry}
+              onClearHistory={handleClearHistory}
               t={t}
             />
           </div>

--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -1,5 +1,6 @@
-import { useRef, CSSProperties } from 'react';
+import { useEffect, useRef, useState, CSSProperties } from 'react';
 import type { Theme } from '../theme';
+import type { HistoryEntry } from '../queryHistory';
 
 interface QueryEditorProps {
   value: string;
@@ -7,7 +8,27 @@ interface QueryEditorProps {
   onRun: () => void;
   isRunning: boolean;
   activeSchema: string;
+  history?: HistoryEntry[];
+  onReopenHistory?: (entry: HistoryEntry) => void;
+  onDeleteHistoryEntry?: (id: string) => void;
+  onClearHistory?: () => void;
   t: Theme;
+}
+
+function formatRelative(ts: number, now: number): string {
+  const s = Math.max(0, Math.round((now - ts) / 1000));
+  if (s < 60) return `${s}s ago`;
+  const m = Math.round(s / 60);
+  if (m < 60) return `${m}m ago`;
+  const h = Math.round(m / 60);
+  if (h < 24) return `${h}h ago`;
+  const d = Math.round(h / 24);
+  return `${d}d ago`;
+}
+
+function oneLine(sql: string, max = 120): string {
+  const s = sql.replace(/\s+/g, ' ').trim();
+  return s.length > max ? s.slice(0, max - 1) + '…' : s;
 }
 
 const ToolBtn = ({ title, onClick, children, t }: { title: string; onClick?: () => void; children: React.ReactNode; t: Theme }) => (
@@ -20,8 +41,32 @@ const ToolBtn = ({ title, onClick, children, t }: { title: string; onClick?: () 
   </button>
 );
 
-export function QueryEditor({ value, onChange, onRun, isRunning, activeSchema, t }: QueryEditorProps) {
+export function QueryEditor({
+  value, onChange, onRun, isRunning, activeSchema,
+  history = [], onReopenHistory, onDeleteHistoryEntry, onClearHistory,
+  t,
+}: QueryEditorProps) {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const [historyOpen, setHistoryOpen] = useState(false);
+  const historyAnchorRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!historyOpen) return;
+    const onClick = (e: MouseEvent) => {
+      if (historyAnchorRef.current && !historyAnchorRef.current.contains(e.target as Node)) {
+        setHistoryOpen(false);
+      }
+    };
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') setHistoryOpen(false); };
+    window.addEventListener('click', onClick);
+    window.addEventListener('keydown', onKey);
+    return () => {
+      window.removeEventListener('click', onClick);
+      window.removeEventListener('keydown', onKey);
+    };
+  }, [historyOpen]);
+
+  const now = Date.now();
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
@@ -41,7 +86,7 @@ export function QueryEditor({ value, onChange, onRun, isRunning, activeSchema, t
   };
 
   const s = {
-    root: { display: 'flex', flexDirection: 'column', background: t.bgSurface, borderBottom: `1px solid ${t.border}`, overflow: 'hidden' } as CSSProperties,
+    root: { display: 'flex', flexDirection: 'column', background: t.bgSurface, borderBottom: `1px solid ${t.border}` } as CSSProperties,
     toolbar: { display: 'flex', alignItems: 'center', gap: 2, padding: '5px 10px', borderBottom: `1px solid ${t.border}`, flexShrink: 0, background: t.bgToolbar } as CSSProperties,
     runBtn: { display: 'flex', alignItems: 'center', gap: 6, height: 28, padding: '0 12px', background: t.accent, color: t.textInverse, border: 'none', borderRadius: 5, fontSize: 12, fontWeight: 600, fontFamily: '"IBM Plex Sans", sans-serif', cursor: 'pointer' } as CSSProperties,
     sep: { width: 1, height: 18, background: t.border, margin: '0 4px' } as CSSProperties,
@@ -73,11 +118,99 @@ export function QueryEditor({ value, onChange, onRun, isRunning, activeSchema, t
             <path d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2z"/><polyline points="17 21 17 13 7 13 7 21"/><polyline points="7 3 7 8 15 8"/>
           </svg>
         </ToolBtn>
-        <ToolBtn title="Query history" t={t}>
-          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-            <path d="M3 3v5h5"/><path d="M3.05 13A9 9 0 1 0 6 5.3L3 8"/><line x1="12" y1="7" x2="12" y2="12"/><line x1="12" y1="12" x2="15" y2="15"/>
-          </svg>
-        </ToolBtn>
+        <div ref={historyAnchorRef} style={{ position: 'relative' }}>
+          <button
+            onClick={() => setHistoryOpen(o => !o)}
+            title={history.length > 0 ? `Query history (${history.length})` : 'Query history — empty'}
+            style={{
+              display: 'flex', alignItems: 'center', justifyContent: 'center',
+              width: 28, height: 28, background: historyOpen ? t.bgSurface : 'none',
+              border: 'none', borderRadius: 5, cursor: 'pointer',
+              color: historyOpen ? t.textPrimary : t.textMuted,
+            }}
+          >
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M3 3v5h5"/><path d="M3.05 13A9 9 0 1 0 6 5.3L3 8"/><line x1="12" y1="7" x2="12" y2="12"/><line x1="12" y1="12" x2="15" y2="15"/>
+            </svg>
+          </button>
+          {historyOpen && (
+            <div
+              role="listbox"
+              style={{
+                position: 'absolute', top: '100%', left: 0, marginTop: 4, zIndex: 100,
+                width: 440, maxHeight: 340, overflowY: 'auto',
+                background: t.bgElevated, border: `1px solid ${t.border}`,
+                borderRadius: 6, boxShadow: t.shadowLg, padding: 4,
+                fontFamily: '"IBM Plex Sans", sans-serif', fontSize: 12,
+              }}
+            >
+              {history.length === 0 && (
+                <div style={{ padding: '14px 12px', fontSize: 12, color: t.textMuted, fontStyle: 'italic' }}>
+                  No recent queries for this connection.
+                </div>
+              )}
+              {history.map(entry => (
+                <div
+                  key={entry.id}
+                  onClick={() => { onReopenHistory?.(entry); setHistoryOpen(false); }}
+                  style={{
+                    display: 'flex', flexDirection: 'column', gap: 3,
+                    padding: '8px 10px', borderRadius: 4, cursor: 'pointer',
+                    borderLeft: `3px solid ${entry.status === 'ok' ? t.colorSuccess : t.colorError}`,
+                  }}
+                  onMouseEnter={(e) => { e.currentTarget.style.background = t.bgHover; }}
+                  onMouseLeave={(e) => { e.currentTarget.style.background = 'transparent'; }}
+                >
+                  <div style={{
+                    fontFamily: '"JetBrains Mono", monospace', fontSize: 11.5, lineHeight: 1.4,
+                    color: t.textPrimary, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis',
+                  }}>{oneLine(entry.sql)}</div>
+                  <div style={{
+                    display: 'flex', alignItems: 'center', gap: 8,
+                    fontSize: 10, color: t.textMuted,
+                  }}>
+                    <span>{formatRelative(entry.executedAt, now)}</span>
+                    <span>·</span>
+                    <span style={{ fontFamily: 'monospace' }}>{entry.schema || '—'}</span>
+                    {entry.status === 'ok' && (<>
+                      <span>·</span>
+                      <span>{entry.durationMs !== null ? `${entry.durationMs}ms` : '—'}</span>
+                      {entry.rowCount !== undefined && (<>
+                        <span>·</span>
+                        <span>{entry.rowCount} rows</span>
+                      </>)}
+                    </>)}
+                    {entry.status === 'error' && (<>
+                      <span>·</span>
+                      <span style={{ color: t.colorError, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', flex: 1 }}>{entry.error}</span>
+                    </>)}
+                    {onDeleteHistoryEntry && (
+                      <button
+                        onClick={(e) => { e.stopPropagation(); onDeleteHistoryEntry(entry.id); }}
+                        title="Remove from history"
+                        style={{ marginLeft: 'auto', border: 'none', background: 'transparent', color: t.textMuted, cursor: 'pointer', padding: 2, fontSize: 11 }}
+                      >×</button>
+                    )}
+                  </div>
+                </div>
+              ))}
+              {history.length > 0 && onClearHistory && (
+                <div style={{ display: 'flex', justifyContent: 'flex-end', padding: '4px 6px', borderTop: `1px solid ${t.borderSubtle}`, marginTop: 4 }}>
+                  <button
+                    onClick={() => { onClearHistory(); setHistoryOpen(false); }}
+                    style={{
+                      padding: '4px 10px', fontSize: 11, fontFamily: 'inherit',
+                      background: 'transparent', color: t.textMuted,
+                      border: 'none', borderRadius: 3, cursor: 'pointer',
+                    }}
+                    onMouseEnter={(e) => { e.currentTarget.style.color = t.colorError; }}
+                    onMouseLeave={(e) => { e.currentTarget.style.color = t.textMuted; }}
+                  >Clear history</button>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
         <div style={{ flex: 1 }}/>
         <span style={s.schemaPill}>
           <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">

--- a/src/queryHistory.ts
+++ b/src/queryHistory.ts
@@ -1,0 +1,59 @@
+export interface HistoryEntry {
+  id: string;
+  sql: string;
+  schema: string;
+  executedAt: number;          // ms since epoch
+  durationMs: number | null;
+  status: 'ok' | 'error';
+  rowCount?: number;
+  error?: string;
+}
+
+const MAX_PER_CONNECTION = 100;
+
+function keyFor(conn: string): string {
+  return `helix.history.${conn}`;
+}
+
+function read(conn: string): HistoryEntry[] {
+  try {
+    const raw = localStorage.getItem(keyFor(conn));
+    if (!raw) return [];
+    const parsed = JSON.parse(raw) as unknown;
+    return Array.isArray(parsed) ? (parsed as HistoryEntry[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+function write(conn: string, list: HistoryEntry[]): void {
+  try { localStorage.setItem(keyFor(conn), JSON.stringify(list)); } catch { /* quota / disabled — ignore */ }
+}
+
+export function listHistory(conn: string): HistoryEntry[] {
+  return conn ? read(conn) : [];
+}
+
+export function addHistoryEntry(
+  conn: string,
+  entry: Omit<HistoryEntry, 'id'>,
+): HistoryEntry | null {
+  if (!conn) return null;
+  const id = `${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+  const full: HistoryEntry = { id, ...entry };
+  const list = read(conn);
+  list.unshift(full);
+  if (list.length > MAX_PER_CONNECTION) list.length = MAX_PER_CONNECTION;
+  write(conn, list);
+  return full;
+}
+
+export function deleteHistoryEntry(conn: string, id: string): HistoryEntry[] {
+  const next = read(conn).filter(e => e.id !== id);
+  write(conn, next);
+  return next;
+}
+
+export function clearHistory(conn: string): void {
+  try { localStorage.removeItem(keyFor(conn)); } catch { /* ignore */ }
+}


### PR DESCRIPTION
## Summary

Closes #6. The Query history icon in the editor toolbar was a no-op. It now opens a themed dropdown of recent queries for the active connection; clicking an entry reopens the SQL in a new tab.

## Walkthrough

<img width="1098" height="560" alt="query-history" src="https://github.com/user-attachments/assets/b356613a-9452-49ab-91fa-048685a160fd" />


Flow: run a few queries (including one that errors) → click the history icon → panel shows entries, latest first, with relative time / schema / duration / row count (or error message) → click an entry to reopen its SQL in a new tab.

## Changes

- **New `src/queryHistory.ts`** — localStorage-backed ring buffer, keyed per connection (\`helix.history.<user@host:port>\`), capped at 100 entries each. Helpers: \`listHistory\`, \`addHistoryEntry\`, \`deleteHistoryEntry\`, \`clearHistory\`.
- **`src/App.tsx`**
  - Loads history into React state on successful connect, clears on disconnect.
  - \`handleRun\` appends a new entry on both success and failure, recording SQL, schema, timestamp, duration, status (\`ok\`/\`error\`), and either row count or error message.
  - Adds \`handleReopenHistory\` (opens a new tab named \`history_<id>.sql\` with the saved SQL), \`handleDeleteHistoryEntry\`, and \`handleClearHistory\`.
- **`src/components/QueryEditor.tsx`**
  - New \`history\`, \`onReopenHistory\`, \`onDeleteHistoryEntry\`, \`onClearHistory\` props (all optional).
  - Query history icon now opens a themed dropdown panel anchored to the button; closes on outside click / Escape.
  - Each entry: mono-font SQL (one line, truncated), colored left border for ok/error, muted metadata line (relative time · schema · duration · rows | error), tiny × to remove, and a \"Clear history\" footer.
  - Removed stray \`overflow: hidden\` on the editor root that was clipping the absolute-positioned panel (the inner \`editorWrap\` still clips the textarea).

## Test plan

Verified against the employees demo DB:

- [x] Run 4 queries including one error → \`localStorage.helix.history.root@127.0.0.1:3310\` shows all 4 with correct metadata (success/failure, duration, row count, error text)
- [x] Panel renders all entries with latest first
- [x] Error entry shows red left border + the MySQL error message inline
- [x] Clicking an entry opens a new tab with the saved SQL as editor contents
- [x] Entries survive a full page reload (persisted to localStorage)
- [x] History is scoped per connection: disconnect clears the in-memory view; reconnect restores from storage

🤖 Generated with [Claude Code](https://claude.com/claude-code)