### PR TITLE
fix: remove duplicate loadSchema calls on connect and schema switch

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -64,6 +64,7 @@ export default function App() {
   }, []);
 
   const handleSchemaChange = useCallback((schema: string) => {
+    // Schema fetch is driven by the useEffect on activeSchema; only update state here.
     setActiveSchema(schema);
   }, []);
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -65,8 +65,7 @@ export default function App() {
 
   const handleSchemaChange = useCallback((schema: string) => {
     setActiveSchema(schema);
-    loadSchema(schema);
-  }, [loadSchema]);
+  }, []);
 
   const handleConnect = async (form: ConnectionForm) => {
     setIsConnecting(true);
@@ -77,7 +76,6 @@ export default function App() {
       const initial = form.database && list.includes(form.database)
         ? form.database
         : list[0] ?? '';
-      if (initial) await loadSchema(initial);
 
       const friendly = form.name.trim();
       setConnectionName(friendly || res.connectionName);


### PR DESCRIPTION
## Summary

- `handleConnect` called `loadSchema(initial)` explicitly, then set `activeSchema` and `connected` which fired the `useEffect` watcher — doubling every schema fetch on connect
- `handleSchemaChange` called `loadSchema(schema)` explicitly, then set `activeSchema` which again fired the `useEffect` — doubling every schema switch fetch
- Fix: remove both explicit calls and let the `useEffect` be the single authority for schema fetches

## Test plan

- [x] Opened DevTools Network tab, connected to MySQL — confirmed `GET /api/schema` fires exactly once (was twice before)
- [x] Schema browser populated correctly after connect
- [x] `npm run build` clean

Closes #69
