### PR TITLE
feat: driver abstraction layer foundation for PostgreSQL support

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -12,12 +12,14 @@
         "@modelcontextprotocol/sdk": "^1.29.0",
         "cors": "^2.8.5",
         "express": "^4.21.2",
-        "mysql2": "^3.14.0"
+        "mysql2": "^3.14.0",
+        "pg": "^8.20.0"
       },
       "devDependencies": {
         "@types/cors": "^2.8.17",
         "@types/express": "^5.0.3",
         "@types/node": "^24.0.0",
+        "@types/pg": "^8.20.0",
         "@types/supertest": "^6.0.0",
         "supertest": "^7.0.0",
         "tsx": "^4.19.4",
@@ -1308,6 +1310,18 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/@types/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
       }
     },
     "node_modules/@types/qs": {
@@ -2715,6 +2729,95 @@
         "node": ">= 14.16"
       }
     },
+    "node_modules/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.12.0",
+        "pg-pool": "^3.13.0",
+        "pg-protocol": "^1.13.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.3.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.3.0.tgz",
+      "integrity": "sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.12.0.tgz",
+      "integrity": "sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.13.0.tgz",
+      "integrity": "sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.13.0.tgz",
+      "integrity": "sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -2771,6 +2874,45 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/proxy-addr": {
@@ -3123,6 +3265,15 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
       }
     },
     "node_modules/sql-escaper": {
@@ -3668,6 +3819,15 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
     },
     "node_modules/zod": {
       "version": "4.3.6",

--- a/server/package.json
+++ b/server/package.json
@@ -16,12 +16,14 @@
     "@modelcontextprotocol/sdk": "^1.29.0",
     "cors": "^2.8.5",
     "express": "^4.21.2",
-    "mysql2": "^3.14.0"
+    "mysql2": "^3.14.0",
+    "pg": "^8.20.0"
   },
   "devDependencies": {
     "@types/cors": "^2.8.17",
     "@types/express": "^5.0.3",
     "@types/node": "^24.0.0",
+    "@types/pg": "^8.20.0",
     "@types/supertest": "^6.0.0",
     "supertest": "^7.0.0",
     "tsx": "^4.19.4",

--- a/server/src/drivers/interface.ts
+++ b/server/src/drivers/interface.ts
@@ -1,0 +1,65 @@
+export interface ConnectionConfig {
+  host: string;
+  port: number;
+  user: string;
+  password: string;
+  database?: string;
+  ssl?: 'require' | 'verify-full';
+  type: 'mysql' | 'postgres';
+}
+
+export interface ColumnMeta {
+  name: string;
+  orgName: string;
+  table: string;
+  orgTable: string;
+  pk: boolean;
+  unique: boolean;
+  notNull: boolean;
+  /** MySQL column type constant; 0 for non-MySQL drivers. */
+  mysqlType: number;
+}
+
+export interface QueryResult {
+  rows: Record<string, unknown>[];
+  columnMeta: ColumnMeta[];
+  affectedRows?: number;
+  insertId?: number | null;
+}
+
+export interface ColumnInfo {
+  name: string;
+  type: string;
+  dataType: string;
+  pk: boolean;
+  nullable: boolean;
+  default: string | null;
+  autoIncrement: boolean;
+  comment: string;
+}
+
+export interface TableInfo {
+  name: string;
+  rows: number;
+  comment: string;
+  columns: ColumnInfo[];
+}
+
+export interface SchemaInfo {
+  tables: TableInfo[];
+  views: string[];
+  procedures: string[];
+  triggers: string[];
+}
+
+export interface DbDriver {
+  /** Run a query, optionally switching schema first (atomically on one connection). */
+  query(sql: string, params?: unknown[], schema?: string): Promise<QueryResult>;
+  getSchemas(): Promise<string[]>;
+  getSchema(schema: string): Promise<SchemaInfo>;
+  getTableDdl(schema: string, table: string, type: 'table' | 'view' | 'procedure' | 'trigger'): Promise<string>;
+  /** Return a quoted, escaped identifier (e.g. `name` for MySQL, "name" for Postgres). */
+  escapeIdent(s: string): string;
+  ping(): Promise<void>;
+  end(): Promise<void>;
+}

--- a/server/src/drivers/mysql.ts
+++ b/server/src/drivers/mysql.ts
@@ -1,0 +1,219 @@
+import mysql from 'mysql2/promise';
+import type { RowDataPacket, FieldPacket, ResultSetHeader } from 'mysql2/promise';
+import type { DbDriver, ConnectionConfig, QueryResult, ColumnMeta, ColumnInfo, SchemaInfo } from './interface.js';
+
+export class MysqlDriver implements DbDriver {
+  private pool: mysql.Pool;
+
+  constructor(config: ConnectionConfig) {
+    this.pool = mysql.createPool({
+      host: config.host,
+      port: config.port,
+      user: config.user,
+      password: config.password,
+      database: config.database || undefined,
+      ssl: config.ssl === 'verify-full' ? { rejectUnauthorized: true }
+         : config.ssl === 'require'     ? { rejectUnauthorized: false }
+         : undefined,
+      waitForConnections: true,
+      connectionLimit: 5,
+      connectTimeout: 10_000,
+    });
+  }
+
+  escapeIdent(s: string): string {
+    return '`' + s.replace(/`/g, '') + '`';
+  }
+
+  async ping(): Promise<void> {
+    const conn = await this.pool.getConnection();
+    try {
+      await conn.ping();
+    } finally {
+      conn.release();
+    }
+  }
+
+  async end(): Promise<void> {
+    await this.pool.end();
+  }
+
+  async query(sql: string, params?: unknown[], schema?: string): Promise<QueryResult> {
+    const conn = await this.pool.getConnection();
+    try {
+      if (schema) {
+        await conn.query(`USE \`${schema.replace(/`/g, '')}\``);
+      }
+
+      const [rows, fields] = await conn.query(sql, params) as [RowDataPacket[] | ResultSetHeader, FieldPacket[]];
+
+      if (!Array.isArray(rows)) {
+        const result = rows as ResultSetHeader;
+        return {
+          rows: [],
+          columnMeta: [],
+          affectedRows: result.affectedRows ?? 0,
+          insertId: result.insertId ?? null,
+        };
+      }
+
+      const NOT_NULL_FLAG = 1;
+      const PRI_KEY_FLAG = 2;
+      const UNIQUE_KEY_FLAG = 4;
+
+      const columnMeta: ColumnMeta[] = fields.map(f => {
+        let flagsNum = 0;
+        if (typeof f.flags === 'number') {
+          flagsNum = f.flags;
+        } else if (Array.isArray(f.flags)) {
+          if ((f.flags as string[]).includes('NOT_NULL')) flagsNum |= NOT_NULL_FLAG;
+          if ((f.flags as string[]).includes('PRI_KEY')) flagsNum |= PRI_KEY_FLAG;
+          if ((f.flags as string[]).includes('UNIQUE_KEY')) flagsNum |= UNIQUE_KEY_FLAG;
+        }
+        return {
+          name: f.name,
+          orgName: f.orgName ?? f.name,
+          table: f.table ?? '',
+          orgTable: f.orgTable ?? '',
+          pk: (flagsNum & PRI_KEY_FLAG) === PRI_KEY_FLAG,
+          unique: (flagsNum & UNIQUE_KEY_FLAG) === UNIQUE_KEY_FLAG,
+          notNull: (flagsNum & NOT_NULL_FLAG) === NOT_NULL_FLAG,
+          mysqlType: f.columnType ?? f.type ?? 0,
+        };
+      });
+
+      const columns = fields.map(f => f.name);
+      const serializedRows = (rows as RowDataPacket[]).map(row => {
+        const out: Record<string, unknown> = {};
+        for (const col of columns) {
+          const val = row[col];
+          if (val === null || val === undefined) {
+            out[col] = null;
+          } else if (Buffer.isBuffer(val)) {
+            out[col] = val.toString('hex');
+          } else if (val instanceof Date) {
+            out[col] = val.toISOString().replace('T', ' ').replace(/\.\d{3}Z$/, '');
+          } else if (typeof val === 'bigint') {
+            out[col] = val.toString();
+          } else {
+            out[col] = val;
+          }
+        }
+        return out;
+      });
+
+      return { rows: serializedRows, columnMeta };
+    } finally {
+      conn.release();
+    }
+  }
+
+  async getSchemas(): Promise<string[]> {
+    const [rows] = await this.pool.query<RowDataPacket[]>(
+      `SELECT SCHEMA_NAME AS name FROM information_schema.SCHEMATA
+       WHERE SCHEMA_NAME NOT IN ('information_schema','performance_schema','mysql','sys')
+       ORDER BY SCHEMA_NAME`,
+    );
+    return rows.map(r => r['name'] as string);
+  }
+
+  async getSchema(schema: string): Promise<SchemaInfo> {
+    const conn = await this.pool.getConnection();
+    try {
+      const [[tables], [columns], [views], [procedures], [triggers]] = await Promise.all([
+        conn.query<RowDataPacket[]>(
+          `SELECT TABLE_NAME AS name, TABLE_ROWS AS row_count, TABLE_COMMENT AS comment
+           FROM information_schema.TABLES
+           WHERE TABLE_SCHEMA = ? AND TABLE_TYPE = 'BASE TABLE'
+           ORDER BY TABLE_NAME`,
+          [schema],
+        ),
+        conn.query<RowDataPacket[]>(
+          `SELECT TABLE_NAME AS tbl, COLUMN_NAME AS col, COLUMN_TYPE AS col_type,
+                  DATA_TYPE AS data_type,
+                  IF(COLUMN_KEY = 'PRI', 1, 0) AS is_pk,
+                  IF(IS_NULLABLE = 'YES', 1, 0) AS nullable,
+                  COLUMN_DEFAULT AS col_default,
+                  EXTRA AS extra,
+                  COLUMN_COMMENT AS comment
+           FROM information_schema.COLUMNS
+           WHERE TABLE_SCHEMA = ?
+           ORDER BY TABLE_NAME, ORDINAL_POSITION`,
+          [schema],
+        ),
+        conn.query<RowDataPacket[]>(
+          `SELECT TABLE_NAME AS name FROM information_schema.VIEWS
+           WHERE TABLE_SCHEMA = ? ORDER BY TABLE_NAME`,
+          [schema],
+        ),
+        conn.query<RowDataPacket[]>(
+          `SELECT ROUTINE_NAME AS name FROM information_schema.ROUTINES
+           WHERE ROUTINE_SCHEMA = ? AND ROUTINE_TYPE = 'PROCEDURE'
+           ORDER BY ROUTINE_NAME`,
+          [schema],
+        ),
+        conn.query<RowDataPacket[]>(
+          `SELECT TRIGGER_NAME AS name FROM information_schema.TRIGGERS
+           WHERE TRIGGER_SCHEMA = ? ORDER BY TRIGGER_NAME`,
+          [schema],
+        ),
+      ]);
+
+      const colsByTable = new Map<string, ColumnInfo[]>();
+      for (const col of columns) {
+        const tname = col['tbl'] as string;
+        if (!colsByTable.has(tname)) colsByTable.set(tname, []);
+        const extra = ((col['extra'] as string) ?? '').toLowerCase();
+        colsByTable.get(tname)!.push({
+          name: col['col'] as string,
+          type: col['col_type'] as string,
+          dataType: ((col['data_type'] as string) ?? '').toLowerCase(),
+          pk: Boolean(col['is_pk']),
+          nullable: Boolean(col['nullable']),
+          default: (col['col_default'] as string | null) ?? null,
+          autoIncrement: extra.includes('auto_increment'),
+          comment: (col['comment'] as string) ?? '',
+        });
+      }
+
+      return {
+        tables: tables.map(t => ({
+          name: t['name'] as string,
+          rows: t['row_count'] as number,
+          comment: (t['comment'] as string) ?? '',
+          columns: colsByTable.get(t['name'] as string) ?? [],
+        })),
+        views: views.map(v => v['name'] as string),
+        procedures: procedures.map(p => p['name'] as string),
+        triggers: triggers.map(t => t['name'] as string),
+      };
+    } finally {
+      conn.release();
+    }
+  }
+
+  async getTableDdl(schema: string, table: string, type: 'table' | 'view' | 'procedure' | 'trigger'): Promise<string> {
+    const qualified = `${this.escapeIdent(schema)}.${this.escapeIdent(table)}`;
+
+    let sql: string;
+    if (type === 'procedure') {
+      sql = `SHOW CREATE PROCEDURE ${qualified}`;
+    } else if (type === 'trigger') {
+      sql = `SHOW CREATE TRIGGER ${qualified}`;
+    } else {
+      sql = `SHOW CREATE TABLE ${qualified}`;
+    }
+
+    const [rows] = await this.pool.query<RowDataPacket[]>(sql);
+    if (rows.length === 0) throw new Error(`No DDL returned for ${qualified}.`);
+
+    const row = rows[0] as Record<string, unknown>;
+    return (
+      row['Create Table'] ??
+      row['Create View'] ??
+      row['Create Procedure'] ??
+      row['SQL Original Statement'] ??
+      ''
+    ) as string;
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `pg` and `@types/pg` to `server/package.json` (closes #87)
- Creates `server/src/drivers/interface.ts` with the `DbDriver` interface, normalized `QueryResult`/`ColumnMeta`/`SchemaInfo` types, and `ConnectionConfig` extended with a `type` field (closes #89)
- Creates `server/src/drivers/mysql.ts` implementing `DbDriver` — migrates pool setup, query (with schema-switching), `getSchemas`, `getSchema`, `getTableDdl`, and `escapeIdent` from the existing route files (closes #90)

No existing behaviour is changed; all current routes still call `db.ts`/`mysql2` directly. Subsequent PRs will wire the routes up to `getDriver()` and add the Postgres driver.

## Test plan
- [ ] `npx tsc --noEmit` passes with no errors
- [ ] `npm test` (unit suite) passes — 11/11 tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)