### PR TITLE
Keep table header visible while scrolling results

### DIFF
--- a/src/components/ResultsTable.tsx
+++ b/src/components/ResultsTable.tsx
@@ -684,7 +684,6 @@ export function ResultsTable({ results, isRunning, error, executionTime, activeS
                     title={hComment}
                     style={{
                       ...s.th,
-                      position: 'relative',
                       cursor: resizingCol ? 'col-resize' : 'grab',
                       overflow: 'hidden',
                       ...(w ? { width: w, minWidth: w } : { minWidth: 80 }),


### PR DESCRIPTION
## Summary
- The result-table header row scrolled away with the rows, making it hard to tell which value belonged to which column.
- The base \`s.th\` style already had \`position: sticky; top: 0\`, but each header cell's inline style appended \`position: relative\` (added so the absolute-positioned resize handle would have a positioning ancestor). That override killed the stickiness.
- Sticky elements establish a positioning context for absolute descendants, so the \`relative\` is unnecessary — removing it restores sticky behaviour.

## Test plan
- [ ] Run a query returning more rows than fit in the viewport and scroll — header stays pinned.
- [ ] Drag a column resize handle — still works (handle positions correctly relative to the th).
- [ ] Reorder columns by drag — still works.
- [ ] Sort indicator and drag-over highlight render unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)