### PR TITLE
feat: PostgresDriver - pg.Pool implementation of DbDriver

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,3 +11,17 @@ services:
       interval: 2s
       timeout: 5s
       retries: 20
+
+  postgres-test:
+    image: postgres:16
+    environment:
+      POSTGRES_USER: root
+      POSTGRES_PASSWORD: root
+      POSTGRES_DB: helix_test
+    ports:
+      - "5433:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U root -d helix_test"]
+      interval: 2s
+      timeout: 5s
+      retries: 20

--- a/server/src/drivers/postgres.integration.test.ts
+++ b/server/src/drivers/postgres.integration.test.ts
@@ -1,0 +1,196 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import pg from 'pg';
+import { PostgresDriver } from './postgres.js';
+
+const PG_CONFIG = {
+  host: process.env['PG_HOST'] ?? 'localhost',
+  port: Number(process.env['PG_PORT'] ?? 5433),
+  user: process.env['PG_USER'] ?? 'root',
+  password: process.env['PG_PASSWORD'] ?? 'root',
+  database: process.env['PG_DB'] ?? 'helix_test',
+  type: 'postgres' as const,
+};
+
+let driver: PostgresDriver;
+let raw: pg.Client;
+
+beforeAll(async () => {
+  driver = new PostgresDriver(PG_CONFIG);
+  raw = new pg.Client(PG_CONFIG);
+  await raw.connect();
+});
+
+afterAll(async () => {
+  await raw.end();
+  await driver.end();
+});
+
+beforeEach(async () => {
+  await raw.query('DELETE FROM orders');
+  await raw.query('DELETE FROM users');
+  await raw.query("SELECT setval('users_id_seq', 1, false)");
+  await raw.query("SELECT setval('orders_id_seq', 1, false)");
+});
+
+// ---------------------------------------------------------------------------
+// ping
+// ---------------------------------------------------------------------------
+
+describe('PostgresDriver – ping', () => {
+  it('resolves without error when connected', async () => {
+    await expect(driver.ping()).resolves.toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// escapeIdent
+// ---------------------------------------------------------------------------
+
+describe('PostgresDriver – escapeIdent', () => {
+  it('wraps identifier in double-quotes', () => {
+    expect(driver.escapeIdent('my_table')).toBe('"my_table"');
+  });
+
+  it('strips embedded double-quotes to prevent injection', () => {
+    expect(driver.escapeIdent('bad"name')).toBe('"badname"');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// query – SELECT
+// ---------------------------------------------------------------------------
+
+describe('PostgresDriver – query (SELECT)', () => {
+  it('returns empty rows for an empty table', async () => {
+    const result = await driver.query('SELECT * FROM users', [], 'public');
+    expect(result.rows).toEqual([]);
+    expect(result.columnMeta.map(c => c.name)).toContain('id');
+  });
+
+  it('returns inserted rows with correct types', async () => {
+    await raw.query("INSERT INTO users (name, age) VALUES ('Alice', 30)");
+    const result = await driver.query('SELECT id, name, age FROM users', [], 'public');
+    expect(result.rows).toHaveLength(1);
+    expect(result.rows[0]).toMatchObject({ name: 'Alice', age: 30 });
+  });
+
+  it('switches schema via SET search_path when schema is provided', async () => {
+    await raw.query("INSERT INTO users (name) VALUES ('Bob')");
+    const result = await driver.query('SELECT name FROM users', [], 'public');
+    expect(result.rows[0]).toMatchObject({ name: 'Bob' });
+  });
+
+  it('runs the query without schema switching when schema is omitted', async () => {
+    const result = await driver.query('SELECT 1 AS one');
+    expect(result.rows[0]).toMatchObject({ one: 1 });
+  });
+
+  it('serializes NULL as null', async () => {
+    await raw.query("INSERT INTO users (name, age) VALUES ('Carol', NULL)");
+    const result = await driver.query('SELECT age FROM users');
+    expect(result.rows[0]!['age']).toBeNull();
+  });
+
+  it('serializes Date columns as ISO-style strings without milliseconds', async () => {
+    await raw.query("INSERT INTO users (name) VALUES ('Dave')");
+    await raw.query("INSERT INTO orders (user_id, total) VALUES (1, 9.99)");
+    const result = await driver.query('SELECT created_at FROM orders');
+    const val = result.rows[0]!['created_at'] as string;
+    expect(val).toMatch(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/);
+  });
+
+  it('populates columnMeta with correct names', async () => {
+    const result = await driver.query('SELECT id, name FROM users');
+    expect(result.columnMeta.map(c => c.name)).toEqual(['id', 'name']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// query – DML
+// ---------------------------------------------------------------------------
+
+describe('PostgresDriver – query (DML)', () => {
+  it('returns affectedRows for an UPDATE statement', async () => {
+    await raw.query("INSERT INTO users (name, age) VALUES ('Eve', 25), ('Frank', 25)");
+    const result = await driver.query("UPDATE users SET age = 26 WHERE age = 25");
+    expect(result.rows).toEqual([]);
+    expect(result.affectedRows).toBe(2);
+  });
+
+  it('returns 0 affectedRows when WHERE matches nothing', async () => {
+    const result = await driver.query("UPDATE users SET age = 99 WHERE id = 9999");
+    expect(result.affectedRows).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getSchemas
+// ---------------------------------------------------------------------------
+
+describe('PostgresDriver – getSchemas', () => {
+  it('returns user schemas and excludes system schemas', async () => {
+    const schemas = await driver.getSchemas();
+    expect(schemas).toContain('public');
+    expect(schemas).not.toContain('pg_catalog');
+    expect(schemas).not.toContain('information_schema');
+    expect(schemas.every(s => !s.startsWith('pg_toast'))).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getSchema
+// ---------------------------------------------------------------------------
+
+describe('PostgresDriver – getSchema', () => {
+  it('returns tables with name and column info', async () => {
+    const info = await driver.getSchema('public');
+    const users = info.tables.find(t => t.name === 'users');
+    expect(users).toBeDefined();
+    const idCol = users!.columns.find(c => c.name === 'id');
+    expect(idCol).toBeDefined();
+    expect(idCol!.pk).toBe(true);
+    expect(idCol!.autoIncrement).toBe(true);
+    const nameCol = users!.columns.find(c => c.name === 'name');
+    expect(nameCol!.nullable).toBe(false);
+  });
+
+  it('includes the orders table with a numeric total column', async () => {
+    const info = await driver.getSchema('public');
+    const orders = info.tables.find(t => t.name === 'orders');
+    expect(orders).toBeDefined();
+    const totalCol = orders!.columns.find(c => c.name === 'total');
+    expect(totalCol).toBeDefined();
+    expect(totalCol!.dataType).toMatch(/numeric|decimal/i);
+  });
+
+  it('row_count is a number (estimated from pg_stat_user_tables)', async () => {
+    const info = await driver.getSchema('public');
+    for (const t of info.tables) {
+      expect(typeof t.rows).toBe('number');
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getTableDdl
+// ---------------------------------------------------------------------------
+
+describe('PostgresDriver – getTableDdl', () => {
+  it('reconstructs CREATE TABLE with columns and primary key', async () => {
+    const ddl = await driver.getTableDdl('public', 'users', 'table');
+    expect(ddl).toMatch(/CREATE TABLE/i);
+    expect(ddl).toMatch(/"users"/);
+    expect(ddl).toMatch(/PRIMARY KEY/i);
+    expect(ddl).toMatch(/"id"/);
+    expect(ddl).toMatch(/"name"/);
+  });
+
+  it('includes non-PK index in the reconstructed DDL', async () => {
+    const ddl = await driver.getTableDdl('public', 'orders', 'table');
+    expect(ddl).toMatch(/idx_orders_user_id/);
+  });
+
+  it('throws for a non-existent table', async () => {
+    await expect(driver.getTableDdl('public', 'ghost_table', 'table')).rejects.toThrow();
+  });
+});

--- a/server/src/drivers/postgres.ts
+++ b/server/src/drivers/postgres.ts
@@ -1,0 +1,321 @@
+import pg from 'pg';
+import type { DbDriver, ConnectionConfig, QueryResult, ColumnMeta, ColumnInfo, SchemaInfo } from './interface.js';
+
+export class PostgresDriver implements DbDriver {
+  private pool: pg.Pool;
+
+  constructor(config: ConnectionConfig) {
+    this.pool = new pg.Pool({
+      host: config.host,
+      port: config.port,
+      user: config.user,
+      password: config.password,
+      database: config.database || undefined,
+      ssl: config.ssl === 'verify-full' ? { rejectUnauthorized: true }
+         : config.ssl === 'require'     ? { rejectUnauthorized: false }
+         : undefined,
+      max: 5,
+      connectionTimeoutMillis: 10_000,
+    });
+  }
+
+  escapeIdent(s: string): string {
+    return '"' + s.replace(/"/g, '') + '"';
+  }
+
+  async ping(): Promise<void> {
+    const client = await this.pool.connect();
+    try {
+      await client.query('SELECT 1');
+    } finally {
+      client.release();
+    }
+  }
+
+  async end(): Promise<void> {
+    await this.pool.end();
+  }
+
+  async query(sql: string, params?: unknown[], schema?: string): Promise<QueryResult> {
+    const client = await this.pool.connect();
+    try {
+      if (schema) {
+        await client.query(`SET search_path TO ${this.escapeIdent(schema)}`);
+      }
+
+      const result = await client.query({ text: sql, values: params?.length ? params : undefined });
+
+      // Non-SELECT (INSERT, UPDATE, DELETE, DDL, etc.)
+      if (!result.fields || result.fields.length === 0) {
+        return {
+          rows: [],
+          columnMeta: [],
+          affectedRows: result.rowCount ?? 0,
+          insertId: null,
+        };
+      }
+
+      const columnMeta: ColumnMeta[] = result.fields.map(f => ({
+        name: f.name,
+        orgName: f.name,
+        table: '',
+        orgTable: '',
+        pk: false,
+        unique: false,
+        notNull: false,
+        mysqlType: 0,
+      }));
+
+      const columns = result.fields.map(f => f.name);
+      const serializedRows = (result.rows as Record<string, unknown>[]).map(row => {
+        const out: Record<string, unknown> = {};
+        for (const col of columns) {
+          const val = row[col];
+          if (val === null || val === undefined) {
+            out[col] = null;
+          } else if (Buffer.isBuffer(val)) {
+            out[col] = val.toString('hex');
+          } else if (val instanceof Date) {
+            out[col] = val.toISOString().replace('T', ' ').replace(/\.\d{3}Z$/, '');
+          } else {
+            out[col] = val;
+          }
+        }
+        return out;
+      });
+
+      return { rows: serializedRows, columnMeta };
+    } finally {
+      client.release();
+    }
+  }
+
+  async getSchemas(): Promise<string[]> {
+    const result = await this.pool.query<{ name: string }>(
+      `SELECT schema_name AS name
+       FROM information_schema.schemata
+       WHERE schema_name NOT IN ('information_schema', 'pg_catalog')
+         AND schema_name NOT LIKE 'pg_toast%'
+       ORDER BY schema_name`,
+    );
+    return result.rows.map(r => r.name);
+  }
+
+  async getSchema(schema: string): Promise<SchemaInfo> {
+    const client = await this.pool.connect();
+    try {
+      // Run all 5 queries on one client to avoid saturating the pool
+      const [tablesRes, columnsRes, viewsRes, procsRes, triggersRes] = await Promise.all([
+        client.query<{ name: string; row_count: string }>(
+          `SELECT t.table_name AS name,
+                  COALESCE(s.n_live_tup, 0)::text AS row_count
+           FROM information_schema.tables t
+           LEFT JOIN pg_stat_user_tables s
+             ON s.schemaname = t.table_schema AND s.relname = t.table_name
+           WHERE t.table_schema = $1 AND t.table_type = 'BASE TABLE'
+           ORDER BY t.table_name`,
+          [schema],
+        ),
+        client.query<{
+          tbl: string; col: string; col_type: string; data_type: string;
+          is_pk: string; nullable: string; col_default: string | null; extra: string;
+        }>(
+          `SELECT c.table_name AS tbl,
+                  c.column_name AS col,
+                  c.udt_name AS col_type,
+                  c.data_type AS data_type,
+                  CASE WHEN pk.column_name IS NOT NULL THEN '1' ELSE '0' END AS is_pk,
+                  CASE WHEN c.is_nullable = 'YES' THEN '1' ELSE '0' END AS nullable,
+                  c.column_default AS col_default,
+                  CASE WHEN c.column_default LIKE 'nextval(%' OR c.is_identity = 'YES'
+                       THEN 'auto_increment' ELSE '' END AS extra
+           FROM information_schema.columns c
+           LEFT JOIN (
+             SELECT kcu.table_name, kcu.column_name, kcu.table_schema
+             FROM information_schema.key_column_usage kcu
+             JOIN information_schema.table_constraints tc
+               ON tc.constraint_name = kcu.constraint_name
+               AND tc.table_schema = kcu.table_schema
+               AND tc.table_name = kcu.table_name
+               AND tc.constraint_type = 'PRIMARY KEY'
+             WHERE kcu.table_schema = $1
+           ) pk ON pk.table_name = c.table_name AND pk.column_name = c.column_name
+           WHERE c.table_schema = $1
+           ORDER BY c.table_name, c.ordinal_position`,
+          [schema],
+        ),
+        client.query<{ name: string }>(
+          `SELECT table_name AS name FROM information_schema.views
+           WHERE table_schema = $1 ORDER BY table_name`,
+          [schema],
+        ),
+        client.query<{ name: string }>(
+          `SELECT routine_name AS name FROM information_schema.routines
+           WHERE routine_schema = $1 AND routine_type IN ('FUNCTION', 'PROCEDURE')
+           ORDER BY routine_name`,
+          [schema],
+        ),
+        client.query<{ name: string }>(
+          `SELECT DISTINCT trigger_name AS name FROM information_schema.triggers
+           WHERE event_object_schema = $1 ORDER BY trigger_name`,
+          [schema],
+        ),
+      ]);
+
+      const colsByTable = new Map<string, ColumnInfo[]>();
+      for (const col of columnsRes.rows) {
+        const tname = col.tbl;
+        if (!colsByTable.has(tname)) colsByTable.set(tname, []);
+        colsByTable.get(tname)!.push({
+          name: col.col,
+          type: col.col_type,
+          dataType: (col.data_type ?? '').toLowerCase(),
+          pk: col.is_pk === '1',
+          nullable: col.nullable === '1',
+          default: col.col_default ?? null,
+          autoIncrement: col.extra.includes('auto_increment'),
+          comment: '',
+        });
+      }
+
+      return {
+        tables: tablesRes.rows.map(t => ({
+          name: t.name,
+          rows: Number(t.row_count),
+          comment: '',
+          columns: colsByTable.get(t.name) ?? [],
+        })),
+        views: viewsRes.rows.map(v => v.name),
+        procedures: procsRes.rows.map(p => p.name),
+        triggers: triggersRes.rows.map(t => t.name),
+      };
+    } finally {
+      client.release();
+    }
+  }
+
+  async getTableDdl(schema: string, table: string, type: 'table' | 'view' | 'procedure' | 'trigger'): Promise<string> {
+    const qualified = `${this.escapeIdent(schema)}.${this.escapeIdent(table)}`;
+
+    if (type === 'view') {
+      const result = await this.pool.query<{ view_definition: string }>(
+        `SELECT view_definition FROM information_schema.views
+         WHERE table_schema = $1 AND table_name = $2`,
+        [schema, table],
+      );
+      if (result.rows.length === 0) throw new Error(`No DDL returned for ${qualified}.`);
+      return `CREATE OR REPLACE VIEW ${qualified} AS\n${result.rows[0].view_definition}`;
+    }
+
+    if (type === 'procedure') {
+      const result = await this.pool.query<{ def: string }>(
+        `SELECT pg_get_functiondef(p.oid) AS def
+         FROM pg_proc p
+         JOIN pg_namespace n ON n.oid = p.pronamespace
+         WHERE n.nspname = $1 AND p.proname = $2
+         LIMIT 1`,
+        [schema, table],
+      );
+      if (result.rows.length === 0) throw new Error(`No DDL returned for ${qualified}.`);
+      return result.rows[0].def;
+    }
+
+    if (type === 'trigger') {
+      const result = await this.pool.query<{ def: string }>(
+        `SELECT pg_get_triggerdef(t.oid) AS def
+         FROM pg_trigger t
+         JOIN pg_class c ON c.oid = t.tgrelid
+         JOIN pg_namespace n ON n.oid = c.relnamespace
+         WHERE n.nspname = $1 AND t.tgname = $2`,
+        [schema, table],
+      );
+      if (result.rows.length === 0) throw new Error(`No DDL returned for ${qualified}.`);
+      return result.rows[0].def;
+    }
+
+    // type === 'table' — reconstruct DDL from catalog tables
+    const client = await this.pool.connect();
+    try {
+      const [colsRes, pkRes, idxRes] = await Promise.all([
+        client.query<{
+          column_name: string; data_type: string; udt_name: string;
+          character_maximum_length: string | null; numeric_precision: string | null;
+          numeric_scale: string | null; is_nullable: string;
+          column_default: string | null; is_identity: string;
+        }>(
+          `SELECT column_name, data_type, udt_name,
+                  character_maximum_length::text, numeric_precision::text, numeric_scale::text,
+                  is_nullable, column_default, is_identity
+           FROM information_schema.columns
+           WHERE table_schema = $1 AND table_name = $2
+           ORDER BY ordinal_position`,
+          [schema, table],
+        ),
+        client.query<{ column_name: string }>(
+          `SELECT kcu.column_name
+           FROM information_schema.table_constraints tc
+           JOIN information_schema.key_column_usage kcu
+             ON kcu.constraint_name = tc.constraint_name
+             AND kcu.table_schema = tc.table_schema
+             AND kcu.table_name = tc.table_name
+           WHERE tc.table_schema = $1 AND tc.table_name = $2 AND tc.constraint_type = 'PRIMARY KEY'
+           ORDER BY kcu.ordinal_position`,
+          [schema, table],
+        ),
+        client.query<{ indexname: string; indexdef: string }>(
+          `SELECT indexname, indexdef FROM pg_indexes
+           WHERE schemaname = $1 AND tablename = $2`,
+          [schema, table],
+        ),
+      ]);
+
+      if (colsRes.rows.length === 0) throw new Error(`No DDL returned for ${qualified}.`);
+
+      const pkCols = new Set(pkRes.rows.map(r => r.column_name));
+
+      const colDefs = colsRes.rows.map(r => {
+        const isSerial =
+          r.is_identity === 'YES' ||
+          (r.column_default?.startsWith('nextval(') ?? false);
+
+        let typeDef: string;
+        if (isSerial) {
+          typeDef = r.udt_name === 'int8' ? 'bigserial'
+                  : r.udt_name === 'int2' ? 'smallserial'
+                  : 'serial';
+        } else if (r.data_type === 'character varying') {
+          typeDef = r.character_maximum_length ? `varchar(${r.character_maximum_length})` : 'varchar';
+        } else if (r.data_type === 'character') {
+          typeDef = r.character_maximum_length ? `char(${r.character_maximum_length})` : 'char';
+        } else if (r.data_type === 'numeric' || r.data_type === 'decimal') {
+          typeDef = r.numeric_precision && r.numeric_scale !== null
+            ? `numeric(${r.numeric_precision},${r.numeric_scale})`
+            : 'numeric';
+        } else {
+          typeDef = r.udt_name ?? r.data_type;
+        }
+
+        let def = `  ${this.escapeIdent(r.column_name)} ${typeDef}`;
+        if (r.is_nullable === 'NO' && !isSerial) def += ' NOT NULL';
+        if (r.column_default && !isSerial) def += ` DEFAULT ${r.column_default}`;
+        return def;
+      });
+
+      if (pkCols.size > 0) {
+        colDefs.push(`  PRIMARY KEY (${[...pkCols].map(c => this.escapeIdent(c)).join(', ')})`);
+      }
+
+      let ddl = `CREATE TABLE ${qualified} (\n${colDefs.join(',\n')}\n)`;
+
+      for (const idx of idxRes.rows) {
+        if (!idx.indexname.endsWith('_pkey')) {
+          ddl += `;\n${idx.indexdef}`;
+        }
+      }
+
+      return ddl;
+    } finally {
+      client.release();
+    }
+  }
+}

--- a/server/src/drivers/postgres.ts
+++ b/server/src/drivers/postgres.ts
@@ -104,63 +104,61 @@ export class PostgresDriver implements DbDriver {
   async getSchema(schema: string): Promise<SchemaInfo> {
     const client = await this.pool.connect();
     try {
-      // Run all 5 queries on one client to avoid saturating the pool
-      const [tablesRes, columnsRes, viewsRes, procsRes, triggersRes] = await Promise.all([
-        client.query<{ name: string; row_count: string }>(
-          `SELECT t.table_name AS name,
-                  COALESCE(s.n_live_tup, 0)::text AS row_count
-           FROM information_schema.tables t
-           LEFT JOIN pg_stat_user_tables s
-             ON s.schemaname = t.table_schema AND s.relname = t.table_name
-           WHERE t.table_schema = $1 AND t.table_type = 'BASE TABLE'
-           ORDER BY t.table_name`,
-          [schema],
-        ),
-        client.query<{
-          tbl: string; col: string; col_type: string; data_type: string;
-          is_pk: string; nullable: string; col_default: string | null; extra: string;
-        }>(
-          `SELECT c.table_name AS tbl,
-                  c.column_name AS col,
-                  c.udt_name AS col_type,
-                  c.data_type AS data_type,
-                  CASE WHEN pk.column_name IS NOT NULL THEN '1' ELSE '0' END AS is_pk,
-                  CASE WHEN c.is_nullable = 'YES' THEN '1' ELSE '0' END AS nullable,
-                  c.column_default AS col_default,
-                  CASE WHEN c.column_default LIKE 'nextval(%' OR c.is_identity = 'YES'
-                       THEN 'auto_increment' ELSE '' END AS extra
-           FROM information_schema.columns c
-           LEFT JOIN (
-             SELECT kcu.table_name, kcu.column_name, kcu.table_schema
-             FROM information_schema.key_column_usage kcu
-             JOIN information_schema.table_constraints tc
-               ON tc.constraint_name = kcu.constraint_name
-               AND tc.table_schema = kcu.table_schema
-               AND tc.table_name = kcu.table_name
-               AND tc.constraint_type = 'PRIMARY KEY'
-             WHERE kcu.table_schema = $1
-           ) pk ON pk.table_name = c.table_name AND pk.column_name = c.column_name
-           WHERE c.table_schema = $1
-           ORDER BY c.table_name, c.ordinal_position`,
-          [schema],
-        ),
-        client.query<{ name: string }>(
-          `SELECT table_name AS name FROM information_schema.views
-           WHERE table_schema = $1 ORDER BY table_name`,
-          [schema],
-        ),
-        client.query<{ name: string }>(
-          `SELECT routine_name AS name FROM information_schema.routines
-           WHERE routine_schema = $1 AND routine_type IN ('FUNCTION', 'PROCEDURE')
-           ORDER BY routine_name`,
-          [schema],
-        ),
-        client.query<{ name: string }>(
-          `SELECT DISTINCT trigger_name AS name FROM information_schema.triggers
-           WHERE event_object_schema = $1 ORDER BY trigger_name`,
-          [schema],
-        ),
-      ]);
+      // pg clients are single-connection — queries must be sequential, not concurrent
+      const tablesRes = await client.query<{ name: string; row_count: string }>(
+        `SELECT t.table_name AS name,
+                COALESCE(s.n_live_tup, 0)::text AS row_count
+         FROM information_schema.tables t
+         LEFT JOIN pg_stat_user_tables s
+           ON s.schemaname = t.table_schema AND s.relname = t.table_name
+         WHERE t.table_schema = $1 AND t.table_type = 'BASE TABLE'
+         ORDER BY t.table_name`,
+        [schema],
+      );
+      const columnsRes = await client.query<{
+        tbl: string; col: string; col_type: string; data_type: string;
+        is_pk: string; nullable: string; col_default: string | null; extra: string;
+      }>(
+        `SELECT c.table_name AS tbl,
+                c.column_name AS col,
+                c.udt_name AS col_type,
+                c.data_type AS data_type,
+                CASE WHEN pk.column_name IS NOT NULL THEN '1' ELSE '0' END AS is_pk,
+                CASE WHEN c.is_nullable = 'YES' THEN '1' ELSE '0' END AS nullable,
+                c.column_default AS col_default,
+                CASE WHEN c.column_default LIKE 'nextval(%' OR c.is_identity = 'YES'
+                     THEN 'auto_increment' ELSE '' END AS extra
+         FROM information_schema.columns c
+         LEFT JOIN (
+           SELECT kcu.table_name, kcu.column_name, kcu.table_schema
+           FROM information_schema.key_column_usage kcu
+           JOIN information_schema.table_constraints tc
+             ON tc.constraint_name = kcu.constraint_name
+             AND tc.table_schema = kcu.table_schema
+             AND tc.table_name = kcu.table_name
+             AND tc.constraint_type = 'PRIMARY KEY'
+           WHERE kcu.table_schema = $1
+         ) pk ON pk.table_name = c.table_name AND pk.column_name = c.column_name
+         WHERE c.table_schema = $1
+         ORDER BY c.table_name, c.ordinal_position`,
+        [schema],
+      );
+      const viewsRes = await client.query<{ name: string }>(
+        `SELECT table_name AS name FROM information_schema.views
+         WHERE table_schema = $1 ORDER BY table_name`,
+        [schema],
+      );
+      const procsRes = await client.query<{ name: string }>(
+        `SELECT routine_name AS name FROM information_schema.routines
+         WHERE routine_schema = $1 AND routine_type IN ('FUNCTION', 'PROCEDURE')
+         ORDER BY routine_name`,
+        [schema],
+      );
+      const triggersRes = await client.query<{ name: string }>(
+        `SELECT DISTINCT trigger_name AS name FROM information_schema.triggers
+         WHERE event_object_schema = $1 ORDER BY trigger_name`,
+        [schema],
+      );
 
       const colsByTable = new Map<string, ColumnInfo[]>();
       for (const col of columnsRes.rows) {
@@ -236,38 +234,36 @@ export class PostgresDriver implements DbDriver {
     // type === 'table' — reconstruct DDL from catalog tables
     const client = await this.pool.connect();
     try {
-      const [colsRes, pkRes, idxRes] = await Promise.all([
-        client.query<{
-          column_name: string; data_type: string; udt_name: string;
-          character_maximum_length: string | null; numeric_precision: string | null;
-          numeric_scale: string | null; is_nullable: string;
-          column_default: string | null; is_identity: string;
-        }>(
-          `SELECT column_name, data_type, udt_name,
-                  character_maximum_length::text, numeric_precision::text, numeric_scale::text,
-                  is_nullable, column_default, is_identity
-           FROM information_schema.columns
-           WHERE table_schema = $1 AND table_name = $2
-           ORDER BY ordinal_position`,
-          [schema, table],
-        ),
-        client.query<{ column_name: string }>(
-          `SELECT kcu.column_name
-           FROM information_schema.table_constraints tc
-           JOIN information_schema.key_column_usage kcu
-             ON kcu.constraint_name = tc.constraint_name
-             AND kcu.table_schema = tc.table_schema
-             AND kcu.table_name = tc.table_name
-           WHERE tc.table_schema = $1 AND tc.table_name = $2 AND tc.constraint_type = 'PRIMARY KEY'
-           ORDER BY kcu.ordinal_position`,
-          [schema, table],
-        ),
-        client.query<{ indexname: string; indexdef: string }>(
-          `SELECT indexname, indexdef FROM pg_indexes
-           WHERE schemaname = $1 AND tablename = $2`,
-          [schema, table],
-        ),
-      ]);
+      const colsRes = await client.query<{
+        column_name: string; data_type: string; udt_name: string;
+        character_maximum_length: string | null; numeric_precision: string | null;
+        numeric_scale: string | null; is_nullable: string;
+        column_default: string | null; is_identity: string;
+      }>(
+        `SELECT column_name, data_type, udt_name,
+                character_maximum_length::text, numeric_precision::text, numeric_scale::text,
+                is_nullable, column_default, is_identity
+         FROM information_schema.columns
+         WHERE table_schema = $1 AND table_name = $2
+         ORDER BY ordinal_position`,
+        [schema, table],
+      );
+      const pkRes = await client.query<{ column_name: string }>(
+        `SELECT kcu.column_name
+         FROM information_schema.table_constraints tc
+         JOIN information_schema.key_column_usage kcu
+           ON kcu.constraint_name = tc.constraint_name
+           AND kcu.table_schema = tc.table_schema
+           AND kcu.table_name = tc.table_name
+         WHERE tc.table_schema = $1 AND tc.table_name = $2 AND tc.constraint_type = 'PRIMARY KEY'
+         ORDER BY kcu.ordinal_position`,
+        [schema, table],
+      );
+      const idxRes = await client.query<{ indexname: string; indexdef: string }>(
+        `SELECT indexname, indexdef FROM pg_indexes
+         WHERE schemaname = $1 AND tablename = $2`,
+        [schema, table],
+      );
 
       if (colsRes.rows.length === 0) throw new Error(`No DDL returned for ${qualified}.`);
 

--- a/server/src/test-setup/global-setup-postgres.ts
+++ b/server/src/test-setup/global-setup-postgres.ts
@@ -1,0 +1,69 @@
+import pg from 'pg';
+
+const TIMEOUT_MS = 30_000;
+const POLL_MS = 500;
+
+const config = {
+  host: process.env['PG_HOST'] ?? 'localhost',
+  port: Number(process.env['PG_PORT'] ?? 5433),
+  user: process.env['PG_USER'] ?? 'root',
+  password: process.env['PG_PASSWORD'] ?? 'root',
+  database: process.env['PG_DB'] ?? 'helix_test',
+};
+
+async function waitForPostgres(): Promise<pg.Client> {
+  const deadline = Date.now() + TIMEOUT_MS;
+  let lastError: unknown;
+  while (Date.now() < deadline) {
+    const client = new pg.Client(config);
+    try {
+      await client.connect();
+      return client;
+    } catch (err) {
+      lastError = err;
+      await client.end().catch(() => {});
+    }
+    await new Promise(r => setTimeout(r, POLL_MS));
+  }
+  throw new Error(`Postgres not reachable after ${TIMEOUT_MS}ms: ${lastError}`);
+}
+
+export async function setup() {
+  const client = await waitForPostgres();
+  try {
+    await client.query(`
+      DROP TABLE IF EXISTS orders CASCADE;
+      DROP TABLE IF EXISTS users CASCADE;
+
+      CREATE TABLE users (
+        id    SERIAL PRIMARY KEY,
+        name  VARCHAR(100) NOT NULL,
+        age   INT,
+        bio   TEXT
+      );
+
+      CREATE TABLE orders (
+        id         SERIAL PRIMARY KEY,
+        user_id    INT REFERENCES users(id),
+        total      NUMERIC(10,2) NOT NULL,
+        created_at TIMESTAMP DEFAULT NOW()
+      );
+
+      CREATE INDEX idx_orders_user_id ON orders(user_id);
+    `);
+  } finally {
+    await client.end();
+  }
+}
+
+export async function teardown() {
+  const client = await waitForPostgres();
+  try {
+    await client.query(`
+      DROP TABLE IF EXISTS orders CASCADE;
+      DROP TABLE IF EXISTS users CASCADE;
+    `);
+  } finally {
+    await client.end();
+  }
+}

--- a/server/vitest.integration-pg.config.ts
+++ b/server/vitest.integration-pg.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/drivers/*.integration.test.ts'],
+    globalSetup: './src/test-setup/global-setup-postgres.ts',
+    testTimeout: 15000,
+    hookTimeout: 15000,
+    pool: 'forks',
+    poolOptions: { forks: { singleFork: true } },
+  },
+});


### PR DESCRIPTION
## Summary
- Creates `server/src/drivers/postgres.ts` with `PostgresDriver` implementing the `DbDriver` interface (closes #91)

## What's in the driver

| Method | Implementation |
|---|---|
| `escapeIdent()` | Double-quote quoting |
| `query()` | `SET search_path` for schema switching; normalizes pg `rows`/`fields` to `QueryResult`; serializes `Buffer`→hex, `Date`→string |
| `getSchemas()` | `information_schema.schemata` excluding `pg_catalog`, `information_schema`, `pg_toast*` |
| `getSchema()` | `udt_name` for column types; `is_identity`/`nextval(` for auto-increment; `n_live_tup` for row estimates; subquery join for PK detection |
| `getTableDdl()` | Reconstructs DDL from `information_schema.columns` + `table_constraints` + `pg_indexes`; `pg_get_functiondef` for functions; `pg_get_triggerdef` for triggers |

No existing routes are changed — the driver is available but not yet wired up. That happens in the next PR (#92).

## Test plan
- [ ] `npx tsc --noEmit` passes
- [ ] `npm test` (unit suite) passes — 11/11 green

🤖 Generated with [Claude Code](https://claude.com/claude-code)