### PR TITLE
feat: MCP server for the connected database

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -7,7 +7,9 @@
     "": {
       "name": "helix-server",
       "version": "0.0.0",
+      "license": "AGPL-3.0-only",
       "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "cors": "^2.8.5",
         "express": "^4.21.2",
         "mysql2": "^3.14.0"
@@ -462,6 +464,358 @@
         "node": ">=18"
       }
     },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/@types/body-parser": {
       "version": "1.19.6",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
@@ -580,6 +934,39 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
       }
     },
     "node_modules/array-flatten": {
@@ -710,6 +1097,20 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/debug": {
@@ -865,6 +1266,27 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
+      "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/express": {
       "version": "4.22.1",
       "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
@@ -910,6 +1332,46 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.4.1.tgz",
+      "integrity": "sha512-NGVYwQSAyEQgzxX1iCM978PP9AdO/hW93gMcF6ZwQCm+rFvLsBH6w4xcXWTcliS8La5EPRN3p9wzItqBwJrfNw==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/finalhandler": {
       "version": "1.3.2",
@@ -1066,6 +1528,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hono": {
+      "version": "4.12.15",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.15.tgz",
+      "integrity": "sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
     "node_modules/http-errors": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
@@ -1104,6 +1575,15 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -1113,11 +1593,44 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
     "node_modules/is-property": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
       "integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==",
       "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
+      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/long": {
       "version": "5.3.2",
@@ -1307,6 +1820,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -1316,11 +1838,29 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/path-to-regexp": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
       "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
       "license": "MIT"
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
@@ -1374,6 +1914,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
@@ -1382,6 +1931,55 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/router/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/router/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/router/node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/safe-buffer": {
@@ -1460,6 +2058,27 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/side-channel": {
       "version": "1.1.0",
@@ -1644,6 +2263,45 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
       }
     }
   }

--- a/server/package.json
+++ b/server/package.json
@@ -10,6 +10,7 @@
     "build": "tsc"
   },
   "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "cors": "^2.8.5",
     "express": "^4.21.2",
     "mysql2": "^3.14.0"

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -1,4 +1,5 @@
 import mysql from 'mysql2/promise';
+import { resetMcpState } from './mcp-state.js';
 
 interface ConnectionConfig {
   host: string;
@@ -17,6 +18,7 @@ export async function connect(config: ConnectionConfig): Promise<void> {
     await pool.end();
     pool = null;
   }
+  resetMcpState();
 
   pool = mysql.createPool({
     host: config.host,
@@ -44,6 +46,7 @@ export async function disconnect(): Promise<void> {
     pool = null;
     activeConfig = null;
   }
+  resetMcpState();
 }
 
 export function getPool(): mysql.Pool {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -8,6 +8,8 @@ import { postUpdateCell } from './routes/updateCell.js';
 import { postInsertRow } from './routes/insertRow.js';
 import { getTableDdl } from './routes/tableDdl.js';
 import { postDropTable } from './routes/dropTable.js';
+import { getMcpStatus, postMcpWrites } from './routes/mcpSettings.js';
+import { mcpHandler } from './mcp.js';
 
 const app = express();
 const PORT = process.env['PORT'] ?? 3001;
@@ -34,6 +36,14 @@ app.post('/api/update-cell', postUpdateCell);
 app.post('/api/insert-row', postInsertRow);
 app.post('/api/drop-table', postDropTable);
 
+// MCP
+app.get('/api/mcp/status', getMcpStatus);
+app.post('/api/mcp/writes', postMcpWrites);
+app.post('/mcp', mcpHandler);
+app.get('/mcp', mcpHandler);
+app.delete('/mcp', mcpHandler);
+
 app.listen(PORT, () => {
   console.log(`Helix server running at http://localhost:${PORT}`);
+  console.log(`MCP endpoint:        http://localhost:${PORT}/mcp`);
 });

--- a/server/src/mcp-state.ts
+++ b/server/src/mcp-state.ts
@@ -1,0 +1,13 @@
+let writesAllowed = false;
+
+export function isMcpWritesAllowed(): boolean {
+  return writesAllowed;
+}
+
+export function setMcpWritesAllowed(enabled: boolean): void {
+  writesAllowed = enabled;
+}
+
+export function resetMcpState(): void {
+  writesAllowed = false;
+}

--- a/server/src/mcp.ts
+++ b/server/src/mcp.ts
@@ -1,0 +1,308 @@
+import type { RequestHandler } from 'express';
+import type { RowDataPacket, FieldPacket } from 'mysql2/promise';
+import mysql from 'mysql2/promise';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { z } from 'zod';
+import { getPool, getActiveConfig, isConnected } from './db.js';
+import { isMcpWritesAllowed } from './mcp-state.js';
+
+const DEFAULT_ROW_LIMIT = 100;
+const MAX_ROW_LIMIT = 10_000;
+
+// Matches the leading keyword of a statement, skipping whitespace and /* */ comments.
+const READ_KEYWORDS = new Set(['SELECT', 'SHOW', 'DESCRIBE', 'DESC', 'EXPLAIN', 'WITH']);
+const WRITE_KEYWORDS = new Set(['INSERT', 'UPDATE', 'DELETE', 'REPLACE']);
+// Everything else (CREATE, DROP, ALTER, TRUNCATE, RENAME, GRANT, REVOKE, SET, CALL, ...) is blocked in v1.
+
+function firstKeyword(sql: string): string {
+  const stripped = sql.replace(/\/\*[\s\S]*?\*\//g, '').replace(/--.*$/gm, '').trimStart();
+  const match = stripped.match(/^([A-Za-z]+)/);
+  return match ? match[1].toUpperCase() : '';
+}
+
+function serializeValue(val: unknown): unknown {
+  if (val === null || val === undefined) return null;
+  if (Buffer.isBuffer(val)) return val.toString('hex');
+  if (val instanceof Date) return val.toISOString().replace('T', ' ').replace(/\.\d{3}Z$/, '');
+  if (typeof val === 'bigint') return val.toString();
+  return val;
+}
+
+function serializeRows(rows: RowDataPacket[], columns: string[]): Record<string, unknown>[] {
+  return rows.map(row => {
+    const out: Record<string, unknown> = {};
+    for (const col of columns) out[col] = serializeValue(row[col]);
+    return out;
+  });
+}
+
+async function useSchema(pool: mysql.Pool, schema?: string): Promise<void> {
+  if (!schema) return;
+  await pool.query(`USE \`${schema.replace(/`/g, '')}\``);
+}
+
+function toolError(message: string) {
+  return {
+    isError: true,
+    content: [{ type: 'text' as const, text: message }],
+  };
+}
+
+function toolJson(value: unknown) {
+  return {
+    content: [{ type: 'text' as const, text: JSON.stringify(value, null, 2) }],
+  };
+}
+
+function requireConnection(): string | null {
+  if (!isConnected()) {
+    return 'No active database connection. Connect to a database via the Helix UI first.';
+  }
+  return null;
+}
+
+export function buildMcpServer(): McpServer {
+  const server = new McpServer(
+    { name: 'helix-mcp', version: '0.1.0' },
+    {
+      capabilities: { tools: {} },
+      instructions: [
+        'Helix MCP exposes the database currently connected in the Helix UI.',
+        'Reads are always allowed. Writes (INSERT/UPDATE/DELETE/REPLACE) are only allowed',
+        'when the user has explicitly enabled them in the Helix UI top-right menu.',
+        'DDL (CREATE/DROP/ALTER/TRUNCATE/RENAME) is not supported in this version.',
+      ].join(' '),
+    },
+  );
+
+  server.registerTool(
+    'list_tables',
+    {
+      description: 'List tables, views, procedures, and triggers in a schema. If no schema is given, lists schemas (databases).',
+      inputSchema: {
+        schema: z.string().optional().describe('Schema/database name. Omit to list available schemas.'),
+      },
+    },
+    async ({ schema }) => {
+      const err = requireConnection();
+      if (err) return toolError(err);
+
+      try {
+        const pool = getPool();
+
+        if (!schema) {
+          const [rows] = await pool.query<RowDataPacket[]>(
+            `SELECT SCHEMA_NAME AS name FROM information_schema.SCHEMATA
+             WHERE SCHEMA_NAME NOT IN ('information_schema','performance_schema','mysql','sys')
+             ORDER BY SCHEMA_NAME`,
+          );
+          return toolJson({ schemas: rows.map(r => r['name']) });
+        }
+
+        const [tables] = await pool.query<RowDataPacket[]>(
+          `SELECT TABLE_NAME AS name, TABLE_ROWS AS approx_rows, TABLE_COMMENT AS comment
+           FROM information_schema.TABLES
+           WHERE TABLE_SCHEMA = ? AND TABLE_TYPE = 'BASE TABLE'
+           ORDER BY TABLE_NAME`,
+          [schema],
+        );
+        const [views] = await pool.query<RowDataPacket[]>(
+          `SELECT TABLE_NAME AS name FROM information_schema.VIEWS
+           WHERE TABLE_SCHEMA = ? ORDER BY TABLE_NAME`,
+          [schema],
+        );
+        return toolJson({
+          schema,
+          tables: tables.map(t => ({ name: t['name'], approxRows: t['approx_rows'], comment: t['comment'] ?? '' })),
+          views: views.map(v => v['name']),
+        });
+      } catch (e) {
+        return toolError(e instanceof Error ? e.message : String(e));
+      }
+    },
+  );
+
+  server.registerTool(
+    'describe_table',
+    {
+      description: 'Describe columns of a table: name, type, nullability, default, primary key, auto-increment.',
+      inputSchema: {
+        schema: z.string().describe('Schema/database name.'),
+        table: z.string().describe('Table name.'),
+      },
+    },
+    async ({ schema, table }) => {
+      const err = requireConnection();
+      if (err) return toolError(err);
+
+      try {
+        const pool = getPool();
+        const [columns] = await pool.query<RowDataPacket[]>(
+          `SELECT COLUMN_NAME AS name, COLUMN_TYPE AS type, DATA_TYPE AS dataType,
+                  IF(COLUMN_KEY = 'PRI', 1, 0) AS isPk,
+                  IF(IS_NULLABLE = 'YES', 1, 0) AS nullable,
+                  COLUMN_DEFAULT AS columnDefault,
+                  EXTRA AS extra,
+                  COLUMN_COMMENT AS comment
+           FROM information_schema.COLUMNS
+           WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ?
+           ORDER BY ORDINAL_POSITION`,
+          [schema, table],
+        );
+        if (columns.length === 0) {
+          return toolError(`Table \`${schema}\`.\`${table}\` not found.`);
+        }
+        return toolJson({
+          schema,
+          table,
+          columns: columns.map(c => ({
+            name: c['name'],
+            type: c['type'],
+            dataType: c['dataType'],
+            pk: Boolean(c['isPk']),
+            nullable: Boolean(c['nullable']),
+            default: c['columnDefault'],
+            autoIncrement: String(c['extra'] ?? '').toLowerCase().includes('auto_increment'),
+            comment: c['comment'] ?? '',
+          })),
+        });
+      } catch (e) {
+        return toolError(e instanceof Error ? e.message : String(e));
+      }
+    },
+  );
+
+  server.registerTool(
+    'execute_query',
+    {
+      description:
+        'Run a read-only SQL query (SELECT / SHOW / DESCRIBE / EXPLAIN / WITH). ' +
+        `Results are capped at ${DEFAULT_ROW_LIMIT} rows by default; pass "limit" (up to ${MAX_ROW_LIMIT}) to change.`,
+      inputSchema: {
+        sql: z.string().min(1).describe('Read-only SQL statement.'),
+        schema: z.string().optional().describe('Schema to USE before the query.'),
+        limit: z.number().int().positive().max(MAX_ROW_LIMIT).optional()
+          .describe(`Max rows returned to the caller (default ${DEFAULT_ROW_LIMIT}, max ${MAX_ROW_LIMIT}).`),
+      },
+    },
+    async ({ sql, schema, limit }) => {
+      const err = requireConnection();
+      if (err) return toolError(err);
+
+      const kw = firstKeyword(sql);
+      if (!READ_KEYWORDS.has(kw)) {
+        if (WRITE_KEYWORDS.has(kw)) {
+          return toolError(`execute_query does not accept ${kw}. Use execute_write for data modifications.`);
+        }
+        return toolError(`execute_query only accepts read statements (SELECT/SHOW/DESCRIBE/EXPLAIN/WITH). Got: ${kw || 'unknown'}.`);
+      }
+
+      const cap = limit ?? DEFAULT_ROW_LIMIT;
+      try {
+        const pool = getPool();
+        await useSchema(pool, schema);
+        const start = Date.now();
+        const [rows, fields]: [RowDataPacket[], FieldPacket[]] = await pool.query(sql) as [RowDataPacket[], FieldPacket[]];
+        const executionTime = Date.now() - start;
+
+        if (!Array.isArray(rows)) {
+          return toolJson({ columns: [], rows: [], executionTime });
+        }
+
+        const columns = fields.map(f => f.name);
+        const totalRows = rows.length;
+        const capped = rows.slice(0, cap);
+        return toolJson({
+          columns,
+          rows: serializeRows(capped, columns),
+          rowCount: capped.length,
+          totalRows,
+          truncated: totalRows > capped.length,
+          limitApplied: cap,
+          executionTime,
+        });
+      } catch (e) {
+        return toolError(e instanceof Error ? e.message : String(e));
+      }
+    },
+  );
+
+  server.registerTool(
+    'execute_write',
+    {
+      description:
+        'Run an INSERT, UPDATE, DELETE, or REPLACE statement. ' +
+        'Requires the user to have enabled "Allow MCP to modify data" in the Helix UI. ' +
+        'DDL (CREATE/DROP/ALTER/TRUNCATE) is not supported.',
+      inputSchema: {
+        sql: z.string().min(1).describe('INSERT / UPDATE / DELETE / REPLACE statement.'),
+        schema: z.string().optional().describe('Schema to USE before the statement.'),
+      },
+    },
+    async ({ sql, schema }) => {
+      const err = requireConnection();
+      if (err) return toolError(err);
+
+      if (!isMcpWritesAllowed()) {
+        return toolError(
+          'Writes are disabled. Ask the user to enable "Allow MCP to modify data" in the Helix UI (top-right menu).',
+        );
+      }
+
+      const kw = firstKeyword(sql);
+      if (!WRITE_KEYWORDS.has(kw)) {
+        if (READ_KEYWORDS.has(kw)) {
+          return toolError(`execute_write does not accept ${kw}. Use execute_query for reads.`);
+        }
+        return toolError(
+          `execute_write only accepts INSERT/UPDATE/DELETE/REPLACE. DDL is not supported. Got: ${kw || 'unknown'}.`,
+        );
+      }
+
+      try {
+        const pool = getPool();
+        await useSchema(pool, schema);
+        const start = Date.now();
+        const [result] = await pool.query(sql) as unknown as [{ affectedRows?: number; insertId?: number; changedRows?: number }];
+        const executionTime = Date.now() - start;
+        return toolJson({
+          affectedRows: result.affectedRows ?? 0,
+          changedRows: result.changedRows ?? 0,
+          insertId: result.insertId ?? null,
+          executionTime,
+        });
+      } catch (e) {
+        return toolError(e instanceof Error ? e.message : String(e));
+      }
+    },
+  );
+
+  return server;
+}
+
+export const mcpHandler: RequestHandler = async (req, res) => {
+  const server = buildMcpServer();
+  const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
+  res.on('close', () => {
+    transport.close().catch(() => { /* ignore */ });
+    server.close().catch(() => { /* ignore */ });
+  });
+  try {
+    await server.connect(transport);
+    await transport.handleRequest(req, res, req.body);
+  } catch (e) {
+    if (!res.headersSent) {
+      res.status(500).json({ error: e instanceof Error ? e.message : String(e) });
+    }
+  }
+};
+
+export function getMcpInfo(): { connected: boolean; writesAllowed: boolean; activeDatabase: string | null } {
+  const cfg = getActiveConfig();
+  return {
+    connected: isConnected(),
+    writesAllowed: isMcpWritesAllowed(),
+    activeDatabase: cfg?.database ?? null,
+  };
+}

--- a/server/src/routes/mcpSettings.ts
+++ b/server/src/routes/mcpSettings.ts
@@ -1,0 +1,27 @@
+import type { RequestHandler } from 'express';
+import { isConnected } from '../db.js';
+import { isMcpWritesAllowed, setMcpWritesAllowed } from '../mcp-state.js';
+
+export const getMcpStatus: RequestHandler = (req, res) => {
+  const host = req.get('host') ?? `localhost:${process.env['PORT'] ?? 3001}`;
+  const protocol = req.protocol ?? 'http';
+  res.json({
+    connected: isConnected(),
+    writesAllowed: isMcpWritesAllowed(),
+    mcpUrl: `${protocol}://${host}/mcp`,
+  });
+};
+
+export const postMcpWrites: RequestHandler = (req, res) => {
+  const { enabled } = req.body as { enabled?: unknown };
+  if (typeof enabled !== 'boolean') {
+    res.status(400).json({ error: '`enabled` (boolean) is required.' });
+    return;
+  }
+  if (enabled && !isConnected()) {
+    res.status(409).json({ error: 'Cannot enable MCP writes without an active database connection.' });
+    return;
+  }
+  setMcpWritesAllowed(enabled);
+  res.json({ writesAllowed: isMcpWritesAllowed() });
+};

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -35,6 +35,9 @@ export default function App() {
   const [history, setHistory] = useState<HistoryEntry[]>([]);
   const [savedQueries, setSavedQueries] = useState<SavedQuery[]>([]);
 
+  const [mcpWritesAllowed, setMcpWritesAllowed] = useState(false);
+  const [mcpUrl, setMcpUrl] = useState<string>('');
+
   const [schemas, setSchemas] = useState<string[]>([]);
   const [activeSchema, setActiveSchema] = useState('');
   const [schemaData, setSchemaData] = useState<SchemaData>(EMPTY_SCHEMA);
@@ -291,6 +294,24 @@ export default function App() {
     if (connected && activeSchema) loadSchema(activeSchema);
   }, [activeSchema, connected, loadSchema]);
 
+  // Sync MCP status on mount and whenever connection state changes (covers page refresh).
+  useEffect(() => {
+    let cancelled = false;
+    api.mcpStatus()
+      .then(s => {
+        if (cancelled) return;
+        setMcpWritesAllowed(s.writesAllowed);
+        setMcpUrl(s.mcpUrl);
+      })
+      .catch(() => { /* server unreachable — leave defaults */ });
+    return () => { cancelled = true; };
+  }, [connected]);
+
+  const handleToggleMcpWrites = async (enabled: boolean) => {
+    const res = await api.setMcpWrites(enabled);
+    setMcpWritesAllowed(res.writesAllowed);
+  };
+
   const appStyle: CSSProperties = {
     display: 'flex', flexDirection: 'column', height: '100vh', overflow: 'hidden',
     background: t.bgBase,
@@ -310,6 +331,9 @@ export default function App() {
         connectionHost={connectionHost}
         connectionStatus={connected ? 'connected' : 'disconnected'}
         onDisconnect={handleDisconnect}
+        mcpWritesAllowed={mcpWritesAllowed}
+        mcpUrl={mcpUrl}
+        onToggleMcpWrites={handleToggleMcpWrites}
         themeName={themeName}
         onToggleTheme={toggleTheme}
         t={t}

--- a/src/api.ts
+++ b/src/api.ts
@@ -121,4 +121,15 @@ export const api = {
     });
   },
 
+  mcpStatus() {
+    return request<{ connected: boolean; writesAllowed: boolean; mcpUrl: string }>('/api/mcp/status');
+  },
+
+  setMcpWrites(enabled: boolean) {
+    return request<{ writesAllowed: boolean }>('/api/mcp/writes', {
+      method: 'POST',
+      body: JSON.stringify({ enabled }),
+    });
+  },
+
 };

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -17,14 +17,21 @@ interface TopBarProps {
   connectionHost?: string | null;
   connectionStatus: 'connected' | 'disconnected' | 'error';
   onDisconnect?: () => void;
+  mcpWritesAllowed?: boolean;
+  mcpUrl?: string;
+  onToggleMcpWrites?: (enabled: boolean) => void | Promise<void>;
   themeName: ThemeName;
   onToggleTheme: () => void;
   t: Theme;
 }
 
-export function TopBar({ tabs, activeTab, onTabChange, onNewTab, onCloseTab, connectionName, connectionHost, connectionStatus, onDisconnect, themeName, onToggleTheme, t }: TopBarProps) {
+export function TopBar({ tabs, activeTab, onTabChange, onNewTab, onCloseTab, connectionName, connectionHost, connectionStatus, onDisconnect, mcpWritesAllowed, mcpUrl, onToggleMcpWrites, themeName, onToggleTheme, t }: TopBarProps) {
   const [menuOpen, setMenuOpen] = useState(false);
+  const [mcpBusy, setMcpBusy] = useState(false);
+  const [mcpError, setMcpError] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
   const canDisconnect = connectionStatus === 'connected' && !!onDisconnect;
+  const isConnected = connectionStatus === 'connected';
 
   useEffect(() => {
     if (!menuOpen) return;
@@ -139,7 +146,7 @@ export function TopBar({ tabs, activeTab, onTabChange, onNewTab, onCloseTab, con
             onClick={(e) => e.stopPropagation()}
             style={{
               position: 'absolute', top: '100%', right: 8, marginTop: 4, zIndex: 100,
-              minWidth: 220, background: t.bgElevated, border: `1px solid ${t.border}`,
+              minWidth: 260, background: t.bgElevated, border: `1px solid ${t.border}`,
               borderRadius: 4, boxShadow: t.shadowMd, padding: 4,
               fontFamily: '"IBM Plex Sans", sans-serif', fontSize: 12,
             }}
@@ -155,6 +162,83 @@ export function TopBar({ tabs, activeTab, onTabChange, onNewTab, onCloseTab, con
                 <div style={{ fontSize: 11, color: t.textMuted, fontFamily: 'monospace', marginTop: connectionName !== connectionHost ? 2 : 0, whiteSpace: 'nowrap' }}>{connectionHost}</div>
               </div>
             )}
+
+            {onToggleMcpWrites && (
+              <div style={{
+                padding: '8px 10px', borderBottom: `1px solid ${t.borderSubtle}`,
+                marginBottom: 4,
+              }}>
+                <div style={{ fontSize: 10, color: t.textMuted, textTransform: 'uppercase', letterSpacing: 0.5, marginBottom: 6 }}>MCP server</div>
+
+                {mcpUrl && (
+                  <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 8 }}>
+                    <code style={{ flex: 1, fontSize: 11, color: t.textSecondary, fontFamily: 'monospace', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{mcpUrl}</code>
+                    <button
+                      onClick={async () => {
+                        try {
+                          await navigator.clipboard.writeText(mcpUrl);
+                          setCopied(true);
+                          setTimeout(() => setCopied(false), 1200);
+                        } catch { /* ignore */ }
+                      }}
+                      title="Copy URL"
+                      style={{ background: 'none', border: `1px solid ${t.borderSubtle}`, color: t.textMuted, borderRadius: 3, padding: '2px 6px', fontSize: 10, cursor: 'pointer', fontFamily: 'inherit' }}
+                    >
+                      {copied ? 'Copied' : 'Copy'}
+                    </button>
+                  </div>
+                )}
+
+                <label style={{
+                  display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+                  gap: 10, cursor: isConnected && !mcpBusy ? 'pointer' : 'default',
+                  opacity: isConnected ? 1 : 0.55,
+                }}>
+                  <div style={{ display: 'flex', flexDirection: 'column', gap: 2, minWidth: 0 }}>
+                    <span style={{ color: t.textPrimary, fontSize: 12 }}>Allow MCP to modify data</span>
+                    <span style={{ color: t.textMuted, fontSize: 10.5 }}>
+                      {isConnected
+                        ? 'INSERT, UPDATE, DELETE via MCP'
+                        : 'Connect to a database to enable'}
+                    </span>
+                  </div>
+                  <span
+                    role="switch"
+                    aria-checked={!!mcpWritesAllowed}
+                    onClick={async () => {
+                      if (!isConnected || mcpBusy || !onToggleMcpWrites) return;
+                      setMcpBusy(true);
+                      setMcpError(null);
+                      try {
+                        await onToggleMcpWrites(!mcpWritesAllowed);
+                      } catch (e) {
+                        setMcpError(e instanceof Error ? e.message : String(e));
+                      } finally {
+                        setMcpBusy(false);
+                      }
+                    }}
+                    style={{
+                      position: 'relative', width: 28, height: 16, borderRadius: 10,
+                      background: mcpWritesAllowed ? t.accent : t.borderSubtle,
+                      transition: 'background 150ms ease',
+                      flexShrink: 0,
+                      cursor: isConnected && !mcpBusy ? 'pointer' : 'default',
+                    }}
+                  >
+                    <span style={{
+                      position: 'absolute', top: 2, left: mcpWritesAllowed ? 14 : 2,
+                      width: 12, height: 12, borderRadius: '50%', background: '#fff',
+                      transition: 'left 150ms ease',
+                    }}/>
+                  </span>
+                </label>
+
+                {mcpError && (
+                  <div style={{ marginTop: 6, fontSize: 10.5, color: t.colorError }}>{mcpError}</div>
+                )}
+              </div>
+            )}
+
             <button
               onClick={() => { setMenuOpen(false); onDisconnect?.(); }}
               style={{


### PR DESCRIPTION
## Summary

- Adds a Model Context Protocol server that exposes the currently connected MySQL database over Streamable HTTP at `POST /mcp`. MCP clients (Claude Desktop, Claude Code, etc.) can now read the live Helix connection.
- **Reads are always on.** Writes (`INSERT`/`UPDATE`/`DELETE`/`REPLACE`) are gated by an explicit toggle in the top-right connection menu — "Allow MCP to modify data". DDL is intentionally out of scope for v1.
- The write grant lives in server memory (`server/src/mcp-state.ts`) and is reset automatically on connect and disconnect, so a page refresh preserves the grant but a reconnect starts clean.

### Tools exposed
- `list_tables` — schemas or tables/views in a schema
- `describe_table` — column info (type, nullable, default, PK, auto-increment)
- `execute_query` — read-only SQL; default 100-row cap, up to 10 000 via `limit`
- `execute_write` — INSERT / UPDATE / DELETE / REPLACE; rejects DDL; requires the UI toggle

### New UI
Inside the existing top-right connection dropdown:
- MCP URL (`http://<host>:<port>/mcp`) with a one-click Copy button
- Toggle switch for write access, with the active-connection state as the gate

### Endpoints added
- `GET /api/mcp/status` → `{ connected, writesAllowed, mcpUrl }`
- `POST /api/mcp/writes` → accepts `{ enabled: boolean }`, 409s without an active connection
- `POST|GET|DELETE /mcp` → MCP Streamable HTTP transport

### Out of scope / next steps
- DDL tools (`CREATE`/`DROP`/`ALTER`) — deferred; would need a second, separately-gated tool.
- Auth on the `/mcp` endpoint — deferred until the app gains multi-user/cloud deployment. For now the endpoint matches the rest of Helix: unauthenticated on localhost.

## Test plan

- [x] Server typechecks (`tsc` clean)
- [x] MCP initialize / tools list handshake returns all four tools
- [x] `execute_query` rejects non-read statements; `execute_write` rejects reads and DDL
- [x] Browser test: connect, open menu, toggle ON, verify `/api/mcp/status` flips and `execute_write` succeeds
- [x] Browser test: toggle OFF, verify `execute_write` returns "Writes are disabled"
- [x] Browser test: page refresh preserves server-side `writesAllowed`; reconnect correctly resets it
- [x] Browser test: Log Out revokes the grant and disables the menu
- [ ] Reviewer: connect your preferred MCP client to `http://localhost:3001/mcp` and sanity-check `list_tables` / `describe_table`

🤖 Generated with [Claude Code](https://claude.com/claude-code)