### PR TITLE
feat: persist theme selection across app restarts

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,9 +23,25 @@ const EMPTY_SCHEMA: SchemaData = { tables: [], views: [], procedures: [], trigge
 
 let tabCounter = 1;
 
+const THEME_KEY = 'helix.theme';
+
+function readStoredTheme(): ThemeName {
+  try {
+    const v = localStorage.getItem(THEME_KEY);
+    return v === 'light' || v === 'dark' ? v : 'dark';
+  } catch {
+    return 'dark';
+  }
+}
+
 export default function App() {
-  const [themeName, setThemeName] = useState<ThemeName>('dark');
+  const [themeName, setThemeName] = useState<ThemeName>(readStoredTheme);
   const t = themeName === 'dark' ? DARK : LIGHT;
+
+  useEffect(() => {
+    document.documentElement.setAttribute('data-theme', themeName);
+    try { localStorage.setItem(THEME_KEY, themeName); } catch { /* quota or disabled storage */ }
+  }, [themeName]);
 
   const [connected, setConnected] = useState(false);
   const [isConnecting, setIsConnecting] = useState(false);
@@ -283,9 +299,7 @@ export default function App() {
   };
 
   const toggleTheme = () => {
-    const next: ThemeName = themeName === 'dark' ? 'light' : 'dark';
-    setThemeName(next);
-    document.documentElement.setAttribute('data-theme', next);
+    setThemeName(themeName === 'dark' ? 'light' : 'dark');
   };
 
   // Reload schema when switching schemas from the dropdown


### PR DESCRIPTION
## Summary

- Theme selector value (Dark/Light) now persists across reloads via `localStorage` key `helix.theme`
- `themeName` hydrates from storage on first render via lazy `useState` init; defaults to `dark` if empty/unreadable
- A single `useEffect` writes back to storage and sets the `data-theme` attribute, so initial load and toggles share one path

## Test plan

- [x] `npx tsc --noEmit` clean
- [ ] Toggle theme, reload — theme persists
- [ ] First-ever load (no storage entry) — defaults to dark
- [ ] Storage disabled (private mode) — falls back to dark, no crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)