### PR TITLE
feat: extend Show schema to views, procedures, and triggers (#15)

### DIFF
--- a/server/src/routes/tableDdl.ts
+++ b/server/src/routes/tableDdl.ts
@@ -17,6 +17,10 @@ export const getTableDdl: RequestHandler = async (req, res) => {
     res.status(400).json({ error: 'table query param is required.' });
     return;
   }
+  if (!['table', 'view', 'procedure', 'trigger'].includes(type)) {
+    res.status(400).json({ error: `Invalid type "${type}". Must be one of: table, view, procedure, trigger.` });
+    return;
+  }
 
   try {
     const pool = getPool();
@@ -26,6 +30,7 @@ export const getTableDdl: RequestHandler = async (req, res) => {
     if (type === 'procedure') {
       sql = `SHOW CREATE PROCEDURE ${qualified}`;
     } else if (type === 'trigger') {
+      // Schema-qualified form requires MySQL 8.0+
       sql = `SHOW CREATE TRIGGER ${qualified}`;
     } else {
       // 'table' or 'view' — SHOW CREATE TABLE works for both

--- a/server/src/routes/tableDdl.ts
+++ b/server/src/routes/tableDdl.ts
@@ -7,6 +7,7 @@ const escapeIdent = (s: string) => '`' + s.replace(/`/g, '') + '`';
 export const getTableDdl: RequestHandler = async (req, res) => {
   const schema = req.query['schema'] as string | undefined;
   const table = req.query['table'] as string | undefined;
+  const type = (req.query['type'] as string | undefined) ?? 'table';
 
   if (!schema || !schema.trim()) {
     res.status(400).json({ error: 'schema query param is required.' });
@@ -20,15 +21,30 @@ export const getTableDdl: RequestHandler = async (req, res) => {
   try {
     const pool = getPool();
     const qualified = `${escapeIdent(schema)}.${escapeIdent(table)}`;
-    const [rows] = await pool.query<RowDataPacket[]>(`SHOW CREATE TABLE ${qualified}`);
+
+    let sql: string;
+    if (type === 'procedure') {
+      sql = `SHOW CREATE PROCEDURE ${qualified}`;
+    } else if (type === 'trigger') {
+      sql = `SHOW CREATE TRIGGER ${qualified}`;
+    } else {
+      // 'table' or 'view' — SHOW CREATE TABLE works for both
+      sql = `SHOW CREATE TABLE ${qualified}`;
+    }
+
+    const [rows] = await pool.query<RowDataPacket[]>(sql);
     if (rows.length === 0) {
       res.status(404).json({ error: `No DDL returned for ${qualified}.` });
       return;
     }
-    // SHOW CREATE TABLE returns [{ Table: '…', 'Create Table': '…' }] for base tables,
-    // or [{ View: '…', 'Create View': '…', character_set_client, collation_connection }] for views.
     const row = rows[0] as Record<string, unknown>;
-    const ddl = (row['Create Table'] ?? row['Create View'] ?? '') as string;
+    const ddl = (
+      row['Create Table'] ??
+      row['Create View'] ??
+      row['Create Procedure'] ??
+      row['SQL Original Statement'] ??   // SHOW CREATE TRIGGER
+      ''
+    ) as string;
     res.json({ ddl });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);

--- a/src/api.ts
+++ b/src/api.ts
@@ -82,8 +82,9 @@ export const api = {
     return request<SchemaData>(`/api/schema?schema=${encodeURIComponent(schema)}`);
   },
 
-  tableDdl(schema: string, table: string) {
-    return request<{ ddl: string }>(`/api/table-ddl?schema=${encodeURIComponent(schema)}&table=${encodeURIComponent(table)}`);
+  tableDdl(schema: string, name: string, type?: string) {
+    const t = type ? `&type=${encodeURIComponent(type)}` : '';
+    return request<{ ddl: string }>(`/api/table-ddl?schema=${encodeURIComponent(schema)}&table=${encodeURIComponent(name)}${t}`);
   },
 
   query(sql: string, schema: string) {

--- a/src/api.ts
+++ b/src/api.ts
@@ -25,6 +25,8 @@ export interface SchemaData {
   triggers: string[];
 }
 
+export type ObjectType = 'table' | 'view' | 'procedure' | 'trigger';
+
 export interface ColumnMeta {
   name: string;
   orgName: string;
@@ -82,7 +84,7 @@ export const api = {
     return request<SchemaData>(`/api/schema?schema=${encodeURIComponent(schema)}`);
   },
 
-  tableDdl(schema: string, name: string, type?: string) {
+  tableDdl(schema: string, name: string, type?: ObjectType) {
     const t = type ? `&type=${encodeURIComponent(type)}` : '';
     return request<{ ddl: string }>(`/api/table-ddl?schema=${encodeURIComponent(schema)}&table=${encodeURIComponent(name)}${t}`);
   },

--- a/src/components/SchemaBrowser.tsx
+++ b/src/components/SchemaBrowser.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef, CSSProperties } from 'react';
 import type { Theme } from '../theme';
-import { ShowSchemaDialog } from './ShowSchemaDialog';
+import { ShowSchemaDialog, type ObjectType } from './ShowSchemaDialog';
 
 interface Column {
   name: string;
@@ -70,8 +70,8 @@ export function SchemaBrowser({ schema, activeTable, onTableSelect, onSchemaChan
   const [expanded, setExpanded] = useState({ tables: true, views: false, procedures: false, triggers: false });
   const [expandedTables, setExpandedTables] = useState<Record<string, boolean>>({});
   const [filter, setFilter] = useState('');
-  const [contextMenu, setContextMenu] = useState<{ x: number; y: number; table: string } | null>(null);
-  const [showSchemaFor, setShowSchemaFor] = useState<string | null>(null);
+  const [contextMenu, setContextMenu] = useState<{ x: number; y: number; name: string; type: ObjectType } | null>(null);
+  const [showSchemaFor, setShowSchemaFor] = useState<{ name: string; type: ObjectType } | null>(null);
   const [confirmDrop, setConfirmDrop] = useState<ConfirmDrop | null>(null);
   const dropInputRef = useRef<HTMLInputElement>(null);
 
@@ -162,7 +162,7 @@ export function SchemaBrowser({ schema, activeTable, onTableSelect, onSchemaChan
                   onClick={() => { onTableSelect(table.name); toggleTable(table.name); }}
                   onContextMenu={(e) => {
                     e.preventDefault();
-                    setContextMenu({ x: e.clientX, y: e.clientY, table: table.name });
+                    setContextMenu({ x: e.clientX, y: e.clientY, name: table.name, type: 'table' });
                   }}
                   title={table.comment || undefined}
                 >
@@ -190,9 +190,35 @@ export function SchemaBrowser({ schema, activeTable, onTableSelect, onSchemaChan
               </div>
             ))}
 
-            {expanded[g.key] && g.key !== 'tables' && (
-              <div style={s.emptyGroup}>No {g.label.toLowerCase()}</div>
-            )}
+            {expanded[g.key] && g.key !== 'tables' && (() => {
+              const objType: ObjectType =
+                g.key === 'views' ? 'view' :
+                g.key === 'procedures' ? 'procedure' :
+                'trigger';
+              const items: string[] = (
+                g.key === 'views' ? schema.views :
+                g.key === 'procedures' ? schema.procedures :
+                schema.triggers
+              ) ?? [];
+              const filtered = filter
+                ? items.filter(n => n.toLowerCase().includes(filter.toLowerCase()))
+                : items;
+              if (filtered.length === 0) return <div style={s.emptyGroup}>No {g.label.toLowerCase()}</div>;
+              return filtered.map(name => (
+                <div
+                  key={name}
+                  style={{ ...s.tableRow, paddingLeft: 28 }}
+                  onContextMenu={(e) => {
+                    e.preventDefault();
+                    setContextMenu({ x: e.clientX, y: e.clientY, name, type: objType });
+                  }}
+                  onClick={() => setShowSchemaFor({ name, type: objType })}
+                  title={name}
+                >
+                  <span style={{ ...s.tableName, color: t.textSecondary }}>{name}</span>
+                </div>
+              ));
+            })()}
             <div style={s.divLine}/>
           </div>
         ))}
@@ -210,18 +236,20 @@ export function SchemaBrowser({ schema, activeTable, onTableSelect, onSchemaChan
         >
           <CtxItem
             t={t}
-            onClick={() => { setShowSchemaFor(contextMenu.table); setContextMenu(null); }}
+            onClick={() => { setShowSchemaFor({ name: contextMenu.name, type: contextMenu.type }); setContextMenu(null); }}
             icon={<><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/></>}
             label="Show schema"
           />
-          <div style={{ height: 1, background: t.borderSubtle, margin: '3px 0' }}/>
-          <CtxItem
-            t={t}
-            onClick={() => { setConfirmDrop({ table: contextMenu.table, typedName: '', error: null, working: false }); setContextMenu(null); }}
-            icon={<><polyline points="3 6 5 6 21 6"/><path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6"/><path d="M10 11v6M14 11v6"/><path d="M5 6l.7-2.1A2 2 0 0 1 7.6 2h8.8a2 2 0 0 1 1.9 1.9L19 6"/></>}
-            label="Drop table"
-            color={t.colorError}
-          />
+          {contextMenu.type === 'table' && (<>
+            <div style={{ height: 1, background: t.borderSubtle, margin: '3px 0' }}/>
+            <CtxItem
+              t={t}
+              onClick={() => { setConfirmDrop({ table: contextMenu.name, typedName: '', error: null, working: false }); setContextMenu(null); }}
+              icon={<><polyline points="3 6 5 6 21 6"/><path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6"/><path d="M10 11v6M14 11v6"/><path d="M5 6l.7-2.1A2 2 0 0 1 7.6 2h8.8a2 2 0 0 1 1.9 1.9L19 6"/></>}
+              label="Drop table"
+              color={t.colorError}
+            />
+          </>)}
         </div>
       )}
 
@@ -292,7 +320,8 @@ export function SchemaBrowser({ schema, activeTable, onTableSelect, onSchemaChan
       {showSchemaFor && (
         <ShowSchemaDialog
           schema={activeSchema}
-          table={showSchemaFor}
+          name={showSchemaFor.name}
+          type={showSchemaFor.type}
           onClose={() => setShowSchemaFor(null)}
           t={t}
         />

--- a/src/components/SchemaBrowser.tsx
+++ b/src/components/SchemaBrowser.tsx
@@ -1,27 +1,8 @@
 import { useState, useEffect, useRef, CSSProperties } from 'react';
 import type { Theme } from '../theme';
-import { ShowSchemaDialog, type ObjectType } from './ShowSchemaDialog';
+import type { ObjectType, SchemaData } from '../api';
+import { ShowSchemaDialog } from './ShowSchemaDialog';
 
-interface Column {
-  name: string;
-  type: string;
-  pk?: boolean;
-  comment?: string;
-}
-
-interface Table {
-  name: string;
-  rows: number | string;
-  comment?: string;
-  columns?: Column[];
-}
-
-interface SchemaData {
-  tables?: Table[];
-  views?: string[];
-  procedures?: string[];
-  triggers?: string[];
-}
 
 interface SchemaBrowserProps {
   schema: SchemaData;
@@ -64,6 +45,25 @@ interface ConfirmDrop {
   typedName: string;
   error: string | null;
   working: boolean;
+}
+
+function NonTableGroupItems({ groupKey, label, schema, filter, t, emptyStyle, rowStyle, nameStyle, onOpen, onContextMenu }: {
+  groupKey: string; label: string; schema: SchemaData; filter: string; t: Theme;
+  emptyStyle: CSSProperties; rowStyle: CSSProperties; nameStyle: CSSProperties;
+  onOpen: (name: string, type: ObjectType) => void;
+  onContextMenu: (e: React.MouseEvent, name: string, type: ObjectType) => void;
+}) {
+  const objType: ObjectType = groupKey === 'views' ? 'view' : groupKey === 'procedures' ? 'procedure' : 'trigger';
+  const items: string[] = (groupKey === 'views' ? schema.views : groupKey === 'procedures' ? schema.procedures : schema.triggers) ?? [];
+  const filtered = filter ? items.filter(n => n.toLowerCase().includes(filter.toLowerCase())) : items;
+  if (filtered.length === 0) return <div style={emptyStyle}>No {label.toLowerCase()}</div>;
+  return <>{filtered.map(name => (
+    <div key={name} style={{ ...rowStyle, paddingLeft: 28 }}
+      onContextMenu={(e) => { e.preventDefault(); onContextMenu(e, name, objType); }}
+      onClick={() => onOpen(name, objType)} title={name}>
+      <span style={{ ...nameStyle, color: t.textSecondary }}>{name}</span>
+    </div>
+  ))}</>;
 }
 
 export function SchemaBrowser({ schema, activeTable, onTableSelect, onSchemaChange, schemas, activeSchema, onDropTable, t }: SchemaBrowserProps) {
@@ -190,35 +190,20 @@ export function SchemaBrowser({ schema, activeTable, onTableSelect, onSchemaChan
               </div>
             ))}
 
-            {expanded[g.key] && g.key !== 'tables' && (() => {
-              const objType: ObjectType =
-                g.key === 'views' ? 'view' :
-                g.key === 'procedures' ? 'procedure' :
-                'trigger';
-              const items: string[] = (
-                g.key === 'views' ? schema.views :
-                g.key === 'procedures' ? schema.procedures :
-                schema.triggers
-              ) ?? [];
-              const filtered = filter
-                ? items.filter(n => n.toLowerCase().includes(filter.toLowerCase()))
-                : items;
-              if (filtered.length === 0) return <div style={s.emptyGroup}>No {g.label.toLowerCase()}</div>;
-              return filtered.map(name => (
-                <div
-                  key={name}
-                  style={{ ...s.tableRow, paddingLeft: 28 }}
-                  onContextMenu={(e) => {
-                    e.preventDefault();
-                    setContextMenu({ x: e.clientX, y: e.clientY, name, type: objType });
-                  }}
-                  onClick={() => setShowSchemaFor({ name, type: objType })}
-                  title={name}
-                >
-                  <span style={{ ...s.tableName, color: t.textSecondary }}>{name}</span>
-                </div>
-              ));
-            })()}
+            {expanded[g.key] && g.key !== 'tables' && (
+              <NonTableGroupItems
+                groupKey={g.key}
+                label={g.label}
+                schema={schema}
+                filter={filter}
+                t={t}
+                emptyStyle={s.emptyGroup}
+                rowStyle={s.tableRow}
+                nameStyle={s.tableName}
+                onOpen={(name, type) => setShowSchemaFor({ name, type })}
+                onContextMenu={(e, name, type) => setContextMenu({ x: e.clientX, y: e.clientY, name, type })}
+              />
+            )}
             <div style={s.divLine}/>
           </div>
         ))}

--- a/src/components/ShowSchemaDialog.tsx
+++ b/src/components/ShowSchemaDialog.tsx
@@ -1,8 +1,7 @@
 import { useEffect, useState, CSSProperties } from 'react';
 import type { Theme } from '../theme';
 import { api } from '../api';
-
-export type ObjectType = 'table' | 'view' | 'procedure' | 'trigger';
+import type { ObjectType } from '../api';
 
 const DIALOG_TITLE: Record<ObjectType, string> = {
   table:     'Table schema',

--- a/src/components/ShowSchemaDialog.tsx
+++ b/src/components/ShowSchemaDialog.tsx
@@ -2,14 +2,24 @@ import { useEffect, useState, CSSProperties } from 'react';
 import type { Theme } from '../theme';
 import { api } from '../api';
 
+export type ObjectType = 'table' | 'view' | 'procedure' | 'trigger';
+
+const DIALOG_TITLE: Record<ObjectType, string> = {
+  table:     'Table schema',
+  view:      'View definition',
+  procedure: 'Procedure definition',
+  trigger:   'Trigger definition',
+};
+
 interface ShowSchemaDialogProps {
   schema: string;
-  table: string;
+  name: string;
+  type: ObjectType;
   onClose: () => void;
   t: Theme;
 }
 
-export function ShowSchemaDialog({ schema, table, onClose, t }: ShowSchemaDialogProps) {
+export function ShowSchemaDialog({ schema, name, type, onClose, t }: ShowSchemaDialogProps) {
   const [ddl, setDdl] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
@@ -18,11 +28,11 @@ export function ShowSchemaDialog({ schema, table, onClose, t }: ShowSchemaDialog
     let cancelled = false;
     setDdl(null);
     setError(null);
-    api.tableDdl(schema, table)
+    api.tableDdl(schema, name, type)
       .then(res => { if (!cancelled) setDdl(res.ddl); })
       .catch(err => { if (!cancelled) setError(err instanceof Error ? err.message : String(err)); });
     return () => { cancelled = true; };
-  }, [schema, table]);
+  }, [schema, name, type]);
 
   useEffect(() => {
     const key = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose(); };
@@ -61,8 +71,8 @@ export function ShowSchemaDialog({ schema, table, onClose, t }: ShowSchemaDialog
     <div style={s.overlay} onClick={onClose}>
       <div style={s.modal} onClick={(e) => e.stopPropagation()}>
         <div style={s.header}>
-          <h3 style={s.title}>Table schema</h3>
-          <span style={s.subtitle}>{schema}.{table}</span>
+          <h3 style={s.title}>{DIALOG_TITLE[type]}</h3>
+          <span style={s.subtitle}>{schema}.{name}</span>
         </div>
 
         <div style={s.body}>


### PR DESCRIPTION
## Summary

- Views, procedures, and triggers now appear as clickable items in the schema browser sidebar (previously all three sections showed a static placeholder even when objects existed)
- Click any item to open its definition dialog; right-click for context menu "Show schema"
- Dialog title adapts to the object type: "View definition", "Procedure definition", "Trigger definition"
- "Drop table" in the context menu is now table-only (hidden for views/procedures/triggers)
- Server: /api/table-ddl accepts a new type query param and dispatches SHOW CREATE PROCEDURE or SHOW CREATE TRIGGER as appropriate

Closes #15

## Test plan

- [ ] Expand Views, click item — "View definition" dialog shows CREATE VIEW DDL
- [ ] Expand Procedures, click item — "Procedure definition" dialog shows CREATE PROCEDURE DDL
- [ ] Expand Triggers, click item — "Trigger definition" dialog shows CREATE TRIGGER DDL
- [ ] Right-click any non-table item — context menu shows "Show schema" only (no "Drop table")
- [ ] Right-click a table — context menu still shows both "Show schema" and "Drop table"
- [ ] Empty sections still show "No views / No procedures / No triggers"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
