### PR TITLE
fix: connection modal can be dismissed without connecting

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -335,6 +335,9 @@ export default function App() {
   const bodyStyle: CSSProperties = { display: 'flex', flex: 1, overflow: 'hidden' };
   const mainStyle: CSSProperties = { display: 'flex', flexDirection: 'column', flex: 1, overflow: 'hidden' };
 
+  const handleDismissModal = useCallback(() => setShowConnectionModal(false), []);
+  const handleOpenConnection = useCallback(() => setShowConnectionModal(true), []);
+
   return (
     <div style={appStyle}>
       <TopBar
@@ -347,7 +350,7 @@ export default function App() {
         connectionHost={connectionHost}
         connectionStatus={connected ? 'connected' : 'disconnected'}
         onDisconnect={handleDisconnect}
-        onOpenConnection={connected ? undefined : () => setShowConnectionModal(true)}
+        onOpenConnection={connected ? undefined : handleOpenConnection}
         mcpWritesAllowed={mcpWritesAllowed}
         mcpUrl={mcpUrl}
         onToggleMcpWrites={handleToggleMcpWrites}
@@ -410,7 +413,7 @@ export default function App() {
           onConnect={handleConnect}
           isConnecting={isConnecting}
           error={connectionError}
-          onDismiss={() => setShowConnectionModal(false)}
+          onDismiss={handleDismissModal}
           t={t}
         />
       )}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -44,6 +44,7 @@ export default function App() {
   }, [themeName]);
 
   const [connected, setConnected] = useState(false);
+  const [showConnectionModal, setShowConnectionModal] = useState(true);
   const [isConnecting, setIsConnecting] = useState(false);
   const [connectionError, setConnectionError] = useState<string | null>(null);
   const [connectionName, setConnectionName] = useState('Not connected');
@@ -102,6 +103,7 @@ export default function App() {
       setSchemas(list);
       setActiveSchema(initial);
       setConnected(true);
+      setShowConnectionModal(false);
 
       // Persist non-secret fields so the user doesn't retype them next time.
       if (friendly) {
@@ -125,6 +127,7 @@ export default function App() {
   const handleDisconnect = async () => {
     try { await api.disconnect(); } catch { /* ignore */ }
     setConnected(false);
+    setShowConnectionModal(true);
     setConnectionName('Not connected');
     setConnectionHost(null);
     setHistory([]);
@@ -344,6 +347,7 @@ export default function App() {
         connectionHost={connectionHost}
         connectionStatus={connected ? 'connected' : 'disconnected'}
         onDisconnect={handleDisconnect}
+        onOpenConnection={connected ? undefined : () => setShowConnectionModal(true)}
         mcpWritesAllowed={mcpWritesAllowed}
         mcpUrl={mcpUrl}
         onToggleMcpWrites={handleToggleMcpWrites}
@@ -401,11 +405,12 @@ export default function App() {
         </div>
       </div>
 
-      {!connected && (
+      {!connected && showConnectionModal && (
         <ConnectionManager
           onConnect={handleConnect}
           isConnecting={isConnecting}
           error={connectionError}
+          onDismiss={() => setShowConnectionModal(false)}
           t={t}
         />
       )}

--- a/src/components/ConnectionManager.tsx
+++ b/src/components/ConnectionManager.tsx
@@ -158,7 +158,7 @@ export function ConnectionManager({ onConnect, isConnecting, error, onDismiss, t
                       if (e.key === 'ArrowDown') { e.preventDefault(); setHighlightIdx(i => Math.min(i + 1, filteredSaved.length - 1)); }
                       else if (e.key === 'ArrowUp') { e.preventDefault(); setHighlightIdx(i => Math.max(i - 1, 0)); }
                       else if (e.key === 'Enter' && highlightIdx >= 0) { e.preventDefault(); applySaved(filteredSaved[highlightIdx]); }
-                      else if (e.key === 'Escape') { e.preventDefault(); setSuggestOpen(false); }
+                      else if (e.key === 'Escape') { e.preventDefault(); e.nativeEvent.stopImmediatePropagation(); setSuggestOpen(false); }
                     }}
                     placeholder="My Database"
                   />

--- a/src/components/ConnectionManager.tsx
+++ b/src/components/ConnectionManager.tsx
@@ -1,4 +1,4 @@
-import { useState, CSSProperties } from 'react';
+import { useState, useEffect, CSSProperties } from 'react';
 import type { Theme } from '../theme';
 import { api } from '../api';
 import { listSavedConnections, deleteSavedConnection, type SavedConnection } from '../savedConnections';
@@ -17,10 +17,11 @@ interface ConnectionManagerProps {
   onConnect: (form: ConnectionForm) => void;
   isConnecting: boolean;
   error: string | null;
+  onDismiss?: () => void;
   t: Theme;
 }
 
-export function ConnectionManager({ onConnect, isConnecting, error, t }: ConnectionManagerProps) {
+export function ConnectionManager({ onConnect, isConnecting, error, onDismiss, t }: ConnectionManagerProps) {
   const [saved, setSaved] = useState<SavedConnection[]>(() => listSavedConnections());
   const initialForm: ConnectionForm = saved[0]
     ? { ...saved[0], password: '' }
@@ -38,6 +39,13 @@ export function ConnectionManager({ onConnect, isConnecting, error, t }: Connect
   const [highlightIdx, setHighlightIdx] = useState(-1);
   const [testing, setTesting] = useState(false);
   const [testResult, setTestResult] = useState<{ ok: true } | { ok: false; error: string } | null>(null);
+
+  useEffect(() => {
+    if (!onDismiss || isConnecting) return;
+    const key = (e: KeyboardEvent) => { if (e.key === 'Escape') onDismiss(); };
+    window.addEventListener('keydown', key);
+    return () => window.removeEventListener('keydown', key);
+  }, [onDismiss, isConnecting]);
 
   const runTest = async () => {
     setTesting(true);
@@ -105,8 +113,8 @@ export function ConnectionManager({ onConnect, isConnecting, error, t }: Connect
   };
 
   return (
-    <div style={s.overlay}>
-      <div style={s.modal}>
+    <div style={s.overlay} onClick={!isConnecting ? onDismiss : undefined}>
+      <div style={s.modal} onClick={(e) => e.stopPropagation()}>
         <div style={s.header}>
           <svg width="20" height="20" viewBox="0 0 40 40" fill="none">
             <path d="M6 6 C6 6, 20 2, 20 20 C20 38, 6 34, 6 34" stroke={t.accent} strokeWidth="2.5" strokeLinecap="round"/>
@@ -312,6 +320,14 @@ export function ConnectionManager({ onConnect, isConnecting, error, t }: Connect
           </div>
 
           <div style={s.footer}>
+            {onDismiss && (
+              <button
+                type="button"
+                onClick={onDismiss}
+                disabled={isConnecting}
+                style={{ ...s.testBtn, opacity: isConnecting ? 0.5 : 1, cursor: isConnecting ? 'not-allowed' : 'pointer' }}
+              >Cancel</button>
+            )}
             <button
               type="button"
               style={{ ...s.testBtn, opacity: testing ? 0.7 : 1, cursor: testing ? 'wait' : 'pointer' }}

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -17,6 +17,7 @@ interface TopBarProps {
   connectionHost?: string | null;
   connectionStatus: 'connected' | 'disconnected' | 'error';
   onDisconnect?: () => void;
+  onOpenConnection?: () => void;
   mcpWritesAllowed?: boolean;
   mcpUrl?: string;
   onToggleMcpWrites?: (enabled: boolean) => void | Promise<void>;
@@ -25,7 +26,7 @@ interface TopBarProps {
   t: Theme;
 }
 
-export function TopBar({ tabs, activeTab, onTabChange, onNewTab, onCloseTab, connectionName, connectionHost, connectionStatus, onDisconnect, mcpWritesAllowed, mcpUrl, onToggleMcpWrites, themeName, onToggleTheme, t }: TopBarProps) {
+export function TopBar({ tabs, activeTab, onTabChange, onNewTab, onCloseTab, connectionName, connectionHost, connectionStatus, onDisconnect, onOpenConnection, mcpWritesAllowed, mcpUrl, onToggleMcpWrites, themeName, onToggleTheme, t }: TopBarProps) {
   const [menuOpen, setMenuOpen] = useState(false);
   const [mcpBusy, setMcpBusy] = useState(false);
   const [mcpError, setMcpError] = useState<string | null>(null);
@@ -122,13 +123,14 @@ export function TopBar({ tabs, activeTab, onTabChange, onNewTab, onCloseTab, con
           onClick={(e) => {
             e.stopPropagation();
             if (canDisconnect) setMenuOpen(v => !v);
+            else if (onOpenConnection) onOpenConnection();
           }}
-          disabled={!canDisconnect}
-          title={canDisconnect ? 'Connection menu' : undefined}
+          disabled={!canDisconnect && !onOpenConnection}
+          title={canDisconnect ? 'Connection menu' : onOpenConnection ? 'Connect to database' : undefined}
           style={{
             display: 'flex', alignItems: 'center', gap: 7, padding: '0 14px',
             height: '100%', background: menuOpen ? t.bgSurface : 'transparent',
-            border: 'none', cursor: canDisconnect ? 'pointer' : 'default',
+            border: 'none', cursor: (canDisconnect || onOpenConnection) ? 'pointer' : 'default',
             alignSelf: 'stretch',
           }}
         >


### PR DESCRIPTION
Fixes #52

## Summary
- **Cancel button** added to the connection modal footer; hidden while a connection attempt is in progress
- **Escape key** dismisses the modal (unless a connection is in progress)
- **Backdrop click** dismisses the modal (clicking outside the modal panel)
- **Disconnected status pill** in the TopBar is now clickable to reopen the modal after dismissing

## How it works
Introduces a `showConnectionModal` boolean in `App.tsx` (independent of the `connected` flag) so the modal can be hidden without changing connection state. On disconnect the modal reappears automatically; on successful connect it hides. The `onDismiss` prop is optional on `ConnectionManager` so cancel affordances are only rendered when a dismiss handler is wired up.

## Test plan
- [ ] Open app fresh — connection modal appears; Cancel, Escape, and backdrop click all dismiss it
- [ ] After dismissing, the status pill shows "Not connected" and is clickable — clicking reopens the modal
- [ ] Successful connect hides the modal; Cancel is not visible while the Connecting spinner is active
- [ ] Disconnect via the TopBar menu — modal reappears automatically
- [ ] Escape on the connection name autocomplete dropdown still only closes the dropdown (not the modal)

Generated with [Claude Code](https://claude.com/claude-code)
