### PR TITLE
fix: rename Log Out to Disconnect; fix MCP toggle colour

### DIFF
--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -221,7 +221,7 @@ export function TopBar({ tabs, activeTab, onTabChange, onNewTab, onCloseTab, con
                     }}
                     style={{
                       position: 'relative', width: 28, height: 16, borderRadius: 10,
-                      background: mcpWritesAllowed ? t.accent : t.borderSubtle,
+                      background: mcpWritesAllowed ? t.accent : t.border,
                       transition: 'background 150ms ease',
                       flexShrink: 0,
                       cursor: isConnected && !mcpBusy ? 'pointer' : 'default',
@@ -257,7 +257,7 @@ export function TopBar({ tabs, activeTab, onTabChange, onNewTab, onCloseTab, con
                 <polyline points="16 17 21 12 16 7"/>
                 <line x1="21" y1="12" x2="9" y2="12"/>
               </svg>
-              Log Out
+              Disconnect
             </button>
           </div>
         )}


### PR DESCRIPTION
Fixes #64

## Summary
- **"Log Out" → "Disconnect"** — database tools (TablePlus, DBeaver, DataGrip) all use "Disconnect"; "Log Out" implies a web session
- **MCP toggle colour** — off-state background changed from `borderSubtle` to `border`, matching the SSL toggle in the connection modal and making the on/off states visually distinct in both light and dark themes

## Test plan
- [ ] Connect to a database, open the connection dropdown — button now reads "Disconnect"
- [ ] Toggle MCP writes off — toggle visibly grey; toggle on — toggle visibly green (accent)
- [ ] Verify in both light and dark themes

Generated with [Claude Code](https://claude.com/claude-code)
