### PR TITLE
Align Export button height with sibling toolbar buttons

### DIFF
--- a/src/components/ResultsTable.tsx
+++ b/src/components/ResultsTable.tsx
@@ -428,7 +428,7 @@ export function ResultsTable({ results, isRunning, error, executionTime, activeS
             New row
           </button>
         )}
-        <div style={{ position: 'relative' }}>
+        <div style={{ position: 'relative', display: 'flex' }}>
           <button
             style={{ ...s.exportBtn, opacity: results ? 1 : 0.5, cursor: results ? 'pointer' : 'not-allowed' }}
             onClick={(e) => { e.stopPropagation(); if (results) setExportOpen(o => !o); }}


### PR DESCRIPTION
## Summary
- The Export button rendered shorter than Filter and New row.
- The toolbar uses \`alignItems: stretch\`, which stretches direct flex children. Filter/New row are direct children and stretch correctly. Export's button is wrapped in \`<div style={{ position: 'relative' }}>\` (needed for the dropdown), so the wrapper became the flex child and the button inside sized to its content.
- Adding \`display: flex\` to the wrapper makes the button a flex item that stretches to match the others.

## Test plan
- [ ] Open results, confirm Filter, New row, and Export buttons share the same height.
- [ ] Open the Export dropdown — still anchored correctly under the button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)