### PR TITLE
fix: add styled tooltips to query editor toolbar buttons

### DIFF
--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -40,7 +40,8 @@ function oneLine(sql: string, max = 120): string {
 const ToolBtn = ({ title, onClick, active, children, t }: { title: string; onClick?: () => void; active?: boolean; children: React.ReactNode; t: Theme }) => (
   <button
     style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', width: 28, height: 28, background: active ? t.bgSurface : 'none', border: 'none', borderRadius: 5, cursor: 'pointer', color: active ? t.textPrimary : t.textMuted }}
-    title={title}
+    aria-label={title}
+    data-tooltip={title}
     onClick={onClick}
   >
     {children}
@@ -169,7 +170,7 @@ export function QueryEditor({
   return (
     <div style={s.root}>
       <div style={s.toolbar}>
-        <button style={{ ...s.runBtn, opacity: isRunning ? 0.85 : 1 }} onClick={onRun}>
+        <button style={{ ...s.runBtn, opacity: isRunning ? 0.85 : 1 }} onClick={onRun} data-tooltip={isRunning ? 'Stop query' : 'Run query (⌘↵)'}>
           {isRunning
             ? <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><rect x="6" y="6" width="12" height="12"/></svg>
             : <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><polygon points="5 3 19 12 5 21 5 3"/></svg>}
@@ -333,7 +334,8 @@ export function QueryEditor({
         <div ref={historyAnchorRef} style={{ position: 'relative' }}>
           <button
             onClick={() => setHistoryOpen(o => !o)}
-            title={history.length > 0 ? `Query history (${history.length})` : 'Query history — empty'}
+            aria-label={history.length > 0 ? `Query history (${history.length})` : 'Query history — empty'}
+            data-tooltip={history.length > 0 ? `Query history (${history.length})` : 'Query history — empty'}
             style={{
               display: 'flex', alignItems: 'center', justifyContent: 'center',
               width: 28, height: 28, background: historyOpen ? t.bgSurface : 'none',

--- a/src/index.css
+++ b/src/index.css
@@ -124,3 +124,28 @@ body {
 ::-webkit-scrollbar-track { background: transparent; }
 ::-webkit-scrollbar-thumb { background: var(--border); border-radius: 3px; }
 ::-webkit-scrollbar-thumb:hover { background: var(--border-strong); }
+
+/* CSS tooltips via data-tooltip attribute */
+[data-tooltip] { position: relative; }
+[data-tooltip]::after {
+  content: attr(data-tooltip);
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 50%;
+  transform: translateX(-50%);
+  white-space: nowrap;
+  padding: 4px 8px;
+  background: var(--bg-overlay);
+  color: var(--text-primary);
+  font-family: var(--font-ui);
+  font-size: 11px;
+  line-height: 1.4;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow-md);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.12s ease;
+  z-index: 9999;
+}
+[data-tooltip]:hover::after { opacity: 1; }


### PR DESCRIPTION
## Summary

- Replaces native browser title attributes with CSS-based tooltips via data-tooltip pseudo-elements
- Tooltips appear instantly on hover, styled with app theme variables (dark and light modes)
- Covers all 5 toolbar controls: Run, Format SQL, Save query, Saved queries (with count), Query history (with count)
- Adds aria-label to icon-only buttons for accessibility

## Test plan

- Hover each toolbar button and confirm tooltip appears immediately below
- Verify text: "Run query", "Format SQL", "Save query", "Saved queries (N)", "Query history (N)"
- Switch to light theme and confirm tooltip styling is readable
- Confirm no double (native + custom) tooltip appears

Closes #36

Generated with Claude Code