### PR TITLE
fix: boolean cell editor for tinyint(1) columns

### DIFF
--- a/server/src/routes/updateCell.ts
+++ b/server/src/routes/updateCell.ts
@@ -15,7 +15,7 @@ export const postUpdateCell: RequestHandler = async (req, res) => {
     table?: string;
     where?: WhereClause[];
     column?: string;
-    value?: string | number | null;
+    value?: string | number | boolean | null;
   };
 
   if (!table || typeof table !== 'string' || !table.trim()) {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -149,7 +149,7 @@ export default function App() {
 
   const handleUpdateCell = async (
     row: Record<string, string | number | null>,
-    target: { table: string; where: { column: string; value: string | number | null }[]; column: string; value: string | number | null },
+    target: { table: string; where: { column: string; value: string | number | null }[]; column: string; value: string | number | boolean | null },
   ) => {
     await api.updateCell(activeSchema, target.table, target.where, target.column, target.value);
     setResults(prev => {

--- a/src/api.ts
+++ b/src/api.ts
@@ -100,7 +100,7 @@ export const api = {
     });
   },
 
-  updateCell(schema: string, table: string, where: DeleteRowWhere[], column: string, value: string | number | null) {
+  updateCell(schema: string, table: string, where: DeleteRowWhere[], column: string, value: string | number | boolean | null) {
     return request<{ affectedRows: number; changedRows: number; sql: string }>('/api/update-cell', {
       method: 'POST',
       body: JSON.stringify({ schema, table, where, column, value }),

--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -40,7 +40,8 @@ function oneLine(sql: string, max = 120): string {
 const ToolBtn = ({ title, onClick, active, children, t }: { title: string; onClick?: () => void; active?: boolean; children: React.ReactNode; t: Theme }) => (
   <button
     style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', width: 28, height: 28, background: active ? t.bgSurface : 'none', border: 'none', borderRadius: 5, cursor: 'pointer', color: active ? t.textPrimary : t.textMuted }}
-    title={title}
+    aria-label={title}
+    data-tooltip={title}
     onClick={onClick}
   >
     {children}
@@ -169,7 +170,7 @@ export function QueryEditor({
   return (
     <div style={s.root}>
       <div style={s.toolbar}>
-        <button style={{ ...s.runBtn, opacity: isRunning ? 0.85 : 1 }} onClick={onRun}>
+        <button style={{ ...s.runBtn, opacity: isRunning ? 0.85 : 1 }} onClick={onRun} data-tooltip={isRunning ? 'Stop query' : 'Run query (⌘↵)'}>
           {isRunning
             ? <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><rect x="6" y="6" width="12" height="12"/></svg>
             : <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><polygon points="5 3 19 12 5 21 5 3"/></svg>}
@@ -333,7 +334,8 @@ export function QueryEditor({
         <div ref={historyAnchorRef} style={{ position: 'relative' }}>
           <button
             onClick={() => setHistoryOpen(o => !o)}
-            title={history.length > 0 ? `Query history (${history.length})` : 'Query history — empty'}
+            aria-label={history.length > 0 ? `Query history (${history.length})` : 'Query history — empty'}
+            data-tooltip={history.length > 0 ? `Query history (${history.length})` : 'Query history — empty'}
             style={{
               display: 'flex', alignItems: 'center', justifyContent: 'center',
               width: 28, height: 28, background: historyOpen ? t.bgSurface : 'none',

--- a/src/components/ResultsTable.tsx
+++ b/src/components/ResultsTable.tsx
@@ -11,7 +11,7 @@ export interface QueryResults {
 }
 
 type Row = Record<string, string | number | null>;
-type CellValue = string | number | null;
+type CellValue = string | number | boolean | null;
 
 interface DeleteTarget {
   table: string;
@@ -25,7 +25,7 @@ export interface UpdateCellTarget {
   value: CellValue;
 }
 
-type EditKind = 'number' | 'date' | 'datetime' | 'time' | 'text';
+type EditKind = 'boolean' | 'number' | 'date' | 'datetime' | 'time' | 'text';
 
 function editKindForType(type: number): EditKind {
   // MySQL column type codes
@@ -71,6 +71,13 @@ function commentFor(schemaData: SchemaData | undefined, meta: ColumnMeta | undef
   const table = schemaData.tables.find(x => x.name === meta.orgTable);
   const col = table?.columns.find(c => c.name === meta.orgName);
   return col?.comment || undefined;
+}
+
+function isBoolColumn(schemaData: SchemaData | undefined, meta: ColumnMeta | undefined): boolean {
+  if (!schemaData || !meta?.orgTable || !meta.orgName) return false;
+  const table = schemaData.tables.find(x => x.name === meta.orgTable);
+  const col = table?.columns.find(c => c.name === meta.orgName);
+  return col?.type === 'tinyint(1)';
 }
 
 interface Deletability {
@@ -123,7 +130,7 @@ export function ResultsTable({ results, isRunning, error, executionTime, activeS
   const [deleteError, setDeleteError] = useState<string | null>(null);
   const [deleting, setDeleting] = useState(false);
 
-  const [editing, setEditing] = useState<{ row: Row; col: string; draft: string; kind: EditKind; saving: boolean; error: string | null } | null>(null);
+  const [editing, setEditing] = useState<{ row: Row; col: string; draft: string; kind: EditKind; nullable: boolean; saving: boolean; error: string | null } | null>(null);
   const [confirmUpdate, setConfirmUpdate] = useState<{ row: Row; target: UpdateCellTarget; error: string | null; saving: boolean } | null>(null);
   const [insertOpen, setInsertOpen] = useState(false);
   const [exportOpen, setExportOpen] = useState(false);
@@ -547,14 +554,17 @@ export function ResultsTable({ results, isRunning, error, executionTime, activeS
               const editable = !!(onUpdateCell && meta && meta.orgTable && meta.orgName && !meta.pk);
               if (!editable || !meta) break;
               e.preventDefault();
-              const kind = editKindForType(meta.mysqlType);
+              const kind = isBoolColumn(schemaData, meta) ? 'boolean' : editKindForType(meta.mysqlType);
+              const nullable = !meta.notNull;
               const current = row[col];
-              const draft = current === null || current === undefined ? ''
+              const draft = kind === 'boolean'
+                ? (current === null || current === undefined ? 'null' : current === 1 || current === true ? 'true' : 'false')
+                : current === null || current === undefined ? ''
                 : kind === 'datetime' ? toDatetimeLocal(current)
                 : kind === 'date' ? String(current).slice(0, 10)
                 : kind === 'time' ? String(current).slice(-8)
                 : String(current);
-              setEditing({ row, col, draft, kind, saving: false, error: null });
+              setEditing({ row, col, draft, kind, nullable, saving: false, error: null });
               break;
             }
             case 'Escape': {
@@ -690,15 +700,17 @@ export function ResultsTable({ results, isRunning, error, executionTime, activeS
                       onDoubleClick={(e) => {
                         if (!editable || !meta) return;
                         e.stopPropagation();
-                        const kind = editKindForType(meta.mysqlType);
+                        const kind = isBoolColumn(schemaData, meta) ? 'boolean' : editKindForType(meta.mysqlType);
+                        const nullable = !meta.notNull;
                         const current = row[col];
-                        const draft = current === null || current === undefined
-                          ? ''
+                        const draft = kind === 'boolean'
+                          ? (current === null || current === undefined ? 'null' : current === 1 || current === true ? 'true' : 'false')
+                          : current === null || current === undefined ? ''
                           : kind === 'datetime' ? toDatetimeLocal(current)
                           : kind === 'date' ? String(current).slice(0, 10)
                           : kind === 'time' ? String(current).slice(-8)
                           : String(current);
-                        setEditing({ row, col, draft, kind, saving: false, error: null });
+                        setEditing({ row, col, draft, kind, nullable, saving: false, error: null });
                       }}
                       title={(() => {
                         const comment = commentFor(schemaData, meta);
@@ -710,6 +722,7 @@ export function ResultsTable({ results, isRunning, error, executionTime, activeS
                         <CellEditor
                           t={t}
                           kind={editing!.kind}
+                          nullable={editing!.nullable}
                           draft={editing!.draft}
                           saving={editing!.saving || !!confirmUpdate}
                           error={editing!.error}
@@ -731,13 +744,18 @@ export function ResultsTable({ results, isRunning, error, executionTime, activeS
                             }
                             const raw = editing.draft;
                             let value: CellValue;
-                            if (raw === '' && !editedMeta.notNull) value = null;
+                            if (editing.kind === 'boolean') value = raw === 'null' ? null : raw === 'true';
+                            else if (raw === '' && !editedMeta.notNull) value = null;
                             else if (editing.kind === 'number') value = raw === '' ? '' : Number(raw);
                             else if (editing.kind === 'datetime') value = raw === '' ? null : fromDatetimeLocal(raw);
                             else value = raw;
 
                             const currentVal = editing.row[editing.col] ?? null;
-                            if (value === currentVal) { setEditing(null); return; }
+                            const normBool = (v: CellValue) => v === null ? null : (v === 1 || v === true);
+                            const unchanged = editing.kind === 'boolean'
+                              ? normBool(value) === normBool(currentVal)
+                              : value === currentVal;
+                            if (unchanged) { setEditing(null); return; }
 
                             setConfirmUpdate({
                               row: editing.row,
@@ -748,7 +766,11 @@ export function ResultsTable({ results, isRunning, error, executionTime, activeS
                           }}
                         />
                       ) : (
-                        row[col] === null ? <em>NULL</em> : String(row[col])
+                        row[col] === null
+                          ? <em>NULL</em>
+                          : isBoolColumn(schemaData, meta)
+                            ? (row[col] === 1 || row[col] === true ? 'true' : 'false')
+                            : String(row[col])
                       )}
                     </td>
                   );
@@ -1002,6 +1024,7 @@ function ExportMenuItem({ t, label, hint, onClick }: { t: Theme; label: string; 
 interface CellEditorProps {
   t: Theme;
   kind: EditKind;
+  nullable?: boolean;
   draft: string;
   saving: boolean;
   error: string | null;
@@ -1012,14 +1035,8 @@ interface CellEditorProps {
   onCancel: () => void;
 }
 
-function CellEditor({ t, kind, draft, saving, error, suspended, inputRef, onChange, onCommit, onCancel }: CellEditorProps) {
-  const inputType = kind === 'number' ? 'number'
-    : kind === 'date' ? 'date'
-    : kind === 'datetime' ? 'datetime-local'
-    : kind === 'time' ? 'time'
-    : 'text';
-
-  const inputStyle: CSSProperties = {
+function CellEditor({ t, kind, nullable, draft, saving, error, suspended, inputRef, onChange, onCommit, onCancel }: CellEditorProps) {
+  const sharedStyle: CSSProperties = {
     width: '100%', boxSizing: 'border-box',
     padding: '6px 12px', margin: 0,
     background: t.bgSurface, color: t.textPrimary,
@@ -1027,6 +1044,49 @@ function CellEditor({ t, kind, draft, saving, error, suspended, inputRef, onChan
     outline: 'none', borderRadius: 2,
     fontFamily: '"JetBrains Mono", monospace', fontSize: 12,
   };
+
+  const sharedKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter') { e.preventDefault(); onCommit(); }
+    else if (e.key === 'Escape') { e.preventDefault(); onCancel(); }
+  };
+
+  const errorBubble = error ? (
+    <div style={{
+      position: 'absolute', top: '100%', left: 0, zIndex: 10,
+      marginTop: 2, padding: '4px 8px',
+      background: t.colorErrorBg, border: `1px solid ${t.colorErrorBorder}`,
+      borderRadius: 3, color: t.colorError, fontSize: 11,
+      fontFamily: '"IBM Plex Sans", sans-serif', whiteSpace: 'nowrap',
+      boxShadow: t.shadowMd,
+    }}>{error}</div>
+  ) : null;
+
+  if (kind === 'boolean') {
+    return (
+      <div style={{ position: 'relative' }} onClick={(e) => e.stopPropagation()}>
+        <select
+          autoFocus
+          value={draft}
+          disabled={saving}
+          onChange={(e) => onChange(e.target.value)}
+          onKeyDown={sharedKeyDown}
+          onBlur={() => { if (!saving && !error && !suspended) onCancel(); }}
+          style={sharedStyle}
+        >
+          {nullable && <option value="null">NULL</option>}
+          <option value="true">true</option>
+          <option value="false">false</option>
+        </select>
+        {errorBubble}
+      </div>
+    );
+  }
+
+  const inputType = kind === 'number' ? 'number'
+    : kind === 'date' ? 'date'
+    : kind === 'datetime' ? 'datetime-local'
+    : kind === 'time' ? 'time'
+    : 'text';
 
   return (
     <div style={{ position: 'relative' }} onClick={(e) => e.stopPropagation()}>
@@ -1037,23 +1097,11 @@ function CellEditor({ t, kind, draft, saving, error, suspended, inputRef, onChan
         disabled={saving}
         step={kind === 'number' ? 'any' : undefined}
         onChange={(e) => onChange(e.target.value)}
-        onKeyDown={(e) => {
-          if (e.key === 'Enter') { e.preventDefault(); onCommit(); }
-          else if (e.key === 'Escape') { e.preventDefault(); onCancel(); }
-        }}
+        onKeyDown={sharedKeyDown}
         onBlur={() => { if (!saving && !error && !suspended) onCancel(); }}
-        style={inputStyle}
+        style={sharedStyle}
       />
-      {error && (
-        <div style={{
-          position: 'absolute', top: '100%', left: 0, zIndex: 10,
-          marginTop: 2, padding: '4px 8px',
-          background: t.colorErrorBg, border: `1px solid ${t.colorErrorBorder}`,
-          borderRadius: 3, color: t.colorError, fontSize: 11,
-          fontFamily: '"IBM Plex Sans", sans-serif', whiteSpace: 'nowrap',
-          boxShadow: t.shadowMd,
-        }}>{error}</div>
-      )}
+      {errorBubble}
     </div>
   );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -124,3 +124,28 @@ body {
 ::-webkit-scrollbar-track { background: transparent; }
 ::-webkit-scrollbar-thumb { background: var(--border); border-radius: 3px; }
 ::-webkit-scrollbar-thumb:hover { background: var(--border-strong); }
+
+/* CSS tooltips via data-tooltip attribute */
+[data-tooltip] { position: relative; }
+[data-tooltip]::after {
+  content: attr(data-tooltip);
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 50%;
+  transform: translateX(-50%);
+  white-space: nowrap;
+  padding: 4px 8px;
+  background: var(--bg-overlay);
+  color: var(--text-primary);
+  font-family: var(--font-ui);
+  font-size: 11px;
+  line-height: 1.4;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow-md);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.12s ease;
+  z-index: 9999;
+}
+[data-tooltip]:hover::after { opacity: 1; }


### PR DESCRIPTION
## Summary

- Detects TINYINT(1) columns via schema metadata and treats them as boolean rather than number
- Replaces the number/text input with a true/false select dropdown
- Sends actual JS boolean true/false to the parameterized query (MySQL receives true/false instead of 0/1)
- Correctly handles unchanged-value detection (DB returns 1/0 numbers, compared as booleans)
- Confirmation SQL preview shows `SET col = true` / `SET col = false`

## Test plan

- [ ] Query a table with a TINYINT(1) column
- [ ] Double-click the boolean cell — should show a select with true/false options
- [ ] Change to true, press Enter — confirmation should show `SET col = true`
- [ ] Confirm update and verify the grid reflects the change
- [ ] Change from true back to false — confirmation shows `SET col = false`
- [ ] Pressing Enter without changing value should close editor silently

Generated with [Claude Code](https://claude.com/claude-code)
