### PR TITLE
feat: wire all routes to DbDriver abstraction

### DIFF
--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -1,60 +1,40 @@
-import mysql from 'mysql2/promise';
-import type { PoolConnection } from 'mysql2/promise';
 import { resetMcpState } from './mcp-state.js';
+import { MysqlDriver } from './drivers/mysql.js';
+import { PostgresDriver } from './drivers/postgres.js';
+import type { DbDriver, ConnectionConfig } from './drivers/interface.js';
 
-interface ConnectionConfig {
-  host: string;
-  port: number;
-  user: string;
-  password: string;
-  database?: string;
-  ssl?: 'require' | 'verify-full';
-}
-
-let pool: mysql.Pool | null = null;
+let driver: DbDriver | null = null;
 let activeConfig: ConnectionConfig | null = null;
 
+function makeDriver(config: ConnectionConfig): DbDriver {
+  return config.type === 'postgres' ? new PostgresDriver(config) : new MysqlDriver(config);
+}
+
 export async function connect(config: ConnectionConfig): Promise<void> {
-  if (pool) {
-    await pool.end();
-    pool = null;
+  if (driver) {
+    await driver.end();
+    driver = null;
   }
   resetMcpState();
 
-  pool = mysql.createPool({
-    host: config.host,
-    port: config.port,
-    user: config.user,
-    password: config.password,
-    database: config.database || undefined,
-    ssl: config.ssl === 'verify-full' ? { rejectUnauthorized: true }
-       : config.ssl === 'require'     ? { rejectUnauthorized: false }
-       : undefined,
-    waitForConnections: true,
-    connectionLimit: 5,
-    connectTimeout: 10_000,
-  });
-
-  // Verify the connection is reachable
-  const conn = await pool.getConnection();
-  await conn.ping();
-  conn.release();
-
+  const d = makeDriver(config);
+  await d.ping();
+  driver = d;
   activeConfig = config;
 }
 
 export async function disconnect(): Promise<void> {
-  if (pool) {
-    await pool.end();
-    pool = null;
+  if (driver) {
+    await driver.end();
+    driver = null;
     activeConfig = null;
   }
   resetMcpState();
 }
 
-export function getPool(): mysql.Pool {
-  if (!pool) throw new Error('Not connected to any MySQL server.');
-  return pool;
+export function getDriver(): DbDriver {
+  if (!driver) throw new Error('Not connected to any database.');
+  return driver;
 }
 
 export function getActiveConfig(): ConnectionConfig | null {
@@ -62,39 +42,14 @@ export function getActiveConfig(): ConnectionConfig | null {
 }
 
 export function isConnected(): boolean {
-  return pool !== null;
-}
-
-// Acquires a single connection, optionally switches schema, runs fn, then releases.
-// Guarantees USE and the subsequent query land on the same connection.
-export async function withSchema<T>(
-  schema: string | undefined,
-  fn: (conn: PoolConnection) => Promise<T>,
-): Promise<T> {
-  const conn = await getPool().getConnection();
-  try {
-    if (schema) await conn.query(`USE \`${schema.replace(/`/g, '')}\``);
-    return await fn(conn);
-  } finally {
-    conn.release();
-  }
+  return driver !== null;
 }
 
 export async function testConnection(config: ConnectionConfig): Promise<void> {
-  const conn = await mysql.createConnection({
-    host: config.host,
-    port: config.port,
-    user: config.user,
-    password: config.password,
-    database: config.database || undefined,
-    ssl: config.ssl === 'verify-full' ? { rejectUnauthorized: true }
-       : config.ssl === 'require'     ? { rejectUnauthorized: false }
-       : undefined,
-    connectTimeout: 10_000,
-  });
+  const d = makeDriver(config);
   try {
-    await conn.ping();
+    await d.ping();
   } finally {
-    await conn.end();
+    await d.end();
   }
 }

--- a/server/src/drivers/interface.ts
+++ b/server/src/drivers/interface.ts
@@ -57,6 +57,8 @@ export interface DbDriver {
   query(sql: string, params?: unknown[], schema?: string): Promise<QueryResult>;
   getSchemas(): Promise<string[]>;
   getSchema(schema: string): Promise<SchemaInfo>;
+  /** Targeted lookup for a single table — returns null if it doesn't exist. */
+  getTable(schema: string, table: string): Promise<TableInfo | null>;
   getTableDdl(schema: string, table: string, type: 'table' | 'view' | 'procedure' | 'trigger'): Promise<string>;
   /** Return a quoted, escaped identifier (e.g. `name` for MySQL, "name" for Postgres). */
   escapeIdent(s: string): string;

--- a/server/src/drivers/interface.ts
+++ b/server/src/drivers/interface.ts
@@ -60,6 +60,8 @@ export interface DbDriver {
   getTableDdl(schema: string, table: string, type: 'table' | 'view' | 'procedure' | 'trigger'): Promise<string>;
   /** Return a quoted, escaped identifier (e.g. `name` for MySQL, "name" for Postgres). */
   escapeIdent(s: string): string;
+  /** " LIMIT N" for dialects that support it in DML; "" for those that don't (e.g. Postgres). */
+  rowLimitClause(n: number): string;
   ping(): Promise<void>;
   end(): Promise<void>;
 }

--- a/server/src/drivers/mysql.test.ts
+++ b/server/src/drivers/mysql.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockConn = {
+  query: vi.fn(),
+  ping: vi.fn(),
+  release: vi.fn(),
+};
+const mockPool = {
+  getConnection: vi.fn(),
+  query: vi.fn(),
+  end: vi.fn(),
+};
+
+vi.mock('mysql2/promise', () => ({
+  default: { createPool: vi.fn(() => mockPool) },
+}));
+
+import { MysqlDriver } from './mysql.js';
+
+function makeDriver() {
+  return new MysqlDriver({
+    host: 'h', port: 3306, user: 'u', password: 'p', type: 'mysql',
+  });
+}
+
+describe('MysqlDriver.query – connection release', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPool.getConnection.mockResolvedValue(mockConn);
+  });
+
+  it('releases the connection on success', async () => {
+    mockConn.query.mockResolvedValueOnce([[{ id: 1 }], [{ name: 'id' }]]);
+    await makeDriver().query('SELECT 1');
+    expect(mockConn.release).toHaveBeenCalledTimes(1);
+  });
+
+  it('releases the connection when query rejects', async () => {
+    mockConn.query.mockRejectedValueOnce(new Error('boom'));
+    await expect(makeDriver().query('SELECT 1')).rejects.toThrow('boom');
+    expect(mockConn.release).toHaveBeenCalledTimes(1);
+  });
+
+  it('releases the connection when USE schema rejects', async () => {
+    mockConn.query.mockRejectedValueOnce(new Error('unknown db'));
+    await expect(makeDriver().query('SELECT 1', [], 'ghost')).rejects.toThrow('unknown db');
+    expect(mockConn.release).toHaveBeenCalledTimes(1);
+  });
+});

--- a/server/src/drivers/mysql.ts
+++ b/server/src/drivers/mysql.ts
@@ -25,6 +25,10 @@ export class MysqlDriver implements DbDriver {
     return '`' + s.replace(/`/g, '') + '`';
   }
 
+  rowLimitClause(n: number): string {
+    return ` LIMIT ${n}`;
+  }
+
   async ping(): Promise<void> {
     const conn = await this.pool.getConnection();
     try {

--- a/server/src/drivers/mysql.ts
+++ b/server/src/drivers/mysql.ts
@@ -1,6 +1,6 @@
 import mysql from 'mysql2/promise';
 import type { RowDataPacket, FieldPacket, ResultSetHeader } from 'mysql2/promise';
-import type { DbDriver, ConnectionConfig, QueryResult, ColumnMeta, ColumnInfo, SchemaInfo } from './interface.js';
+import type { DbDriver, ConnectionConfig, QueryResult, ColumnMeta, ColumnInfo, SchemaInfo, TableInfo } from './interface.js';
 
 export class MysqlDriver implements DbDriver {
   private pool: mysql.Pool;
@@ -190,6 +190,57 @@ export class MysqlDriver implements DbDriver {
         views: views.map(v => v['name'] as string),
         procedures: procedures.map(p => p['name'] as string),
         triggers: triggers.map(t => t['name'] as string),
+      };
+    } finally {
+      conn.release();
+    }
+  }
+
+  async getTable(schema: string, table: string): Promise<TableInfo | null> {
+    const conn = await this.pool.getConnection();
+    try {
+      const [[tables], [columns]] = await Promise.all([
+        conn.query<RowDataPacket[]>(
+          `SELECT TABLE_NAME AS name, TABLE_ROWS AS row_count, TABLE_COMMENT AS comment
+           FROM information_schema.TABLES
+           WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ? AND TABLE_TYPE = 'BASE TABLE'`,
+          [schema, table],
+        ),
+        conn.query<RowDataPacket[]>(
+          `SELECT COLUMN_NAME AS col, COLUMN_TYPE AS col_type,
+                  DATA_TYPE AS data_type,
+                  IF(COLUMN_KEY = 'PRI', 1, 0) AS is_pk,
+                  IF(IS_NULLABLE = 'YES', 1, 0) AS nullable,
+                  COLUMN_DEFAULT AS col_default,
+                  EXTRA AS extra,
+                  COLUMN_COMMENT AS comment
+           FROM information_schema.COLUMNS
+           WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ?
+           ORDER BY ORDINAL_POSITION`,
+          [schema, table],
+        ),
+      ]);
+
+      if (tables.length === 0) return null;
+      const t = tables[0];
+      const cols: ColumnInfo[] = columns.map(col => {
+        const extra = ((col['extra'] as string) ?? '').toLowerCase();
+        return {
+          name: col['col'] as string,
+          type: col['col_type'] as string,
+          dataType: ((col['data_type'] as string) ?? '').toLowerCase(),
+          pk: Boolean(col['is_pk']),
+          nullable: Boolean(col['nullable']),
+          default: (col['col_default'] as string | null) ?? null,
+          autoIncrement: extra.includes('auto_increment'),
+          comment: (col['comment'] as string) ?? '',
+        };
+      });
+      return {
+        name: t['name'] as string,
+        rows: t['row_count'] as number,
+        comment: (t['comment'] as string) ?? '',
+        columns: cols,
       };
     } finally {
       conn.release();

--- a/server/src/drivers/postgres.test.ts
+++ b/server/src/drivers/postgres.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockClient = {
+  query: vi.fn(),
+  release: vi.fn(),
+};
+
+class MockPool {
+  connect = vi.fn(() => Promise.resolve(mockClient));
+  query = vi.fn();
+  end = vi.fn();
+}
+const mockPoolInstance = new MockPool();
+
+vi.mock('pg', () => ({
+  default: { Pool: vi.fn(() => mockPoolInstance) },
+}));
+
+import { PostgresDriver } from './postgres.js';
+
+function makeDriver() {
+  return new PostgresDriver({
+    host: 'h', port: 5432, user: 'u', password: 'p', type: 'postgres',
+  });
+}
+
+describe('PostgresDriver.query – connection release', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPoolInstance.connect.mockResolvedValue(mockClient);
+  });
+
+  it('releases the client on success', async () => {
+    mockClient.query.mockResolvedValueOnce({ rows: [{ id: 1 }], fields: [{ name: 'id' }], rowCount: 1 });
+    await makeDriver().query('SELECT 1');
+    expect(mockClient.release).toHaveBeenCalledTimes(1);
+  });
+
+  it('releases the client when query rejects', async () => {
+    mockClient.query.mockRejectedValueOnce(new Error('boom'));
+    await expect(makeDriver().query('SELECT 1')).rejects.toThrow('boom');
+    expect(mockClient.release).toHaveBeenCalledTimes(1);
+  });
+
+  it('releases the client when SET search_path rejects', async () => {
+    mockClient.query.mockRejectedValueOnce(new Error('bad schema'));
+    await expect(makeDriver().query('SELECT 1', [], 'ghost')).rejects.toThrow('bad schema');
+    expect(mockClient.release).toHaveBeenCalledTimes(1);
+  });
+
+  it('resets search_path before release when a schema was set', async () => {
+    mockClient.query
+      .mockResolvedValueOnce({}) // SET search_path TO ghost
+      .mockResolvedValueOnce({ rows: [], fields: [], rowCount: 0 }); // user query
+    await makeDriver().query('SELECT 1', [], 'ghost');
+    const calls = mockClient.query.mock.calls.map(c => (typeof c[0] === 'string' ? c[0] : c[0].text));
+    expect(calls).toContain('SET search_path TO DEFAULT');
+    expect(mockClient.release).toHaveBeenCalledTimes(1);
+  });
+
+  it('resets search_path even when the user query rejects', async () => {
+    mockClient.query
+      .mockResolvedValueOnce({}) // SET search_path TO ghost
+      .mockRejectedValueOnce(new Error('boom')); // user query
+    await expect(makeDriver().query('SELECT 1', [], 'ghost')).rejects.toThrow('boom');
+    const calls = mockClient.query.mock.calls.map(c => (typeof c[0] === 'string' ? c[0] : c[0].text));
+    expect(calls).toContain('SET search_path TO DEFAULT');
+    expect(mockClient.release).toHaveBeenCalledTimes(1);
+  });
+});

--- a/server/src/drivers/postgres.ts
+++ b/server/src/drivers/postgres.ts
@@ -1,5 +1,5 @@
 import pg from 'pg';
-import type { DbDriver, ConnectionConfig, QueryResult, ColumnMeta, ColumnInfo, SchemaInfo } from './interface.js';
+import type { DbDriver, ConnectionConfig, QueryResult, ColumnMeta, ColumnInfo, SchemaInfo, TableInfo } from './interface.js';
 
 export class PostgresDriver implements DbDriver {
   private pool: pg.Pool;
@@ -42,12 +42,15 @@ export class PostgresDriver implements DbDriver {
 
   async query(sql: string, params?: unknown[], schema?: string): Promise<QueryResult> {
     const client = await this.pool.connect();
+    let searchPathSet = false;
     try {
       if (schema) {
         await client.query(`SET search_path TO ${this.escapeIdent(schema)}`);
+        searchPathSet = true;
       }
 
-      // Convert MySQL-style ? placeholders to Postgres $N so DML routes stay uniform
+      // Naive ?→$N rewrite: assumes machine-generated SQL when params is non-empty.
+      // User-authored SQL must be passed without params (the rewrite is skipped then).
       let pgSql = sql;
       if (params?.length) {
         let n = 0;
@@ -96,6 +99,11 @@ export class PostgresDriver implements DbDriver {
 
       return { rows: serializedRows, columnMeta };
     } finally {
+      // pg.Pool reuses clients without resetting session state, so search_path
+      // would leak to the next caller on this same client.
+      if (searchPathSet) {
+        try { await client.query('SET search_path TO DEFAULT'); } catch { /* fall through to release */ }
+      }
       client.release();
     }
   }
@@ -196,6 +204,70 @@ export class PostgresDriver implements DbDriver {
         views: viewsRes.rows.map(v => v.name),
         procedures: procsRes.rows.map(p => p.name),
         triggers: triggersRes.rows.map(t => t.name),
+      };
+    } finally {
+      client.release();
+    }
+  }
+
+  async getTable(schema: string, table: string): Promise<TableInfo | null> {
+    const client = await this.pool.connect();
+    try {
+      const tableRes = await client.query<{ name: string; row_count: string }>(
+        `SELECT t.table_name AS name,
+                COALESCE(s.n_live_tup, 0)::text AS row_count
+         FROM information_schema.tables t
+         LEFT JOIN pg_stat_user_tables s
+           ON s.schemaname = t.table_schema AND s.relname = t.table_name
+         WHERE t.table_schema = $1 AND t.table_name = $2 AND t.table_type = 'BASE TABLE'`,
+        [schema, table],
+      );
+      if (tableRes.rows.length === 0) return null;
+
+      const colsRes = await client.query<{
+        col: string; col_type: string; data_type: string;
+        is_pk: string; nullable: string; col_default: string | null; extra: string;
+      }>(
+        `SELECT c.column_name AS col,
+                c.udt_name AS col_type,
+                c.data_type AS data_type,
+                CASE WHEN pk.column_name IS NOT NULL THEN '1' ELSE '0' END AS is_pk,
+                CASE WHEN c.is_nullable = 'YES' THEN '1' ELSE '0' END AS nullable,
+                c.column_default AS col_default,
+                CASE WHEN c.column_default LIKE 'nextval(%' OR c.is_identity = 'YES'
+                     THEN 'auto_increment' ELSE '' END AS extra
+         FROM information_schema.columns c
+         LEFT JOIN (
+           SELECT kcu.table_name, kcu.column_name, kcu.table_schema
+           FROM information_schema.key_column_usage kcu
+           JOIN information_schema.table_constraints tc
+             ON tc.constraint_name = kcu.constraint_name
+             AND tc.table_schema = kcu.table_schema
+             AND tc.table_name = kcu.table_name
+             AND tc.constraint_type = 'PRIMARY KEY'
+           WHERE kcu.table_schema = $1 AND kcu.table_name = $2
+         ) pk ON pk.column_name = c.column_name
+         WHERE c.table_schema = $1 AND c.table_name = $2
+         ORDER BY c.ordinal_position`,
+        [schema, table],
+      );
+
+      const cols: ColumnInfo[] = colsRes.rows.map(r => ({
+        name: r.col,
+        type: r.col_type,
+        dataType: (r.data_type ?? '').toLowerCase(),
+        pk: r.is_pk === '1',
+        nullable: r.nullable === '1',
+        default: r.col_default ?? null,
+        autoIncrement: r.extra.includes('auto_increment'),
+        comment: '',
+      }));
+
+      return {
+        name: tableRes.rows[0].name,
+        rows: Number(tableRes.rows[0].row_count),
+        comment: '',
+        columns: cols,
       };
     } finally {
       client.release();

--- a/server/src/drivers/postgres.ts
+++ b/server/src/drivers/postgres.ts
@@ -23,6 +23,10 @@ export class PostgresDriver implements DbDriver {
     return '"' + s.replace(/"/g, '') + '"';
   }
 
+  rowLimitClause(_n: number): string {
+    return '';
+  }
+
   async ping(): Promise<void> {
     const client = await this.pool.connect();
     try {
@@ -43,7 +47,13 @@ export class PostgresDriver implements DbDriver {
         await client.query(`SET search_path TO ${this.escapeIdent(schema)}`);
       }
 
-      const result = await client.query({ text: sql, values: params?.length ? params : undefined });
+      // Convert MySQL-style ? placeholders to Postgres $N so DML routes stay uniform
+      let pgSql = sql;
+      if (params?.length) {
+        let n = 0;
+        pgSql = sql.replace(/\?/g, () => `$${++n}`);
+      }
+      const result = await client.query({ text: pgSql, values: params?.length ? params : undefined });
 
       // Non-SELECT (INSERT, UPDATE, DELETE, DDL, etc.)
       if (!result.fields || result.fields.length === 0) {

--- a/server/src/mcp.ts
+++ b/server/src/mcp.ts
@@ -1,18 +1,15 @@
 import type { RequestHandler } from 'express';
-import type { RowDataPacket, FieldPacket } from 'mysql2/promise';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import { z } from 'zod';
-import { getPool, getActiveConfig, isConnected, withSchema } from './db.js';
+import { getDriver, getActiveConfig, isConnected } from './db.js';
 import { isMcpWritesAllowed } from './mcp-state.js';
 
 const DEFAULT_ROW_LIMIT = 100;
 const MAX_ROW_LIMIT = 10_000;
 
-// Matches the leading keyword of a statement, skipping whitespace and /* */ comments.
 const READ_KEYWORDS = new Set(['SELECT', 'SHOW', 'DESCRIBE', 'DESC', 'EXPLAIN', 'WITH']);
 const WRITE_KEYWORDS = new Set(['INSERT', 'UPDATE', 'DELETE', 'REPLACE']);
-// Everything else (CREATE, DROP, ALTER, TRUNCATE, RENAME, GRANT, REVOKE, SET, CALL, ...) is blocked in v1.
 
 function firstKeyword(sql: string): string {
   const stripped = sql.replace(/\/\*[\s\S]*?\*\//g, '').replace(/--.*$/gm, '').trimStart();
@@ -20,33 +17,12 @@ function firstKeyword(sql: string): string {
   return match ? match[1].toUpperCase() : '';
 }
 
-function serializeValue(val: unknown): unknown {
-  if (val === null || val === undefined) return null;
-  if (Buffer.isBuffer(val)) return val.toString('hex');
-  if (val instanceof Date) return val.toISOString().replace('T', ' ').replace(/\.\d{3}Z$/, '');
-  if (typeof val === 'bigint') return val.toString();
-  return val;
-}
-
-function serializeRows(rows: RowDataPacket[], columns: string[]): Record<string, unknown>[] {
-  return rows.map(row => {
-    const out: Record<string, unknown> = {};
-    for (const col of columns) out[col] = serializeValue(row[col]);
-    return out;
-  });
-}
-
 function toolError(message: string) {
-  return {
-    isError: true,
-    content: [{ type: 'text' as const, text: message }],
-  };
+  return { isError: true, content: [{ type: 'text' as const, text: message }] };
 }
 
 function toolJson(value: unknown) {
-  return {
-    content: [{ type: 'text' as const, text: JSON.stringify(value, null, 2) }],
-  };
+  return { content: [{ type: 'text' as const, text: JSON.stringify(value, null, 2) }] };
 }
 
 function requireConnection(): string | null {
@@ -83,33 +59,22 @@ export function buildMcpServer(): McpServer {
       if (err) return toolError(err);
 
       try {
-        const pool = getPool();
+        const driver = getDriver();
 
         if (!schema) {
-          const [rows] = await pool.query<RowDataPacket[]>(
-            `SELECT SCHEMA_NAME AS name FROM information_schema.SCHEMATA
-             WHERE SCHEMA_NAME NOT IN ('information_schema','performance_schema','mysql','sys')
-             ORDER BY SCHEMA_NAME`,
-          );
-          return toolJson({ schemas: rows.map(r => r['name']) });
+          const schemas = await driver.getSchemas();
+          return toolJson({ schemas });
         }
 
-        const [tables] = await pool.query<RowDataPacket[]>(
-          `SELECT TABLE_NAME AS name, TABLE_ROWS AS approx_rows, TABLE_COMMENT AS comment
-           FROM information_schema.TABLES
-           WHERE TABLE_SCHEMA = ? AND TABLE_TYPE = 'BASE TABLE'
-           ORDER BY TABLE_NAME`,
-          [schema],
-        );
-        const [views] = await pool.query<RowDataPacket[]>(
-          `SELECT TABLE_NAME AS name FROM information_schema.VIEWS
-           WHERE TABLE_SCHEMA = ? ORDER BY TABLE_NAME`,
-          [schema],
-        );
+        const info = await driver.getSchema(schema);
         return toolJson({
           schema,
-          tables: tables.map(t => ({ name: t['name'], approxRows: t['approx_rows'], comment: t['comment'] ?? '' })),
-          views: views.map(v => v['name']),
+          tables: info.tables.map(t => ({
+            name: t.name,
+            approxRows: t.rows,
+            comment: t.comment,
+          })),
+          views: info.views,
         });
       } catch (e) {
         return toolError(e instanceof Error ? e.message : String(e));
@@ -131,36 +96,12 @@ export function buildMcpServer(): McpServer {
       if (err) return toolError(err);
 
       try {
-        const pool = getPool();
-        const [columns] = await pool.query<RowDataPacket[]>(
-          `SELECT COLUMN_NAME AS name, COLUMN_TYPE AS type, DATA_TYPE AS dataType,
-                  IF(COLUMN_KEY = 'PRI', 1, 0) AS isPk,
-                  IF(IS_NULLABLE = 'YES', 1, 0) AS nullable,
-                  COLUMN_DEFAULT AS columnDefault,
-                  EXTRA AS extra,
-                  COLUMN_COMMENT AS comment
-           FROM information_schema.COLUMNS
-           WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ?
-           ORDER BY ORDINAL_POSITION`,
-          [schema, table],
-        );
-        if (columns.length === 0) {
-          return toolError(`Table \`${schema}\`.\`${table}\` not found.`);
+        const info = await getDriver().getSchema(schema);
+        const tableInfo = info.tables.find(t => t.name === table);
+        if (!tableInfo) {
+          return toolError(`Table "${schema}"."${table}" not found.`);
         }
-        return toolJson({
-          schema,
-          table,
-          columns: columns.map(c => ({
-            name: c['name'],
-            type: c['type'],
-            dataType: c['dataType'],
-            pk: Boolean(c['isPk']),
-            nullable: Boolean(c['nullable']),
-            default: c['columnDefault'],
-            autoIncrement: String(c['extra'] ?? '').toLowerCase().includes('auto_increment'),
-            comment: c['comment'] ?? '',
-          })),
-        });
+        return toolJson({ schema, table, columns: tableInfo.columns });
       } catch (e) {
         return toolError(e instanceof Error ? e.message : String(e));
       }
@@ -175,9 +116,9 @@ export function buildMcpServer(): McpServer {
         `Results are capped at ${DEFAULT_ROW_LIMIT} rows by default; pass "limit" (up to ${MAX_ROW_LIMIT}) to change.`,
       inputSchema: {
         sql: z.string().min(1).describe('Read-only SQL statement.'),
-        schema: z.string().optional().describe('Schema to USE before the query.'),
+        schema: z.string().optional().describe('Schema to switch to before the query.'),
         limit: z.number().int().positive().max(MAX_ROW_LIMIT).optional()
-          .describe(`Max rows returned to the caller (default ${DEFAULT_ROW_LIMIT}, max ${MAX_ROW_LIMIT}).`),
+          .describe(`Max rows returned (default ${DEFAULT_ROW_LIMIT}, max ${MAX_ROW_LIMIT}).`),
       },
     },
     async ({ sql, schema, limit }) => {
@@ -194,27 +135,21 @@ export function buildMcpServer(): McpServer {
 
       const cap = limit ?? DEFAULT_ROW_LIMIT;
       try {
-        return await withSchema(schema, async (conn) => {
-          const start = Date.now();
-          const [rows, fields]: [RowDataPacket[], FieldPacket[]] = await conn.query(sql) as [RowDataPacket[], FieldPacket[]];
-          const executionTime = Date.now() - start;
+        const start = Date.now();
+        const result = await getDriver().query(sql, [], schema);
+        const executionTime = Date.now() - start;
 
-          if (!Array.isArray(rows)) {
-            return toolJson({ columns: [], rows: [], executionTime });
-          }
-
-          const columns = fields.map(f => f.name);
-          const totalRows = rows.length;
-          const capped = rows.slice(0, cap);
-          return toolJson({
-            columns,
-            rows: serializeRows(capped, columns),
-            rowCount: capped.length,
-            totalRows,
-            truncated: totalRows > capped.length,
-            limitApplied: cap,
-            executionTime,
-          });
+        const columns = result.columnMeta.map(c => c.name);
+        const totalRows = result.rows.length;
+        const capped = result.rows.slice(0, cap);
+        return toolJson({
+          columns,
+          rows: capped,
+          rowCount: capped.length,
+          totalRows,
+          truncated: totalRows > capped.length,
+          limitApplied: cap,
+          executionTime,
         });
       } catch (e) {
         return toolError(e instanceof Error ? e.message : String(e));
@@ -231,7 +166,7 @@ export function buildMcpServer(): McpServer {
         'DDL (CREATE/DROP/ALTER/TRUNCATE) is not supported.',
       inputSchema: {
         sql: z.string().min(1).describe('INSERT / UPDATE / DELETE / REPLACE statement.'),
-        schema: z.string().optional().describe('Schema to USE before the statement.'),
+        schema: z.string().optional().describe('Schema to switch to before the statement.'),
       },
     },
     async ({ sql, schema }) => {
@@ -255,16 +190,13 @@ export function buildMcpServer(): McpServer {
       }
 
       try {
-        return await withSchema(schema, async (conn) => {
-          const start = Date.now();
-          const [result] = await conn.query(sql) as unknown as [{ affectedRows?: number; insertId?: number; changedRows?: number }];
-          const executionTime = Date.now() - start;
-          return toolJson({
-            affectedRows: result.affectedRows ?? 0,
-            changedRows: result.changedRows ?? 0,
-            insertId: result.insertId ?? null,
-            executionTime,
-          });
+        const start = Date.now();
+        const result = await getDriver().query(sql, [], schema);
+        const executionTime = Date.now() - start;
+        return toolJson({
+          affectedRows: result.affectedRows ?? 0,
+          insertId: result.insertId ?? null,
+          executionTime,
         });
       } catch (e) {
         return toolError(e instanceof Error ? e.message : String(e));

--- a/server/src/mcp.ts
+++ b/server/src/mcp.ts
@@ -96,8 +96,7 @@ export function buildMcpServer(): McpServer {
       if (err) return toolError(err);
 
       try {
-        const info = await getDriver().getSchema(schema);
-        const tableInfo = info.tables.find(t => t.name === table);
+        const tableInfo = await getDriver().getTable(schema, table);
         if (!tableInfo) {
           return toolError(`Table "${schema}"."${table}" not found.`);
         }

--- a/server/src/routes/connect.ts
+++ b/server/src/routes/connect.ts
@@ -58,31 +58,46 @@ function friendlyConnectError(err: unknown, host: string, port: number, type: Db
 
 export { friendlyConnectError };
 
-export const postConnect: RequestHandler = async (req, res) => {
-  const { host, port, user, password, database, ssl, type } = req.body as {
-    host: string;
-    port?: number;
-    user: string;
-    password: string;
-    database?: string;
-    ssl?: 'require' | 'verify-full';
-    type?: DbType;
-  };
+type ConnectBody = {
+  host?: string;
+  port?: number;
+  user?: string;
+  password?: string;
+  database?: string;
+  ssl?: 'require' | 'verify-full';
+  type?: unknown;
+};
+
+function parseConnectBody(body: ConnectBody): { config: ConnectionConfig } | { error: string } {
+  const { host, port, user, password, database, ssl, type } = body;
 
   if (!host || !user) {
-    res.status(400).json({ error: 'host and user are required.' });
-    return;
+    return { error: 'host and user are required.' };
+  }
+  if (type !== undefined && type !== 'mysql' && type !== 'postgres') {
+    return { error: `Unsupported db type: ${String(type)}` };
   }
 
-  const dbType: DbType = type === 'postgres' ? 'postgres' : 'mysql';
+  const dbType: DbType = (type as DbType | undefined) ?? 'mysql';
   const effectivePort = Number(port) || defaultPort(dbType);
-  const config: ConnectionConfig = { host, port: effectivePort, user, password, database, ssl, type: dbType };
+  return {
+    config: { host, port: effectivePort, user, password: password ?? '', database, ssl, type: dbType },
+  };
+}
+
+export const postConnect: RequestHandler = async (req, res) => {
+  const parsed = parseConnectBody(req.body as ConnectBody);
+  if ('error' in parsed) {
+    res.status(400).json({ error: parsed.error });
+    return;
+  }
+  const { config } = parsed;
 
   try {
     await connect(config);
-    res.json({ ok: true, connectionName: `${user}@${host}:${effectivePort}` });
+    res.json({ ok: true, connectionName: `${config.user}@${config.host}:${config.port}` });
   } catch (err) {
-    res.status(400).json({ error: friendlyConnectError(err, host, effectivePort, dbType) });
+    res.status(400).json({ error: friendlyConnectError(err, config.host, config.port, config.type) });
   }
 };
 
@@ -92,30 +107,18 @@ export const deleteConnect: RequestHandler = async (_req, res) => {
 };
 
 export const postTestConnect: RequestHandler = async (req, res) => {
-  const { host, port, user, password, database, ssl, type } = req.body as {
-    host: string;
-    port?: number;
-    user: string;
-    password: string;
-    database?: string;
-    ssl?: 'require' | 'verify-full';
-    type?: DbType;
-  };
-
-  if (!host || !user) {
-    res.status(400).json({ error: 'host and user are required.' });
+  const parsed = parseConnectBody(req.body as ConnectBody);
+  if ('error' in parsed) {
+    res.status(400).json({ error: parsed.error });
     return;
   }
-
-  const dbType: DbType = type === 'postgres' ? 'postgres' : 'mysql';
-  const effectivePort = Number(port) || defaultPort(dbType);
-  const config: ConnectionConfig = { host, port: effectivePort, user, password, database, ssl, type: dbType };
+  const { config } = parsed;
 
   try {
     await testConnection(config);
     res.json({ ok: true });
   } catch (err) {
-    res.status(400).json({ error: friendlyConnectError(err, host, effectivePort, dbType) });
+    res.status(400).json({ error: friendlyConnectError(err, config.host, config.port, config.type) });
   }
 };
 

--- a/server/src/routes/connect.ts
+++ b/server/src/routes/connect.ts
@@ -1,7 +1,14 @@
 import type { RequestHandler } from 'express';
+import type { ConnectionConfig } from '../drivers/interface.js';
 import { connect, disconnect, isConnected, getActiveConfig, testConnection } from '../db.js';
 
-interface MySQLError {
+type DbType = 'mysql' | 'postgres';
+
+function defaultPort(type: DbType): number {
+  return type === 'postgres' ? 5432 : 3306;
+}
+
+interface ConnectError {
   message?: string;
   code?: string;
   errno?: number;
@@ -10,25 +17,34 @@ interface MySQLError {
   sqlMessage?: string;
 }
 
-function friendlyConnectError(err: unknown, host: string, port: number): string {
-  const e = err as MySQLError;
+function friendlyConnectError(err: unknown, host: string, port: number, type: DbType): string {
+  const e = err as ConnectError;
   const code = e?.code;
   const where = `${host}:${port}`;
+
   const byCode: Record<string, string> = {
-    ECONNREFUSED:            `Couldn't reach MySQL at ${where}. Make sure the server is running and the port is open.`,
-    ETIMEDOUT:               `Timed out connecting to ${where}. Check the host, port, and any firewall or VPN between you and the server.`,
-    ENOTFOUND:               `Unknown host '${host}'. Check the hostname for typos.`,
-    EHOSTUNREACH:            `Host '${host}' is unreachable. Check your network, VPN, or firewall rules.`,
-    ENETUNREACH:             `Network is unreachable. Check your internet connection or VPN.`,
-    ECONNRESET:              `Connection to ${where} was reset. The server may have dropped the connection — verify it's a MySQL server and try again.`,
-    EADDRNOTAVAIL:           `Can't bind a local address to reach ${where}. Check your network configuration.`,
-    ER_ACCESS_DENIED_ERROR:  `Access denied. Check the username and password.`,
-    ER_DBACCESS_DENIED_ERROR:`The user doesn't have access to the selected default schema.`,
-    ER_BAD_DB_ERROR:         `The default schema doesn't exist on this server.`,
-    ER_HOST_NOT_PRIVILEGED:  `This host isn't allowed to connect to the MySQL server.`,
-    ER_NOT_SUPPORTED_AUTH_MODE: `Authentication mode isn't supported by your MySQL client. The server may require a different auth plugin (e.g. caching_sha2_password).`,
-    HANDSHAKE_NO_SSL_SUPPORT:`The MySQL server doesn't support SSL/TLS. Turn off "Use SSL / TLS" and try again.`,
-    PROTOCOL_CONNECTION_LOST:`Lost connection to the MySQL server during the handshake.`,
+    // Network errors (shared)
+    ECONNREFUSED:  `Couldn't reach the database at ${where}. Make sure the server is running and the port is open.`,
+    ETIMEDOUT:     `Timed out connecting to ${where}. Check the host, port, and any firewall or VPN between you and the server.`,
+    ENOTFOUND:     `Unknown host '${host}'. Check the hostname for typos.`,
+    EHOSTUNREACH:  `Host '${host}' is unreachable. Check your network, VPN, or firewall rules.`,
+    ENETUNREACH:   `Network is unreachable. Check your internet connection or VPN.`,
+    ECONNRESET:    `Connection to ${where} was reset. The server may have dropped the connection — verify it's a database server and try again.`,
+    EADDRNOTAVAIL: `Can't bind a local address to reach ${where}. Check your network configuration.`,
+    // MySQL error codes
+    ER_ACCESS_DENIED_ERROR:     `Access denied. Check the username and password.`,
+    ER_DBACCESS_DENIED_ERROR:   `The user doesn't have access to the selected default schema.`,
+    ER_BAD_DB_ERROR:            `The default schema doesn't exist on this server.`,
+    ER_HOST_NOT_PRIVILEGED:     `This host isn't allowed to connect to the server.`,
+    ER_NOT_SUPPORTED_AUTH_MODE: `Authentication mode isn't supported. The server may require a different auth plugin.`,
+    HANDSHAKE_NO_SSL_SUPPORT:   `The server doesn't support SSL/TLS. Turn off "Use SSL / TLS" and try again.`,
+    PROTOCOL_CONNECTION_LOST:   `Lost connection to the server during the handshake.`,
+    // Postgres error codes
+    '28P01': `Access denied. Check the username and password.`,
+    '3D000': `The default schema (database) doesn't exist on this server.`,
+    '42501': `The user doesn't have permission to connect.`,
+    '28000': `Authentication failed. Check the username and password.`,
+    '08006': `Connection to the server failed.`,
   };
 
   const friendly = code && byCode[code];
@@ -37,19 +53,20 @@ function friendlyConnectError(err: unknown, host: string, port: number): string 
   if (raw && code) return `${raw} (${code})`;
   if (raw) return raw;
   if (code) return `(${code})`;
-  return 'Unknown connection error.';
+  return `Unknown connection error connecting to ${type === 'postgres' ? 'PostgreSQL' : 'MySQL'}.`;
 }
 
 export { friendlyConnectError };
 
 export const postConnect: RequestHandler = async (req, res) => {
-  const { host, port, user, password, database, ssl } = req.body as {
+  const { host, port, user, password, database, ssl, type } = req.body as {
     host: string;
-    port: number;
+    port?: number;
     user: string;
     password: string;
     database?: string;
     ssl?: 'require' | 'verify-full';
+    type?: DbType;
   };
 
   if (!host || !user) {
@@ -57,12 +74,15 @@ export const postConnect: RequestHandler = async (req, res) => {
     return;
   }
 
+  const dbType: DbType = type === 'postgres' ? 'postgres' : 'mysql';
+  const effectivePort = Number(port) || defaultPort(dbType);
+  const config: ConnectionConfig = { host, port: effectivePort, user, password, database, ssl, type: dbType };
+
   try {
-    const effectivePort = Number(port) || 3306;
-    await connect({ host, port: effectivePort, user, password, database, ssl });
+    await connect(config);
     res.json({ ok: true, connectionName: `${user}@${host}:${effectivePort}` });
   } catch (err) {
-    res.status(400).json({ error: friendlyConnectError(err, host, Number(port) || 3306) });
+    res.status(400).json({ error: friendlyConnectError(err, host, effectivePort, dbType) });
   }
 };
 
@@ -72,13 +92,14 @@ export const deleteConnect: RequestHandler = async (_req, res) => {
 };
 
 export const postTestConnect: RequestHandler = async (req, res) => {
-  const { host, port, user, password, database, ssl } = req.body as {
+  const { host, port, user, password, database, ssl, type } = req.body as {
     host: string;
-    port: number;
+    port?: number;
     user: string;
     password: string;
     database?: string;
     ssl?: 'require' | 'verify-full';
+    type?: DbType;
   };
 
   if (!host || !user) {
@@ -86,12 +107,15 @@ export const postTestConnect: RequestHandler = async (req, res) => {
     return;
   }
 
+  const dbType: DbType = type === 'postgres' ? 'postgres' : 'mysql';
+  const effectivePort = Number(port) || defaultPort(dbType);
+  const config: ConnectionConfig = { host, port: effectivePort, user, password, database, ssl, type: dbType };
+
   try {
-    const effectivePort = Number(port) || 3306;
-    await testConnection({ host, port: effectivePort, user, password, database, ssl });
+    await testConnection(config);
     res.json({ ok: true });
   } catch (err) {
-    res.status(400).json({ error: friendlyConnectError(err, host, Number(port) || 3306) });
+    res.status(400).json({ error: friendlyConnectError(err, host, effectivePort, dbType) });
   }
 };
 

--- a/server/src/routes/crud.integration.test.ts
+++ b/server/src/routes/crud.integration.test.ts
@@ -13,6 +13,7 @@ const DB_CONFIG = {
   port: Number(process.env['MYSQL_PORT'] ?? 3307),
   user: process.env['MYSQL_USER'] ?? 'root',
   password: process.env['MYSQL_PASSWORD'] ?? 'root',
+  type: 'mysql' as const,
 };
 
 function makeApp() {

--- a/server/src/routes/deleteRow.ts
+++ b/server/src/routes/deleteRow.ts
@@ -1,13 +1,10 @@
 import type { RequestHandler } from 'express';
-import type { ResultSetHeader } from 'mysql2/promise';
-import { getPool } from '../db.js';
+import { getDriver } from '../db.js';
 
 interface WhereClause {
   column: string;
   value: string | number | null;
 }
-
-const escapeIdent = (s: string) => '`' + s.replace(/`/g, '') + '`';
 
 export const postDeleteRow: RequestHandler = async (req, res) => {
   const { schema, table, where } = req.body as {
@@ -29,17 +26,17 @@ export const postDeleteRow: RequestHandler = async (req, res) => {
     return;
   }
 
+  const driver = getDriver();
   const qualifiedTable = schema
-    ? `${escapeIdent(schema)}.${escapeIdent(table)}`
-    : escapeIdent(table);
+    ? `${driver.escapeIdent(schema)}.${driver.escapeIdent(table)}`
+    : driver.escapeIdent(table);
 
-  const whereClause = where.map(w => `${escapeIdent(w.column)} = ?`).join(' AND ');
-  const sql = `DELETE FROM ${qualifiedTable} WHERE ${whereClause} LIMIT 1`;
+  const whereClause = where.map(w => `${driver.escapeIdent(w.column)} = ?`).join(' AND ');
+  const sql = `DELETE FROM ${qualifiedTable} WHERE ${whereClause}${driver.rowLimitClause(1)}`;
   const values = where.map(w => w.value);
 
   try {
-    const pool = getPool();
-    const [result] = await pool.query(sql, values) as [ResultSetHeader, unknown];
+    const result = await driver.query(sql, values);
     res.json({ affectedRows: result.affectedRows ?? 0, sql });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);

--- a/server/src/routes/dropTable.ts
+++ b/server/src/routes/dropTable.ts
@@ -1,7 +1,5 @@
 import type { RequestHandler } from 'express';
-import { getPool } from '../db.js';
-
-const escapeIdent = (s: string) => '`' + s.replace(/`/g, '') + '`';
+import { getDriver } from '../db.js';
 
 export const postDropTable: RequestHandler = async (req, res) => {
   const { schema, table } = req.body as { schema?: string; table?: string };
@@ -9,13 +7,15 @@ export const postDropTable: RequestHandler = async (req, res) => {
     res.status(400).json({ error: 'table is required.' });
     return;
   }
+
+  const driver = getDriver();
   const qualifiedTable = schema
-    ? `${escapeIdent(schema)}.${escapeIdent(table)}`
-    : escapeIdent(table);
+    ? `${driver.escapeIdent(schema)}.${driver.escapeIdent(table)}`
+    : driver.escapeIdent(table);
   const sql = `DROP TABLE ${qualifiedTable}`;
+
   try {
-    const pool = getPool();
-    await pool.query(sql);
+    await driver.query(sql);
     res.json({ ok: true, sql });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);

--- a/server/src/routes/insertRow.ts
+++ b/server/src/routes/insertRow.ts
@@ -1,8 +1,5 @@
 import type { RequestHandler } from 'express';
-import type { ResultSetHeader } from 'mysql2/promise';
-import { getPool } from '../db.js';
-
-const escapeIdent = (s: string) => '`' + s.replace(/`/g, '') + '`';
+import { getDriver } from '../db.js';
 
 export const postInsertRow: RequestHandler = async (req, res) => {
   const { schema, table, values } = req.body as {
@@ -20,19 +17,19 @@ export const postInsertRow: RequestHandler = async (req, res) => {
     return;
   }
 
+  const driver = getDriver();
   const cols = Object.keys(values);
   const qualifiedTable = schema
-    ? `${escapeIdent(schema)}.${escapeIdent(table)}`
-    : escapeIdent(table);
+    ? `${driver.escapeIdent(schema)}.${driver.escapeIdent(table)}`
+    : driver.escapeIdent(table);
 
-  const colList = cols.map(escapeIdent).join(', ');
+  const colList = cols.map(c => driver.escapeIdent(c)).join(', ');
   const placeholders = cols.map(() => '?').join(', ');
   const sql = `INSERT INTO ${qualifiedTable} (${colList}) VALUES (${placeholders})`;
   const params = cols.map(c => values[c]);
 
   try {
-    const pool = getPool();
-    const [result] = await pool.query(sql, params) as [ResultSetHeader, unknown];
+    const result = await driver.query(sql, params);
     res.json({
       affectedRows: result.affectedRows ?? 0,
       insertId: result.insertId ?? null,

--- a/server/src/routes/query.test.ts
+++ b/server/src/routes/query.test.ts
@@ -2,30 +2,15 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import request from 'supertest';
 import express from 'express';
 
-vi.mock('../db.js', () => {
-  const getPool = vi.fn();
-  return {
-    getPool,
-    // Mirror the real withSchema behaviour so connection-pinning assertions still pass.
-    withSchema: vi.fn(async (schema: string | undefined, fn: (conn: any) => Promise<any>) => {
-      const pool = getPool();
-      const conn = await pool.getConnection();
-      try {
-        if (schema) await conn.query(`USE \`${schema.replace(/`/g, '')}\``);
-        return await fn(conn);
-      } finally {
-        conn.release();
-      }
-    }),
-  };
-});
+vi.mock('../db.js', () => ({
+  getDriver: vi.fn(),
+}));
 
-import { getPool } from '../db.js';
+import { getDriver } from '../db.js';
 import { postQuery } from './query.js';
 
-// Minimal FieldPacket shape that postQuery reads from
-function makeField(name: string, flags = 0, columnType = 253) {
-  return { name, orgName: name, table: 't', orgTable: 't', flags, columnType, type: columnType };
+function makeMeta(name: string, { pk = false, unique = false, notNull = false } = {}) {
+  return { name, orgName: name, table: 't', orgTable: 't', pk, unique, notNull, mysqlType: 253 };
 }
 
 function makeApp() {
@@ -35,69 +20,73 @@ function makeApp() {
   return app;
 }
 
-describe('postQuery – connection pinning', () => {
+describe('postQuery – driver delegation', () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it('issues USE and SELECT on the same connection when schema is provided', async () => {
-    const mockConn = {
-      query: vi.fn()
-        .mockResolvedValueOnce([[], []])                          // USE `mydb`
-        .mockResolvedValueOnce([                                  // SELECT * FROM users
-          [{ id: 1, name: 'Alice' }],
-          [makeField('id', /* PRI_KEY */ 2), makeField('name')],
-        ]),
-      release: vi.fn(),
+  it('passes schema to driver.query() and returns rows + columnMeta', async () => {
+    const mockDriver = {
+      query: vi.fn().mockResolvedValue({
+        rows: [{ id: 1, name: 'Alice' }],
+        columnMeta: [makeMeta('id', { pk: true }), makeMeta('name')],
+      }),
     };
-    vi.mocked(getPool).mockReturnValue({ getConnection: vi.fn().mockResolvedValue(mockConn) } as any);
+    vi.mocked(getDriver).mockReturnValue(mockDriver as any);
 
     const res = await request(makeApp())
       .post('/api/query')
       .send({ sql: 'SELECT * FROM users', schema: 'mydb' });
 
     expect(res.status).toBe(200);
-
-    // Both calls landed on the same mock connection object — not on pool directly
-    expect(mockConn.query).toHaveBeenCalledTimes(2);
-    expect(mockConn.query).toHaveBeenNthCalledWith(1, 'USE `mydb`');
-    expect(mockConn.query).toHaveBeenNthCalledWith(2, 'SELECT * FROM users');
-
-    // Connection is always returned to the pool
-    expect(mockConn.release).toHaveBeenCalledTimes(1);
-
-    // Spot-check response shape
+    expect(mockDriver.query).toHaveBeenCalledWith('SELECT * FROM users', [], 'mydb');
     expect(res.body.columns).toEqual(['id', 'name']);
     expect(res.body.rows).toEqual([{ id: 1, name: 'Alice' }]);
     expect(res.body.columnMeta[0]).toMatchObject({ name: 'id', pk: true });
+    expect(res.body).toHaveProperty('executionTime');
   });
 
-  it('skips USE and runs the query directly when no schema is provided', async () => {
-    const mockConn = {
-      query: vi.fn().mockResolvedValueOnce([
-        [{ one: 1 }],
-        [makeField('one')],
-      ]),
-      release: vi.fn(),
+  it('passes undefined schema when no schema is provided', async () => {
+    const mockDriver = {
+      query: vi.fn().mockResolvedValue({
+        rows: [{ one: 1 }],
+        columnMeta: [makeMeta('one')],
+      }),
     };
-    vi.mocked(getPool).mockReturnValue({ getConnection: vi.fn().mockResolvedValue(mockConn) } as any);
+    vi.mocked(getDriver).mockReturnValue(mockDriver as any);
 
     const res = await request(makeApp())
       .post('/api/query')
       .send({ sql: 'SELECT 1 AS one' });
 
     expect(res.status).toBe(200);
-    expect(mockConn.query).toHaveBeenCalledTimes(1);
-    expect(mockConn.query).toHaveBeenCalledWith('SELECT 1 AS one');
-    expect(mockConn.release).toHaveBeenCalledTimes(1);
+    expect(mockDriver.query).toHaveBeenCalledWith('SELECT 1 AS one', [], undefined);
   });
 
-  it('releases the connection even when the query throws', async () => {
-    const mockConn = {
-      query: vi.fn()
-        .mockResolvedValueOnce([[], []])  // USE succeeds
-        .mockRejectedValueOnce(new Error("Table 'mydb.ghost' doesn't exist")),
-      release: vi.fn(),
+  it('returns affectedRows and insertId for DML (empty columnMeta)', async () => {
+    const mockDriver = {
+      query: vi.fn().mockResolvedValue({
+        rows: [],
+        columnMeta: [],
+        affectedRows: 3,
+        insertId: 0,
+      }),
     };
-    vi.mocked(getPool).mockReturnValue({ getConnection: vi.fn().mockResolvedValue(mockConn) } as any);
+    vi.mocked(getDriver).mockReturnValue(mockDriver as any);
+
+    const res = await request(makeApp())
+      .post('/api/query')
+      .send({ sql: "UPDATE users SET active = 0 WHERE role = 'guest'" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.columns).toEqual([]);
+    expect(res.body.rows).toEqual([]);
+    expect(res.body.affectedRows).toBe(3);
+  });
+
+  it('returns 400 when driver.query() throws', async () => {
+    const mockDriver = {
+      query: vi.fn().mockRejectedValue(new Error("Table 'mydb.ghost' doesn't exist")),
+    };
+    vi.mocked(getDriver).mockReturnValue(mockDriver as any);
 
     const res = await request(makeApp())
       .post('/api/query')
@@ -105,23 +94,6 @@ describe('postQuery – connection pinning', () => {
 
     expect(res.status).toBe(400);
     expect(res.body.error).toContain('ghost');
-    expect(mockConn.release).toHaveBeenCalledTimes(1);
-  });
-
-  it('releases the connection even when USE throws', async () => {
-    const mockConn = {
-      query: vi.fn().mockRejectedValueOnce(new Error("Unknown database 'noexist'")),
-      release: vi.fn(),
-    };
-    vi.mocked(getPool).mockReturnValue({ getConnection: vi.fn().mockResolvedValue(mockConn) } as any);
-
-    const res = await request(makeApp())
-      .post('/api/query')
-      .send({ sql: 'SELECT 1', schema: 'noexist' });
-
-    expect(res.status).toBe(400);
-    expect(res.body.error).toContain('noexist');
-    expect(mockConn.release).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -141,89 +113,26 @@ describe('postQuery – input validation', () => {
   });
 });
 
-describe('postQuery – response serialization', () => {
+describe('postQuery – row serialization passthrough', () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it('serializes Buffer columns as hex strings', async () => {
-    const mockConn = {
-      query: vi.fn().mockResolvedValueOnce([
-        [{ hash: Buffer.from('deadbeef', 'hex') }],
-        [makeField('hash')],
-      ]),
-      release: vi.fn(),
+  it('passes driver-serialized rows straight through to the response', async () => {
+    const mockDriver = {
+      query: vi.fn().mockResolvedValue({
+        rows: [{ hash: 'deadbeef', created_at: '2024-06-15 12:34:56', big: '9007199254740993', val: null }],
+        columnMeta: [makeMeta('hash'), makeMeta('created_at'), makeMeta('big'), makeMeta('val')],
+      }),
     };
-    vi.mocked(getPool).mockReturnValue({ getConnection: vi.fn().mockResolvedValue(mockConn) } as any);
-
-    const res = await request(makeApp()).post('/api/query').send({ sql: 'SELECT hash FROM t' });
-
-    expect(res.status).toBe(200);
-    expect(res.body.rows[0].hash).toBe('deadbeef');
-  });
-
-  it('serializes Date columns as ISO-style strings without milliseconds', async () => {
-    const mockConn = {
-      query: vi.fn().mockResolvedValueOnce([
-        [{ created_at: new Date('2024-06-15T12:34:56.000Z') }],
-        [makeField('created_at')],
-      ]),
-      release: vi.fn(),
-    };
-    vi.mocked(getPool).mockReturnValue({ getConnection: vi.fn().mockResolvedValue(mockConn) } as any);
-
-    const res = await request(makeApp()).post('/api/query').send({ sql: 'SELECT created_at FROM t' });
-
-    expect(res.status).toBe(200);
-    expect(res.body.rows[0].created_at).toBe('2024-06-15 12:34:56');
-  });
-
-  it('serializes BigInt columns as strings', async () => {
-    const mockConn = {
-      query: vi.fn().mockResolvedValueOnce([
-        [{ big: BigInt('9007199254740993') }],
-        [makeField('big')],
-      ]),
-      release: vi.fn(),
-    };
-    vi.mocked(getPool).mockReturnValue({ getConnection: vi.fn().mockResolvedValue(mockConn) } as any);
-
-    const res = await request(makeApp()).post('/api/query').send({ sql: 'SELECT big FROM t' });
-
-    expect(res.status).toBe(200);
-    expect(res.body.rows[0].big).toBe('9007199254740993');
-  });
-
-  it('serializes NULL values as null', async () => {
-    const mockConn = {
-      query: vi.fn().mockResolvedValueOnce([
-        [{ val: null }],
-        [makeField('val')],
-      ]),
-      release: vi.fn(),
-    };
-    vi.mocked(getPool).mockReturnValue({ getConnection: vi.fn().mockResolvedValue(mockConn) } as any);
-
-    const res = await request(makeApp()).post('/api/query').send({ sql: 'SELECT NULL AS val' });
-
-    expect(res.status).toBe(200);
-    expect(res.body.rows[0].val).toBeNull();
-  });
-
-  it('returns affectedRows and insertId for non-SELECT statements', async () => {
-    const mockConn = {
-      // mysql2 returns a ResultSetHeader (plain object, not array) for DML
-      query: vi.fn().mockResolvedValueOnce([{ affectedRows: 3, insertId: 0 }]),
-      release: vi.fn(),
-    };
-    vi.mocked(getPool).mockReturnValue({ getConnection: vi.fn().mockResolvedValue(mockConn) } as any);
+    vi.mocked(getDriver).mockReturnValue(mockDriver as any);
 
     const res = await request(makeApp())
       .post('/api/query')
-      .send({ sql: "UPDATE users SET active = 0 WHERE role = 'guest'" });
+      .send({ sql: 'SELECT hash, created_at, big, val FROM t' });
 
     expect(res.status).toBe(200);
-    expect(res.body.columns).toEqual([]);
-    expect(res.body.rows).toEqual([]);
-    expect(res.body.affectedRows).toBe(3);
-    expect(mockConn.release).toHaveBeenCalledTimes(1);
+    expect(res.body.rows[0].hash).toBe('deadbeef');
+    expect(res.body.rows[0].created_at).toBe('2024-06-15 12:34:56');
+    expect(res.body.rows[0].big).toBe('9007199254740993');
+    expect(res.body.rows[0].val).toBeNull();
   });
 });

--- a/server/src/routes/query.ts
+++ b/server/src/routes/query.ts
@@ -1,6 +1,5 @@
 import type { RequestHandler } from 'express';
-import type { RowDataPacket, FieldPacket } from 'mysql2/promise';
-import { withSchema } from '../db.js';
+import { getDriver } from '../db.js';
 
 export const postQuery: RequestHandler = async (req, res) => {
   const { sql, schema } = req.body as { sql: string; schema?: string };
@@ -11,72 +10,26 @@ export const postQuery: RequestHandler = async (req, res) => {
   }
 
   try {
-    await withSchema(schema, async (conn) => {
-      const start = Date.now();
-      const [rows, fields]: [RowDataPacket[], FieldPacket[]] = await conn.query(sql) as [RowDataPacket[], FieldPacket[]];
-      const executionTime = Date.now() - start;
+    const start = Date.now();
+    const result = await getDriver().query(sql, [], schema);
+    const executionTime = Date.now() - start;
 
-      // Non-SELECT statements (INSERT, UPDATE, DELETE, etc.)
-      if (!Array.isArray(rows)) {
-        const result = rows as unknown as { affectedRows: number; insertId: number };
-        res.json({
-          columns: [],
-          rows: [],
-          affectedRows: result.affectedRows ?? 0,
-          insertId: result.insertId ?? null,
-          executionTime,
-        });
-        return;
-      }
-
-      const columns = fields.map(f => f.name);
-      const NOT_NULL_FLAG = 1;
-      const PRI_KEY_FLAG = 2;
-      const UNIQUE_KEY_FLAG = 4;
-      const columnMeta = fields.map(f => {
-        let flagsNum = 0;
-        if (typeof f.flags === 'number') {
-          flagsNum = f.flags;
-        } else if (Array.isArray(f.flags)) {
-          if (f.flags.includes('NOT_NULL')) flagsNum |= NOT_NULL_FLAG;
-          if (f.flags.includes('PRI_KEY')) flagsNum |= PRI_KEY_FLAG;
-          if (f.flags.includes('UNIQUE_KEY')) flagsNum |= UNIQUE_KEY_FLAG;
-        }
-        return {
-          name: f.name,
-          orgName: f.orgName ?? f.name,
-          table: f.table ?? '',
-          orgTable: f.orgTable ?? '',
-          pk: (flagsNum & PRI_KEY_FLAG) === PRI_KEY_FLAG,
-          unique: (flagsNum & UNIQUE_KEY_FLAG) === UNIQUE_KEY_FLAG,
-          notNull: (flagsNum & NOT_NULL_FLAG) === NOT_NULL_FLAG,
-          mysqlType: f.columnType ?? f.type ?? 0,
-        };
+    if (result.columnMeta.length === 0) {
+      res.json({
+        columns: [],
+        rows: [],
+        affectedRows: result.affectedRows ?? 0,
+        insertId: result.insertId ?? null,
+        executionTime,
       });
+      return;
+    }
 
-      // Serialize rows — convert Buffer/Date/BigInt to plain values
-      const serialized = rows.map(row => {
-        const out: Record<string, unknown> = {};
-        for (const col of columns) {
-          const val = row[col];
-          if (val === null || val === undefined) {
-            out[col] = null;
-          } else if (Buffer.isBuffer(val)) {
-            out[col] = val.toString('hex');
-          } else if (val instanceof Date) {
-            // mysql2 gives a Date for DATETIME/TIMESTAMP; .toISOString() is always UTC.
-            // Assumes the MySQL server is also UTC — displayed time will be wrong otherwise.
-            out[col] = val.toISOString().replace('T', ' ').replace(/\.\d{3}Z$/, '');
-          } else if (typeof val === 'bigint') {
-            out[col] = val.toString();
-          } else {
-            out[col] = val;
-          }
-        }
-        return out;
-      });
-
-      res.json({ columns, columnMeta, rows: serialized, executionTime });
+    res.json({
+      columns: result.columnMeta.map(c => c.name),
+      columnMeta: result.columnMeta,
+      rows: result.rows,
+      executionTime,
     });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);

--- a/server/src/routes/schema.ts
+++ b/server/src/routes/schema.ts
@@ -1,16 +1,10 @@
 import type { RequestHandler } from 'express';
-import mysql from 'mysql2/promise';
-import { getPool } from '../db.js';
+import { getDriver } from '../db.js';
 
 export const getSchemas: RequestHandler = async (_req, res) => {
   try {
-    const pool = getPool();
-    const [rows] = await pool.query<mysql.RowDataPacket[]>(
-      `SELECT SCHEMA_NAME AS name FROM information_schema.SCHEMATA
-       WHERE SCHEMA_NAME NOT IN ('information_schema','performance_schema','mysql','sys')
-       ORDER BY SCHEMA_NAME`
-    );
-    res.json({ schemas: rows.map(r => r['name'] as string) });
+    const schemas = await getDriver().getSchemas();
+    res.json({ schemas });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     res.status(500).json({ error: message });
@@ -24,92 +18,11 @@ export const getSchema: RequestHandler = async (req, res) => {
     return;
   }
 
-  // All 5 queries run on one connection to avoid consuming multiple pool slots
-  // simultaneously. If any query fails the error propagates from the catch block;
-  // check MySQL grants for each information_schema table independently if this
-  // endpoint returns 500.
-  const conn = await getPool().getConnection();
   try {
-    const [[tables], [columns], [views], [procedures], [triggers]] = await Promise.all([
-      conn.query<mysql.RowDataPacket[]>(
-        `SELECT TABLE_NAME AS name, TABLE_ROWS AS row_count, TABLE_COMMENT AS comment
-         FROM information_schema.TABLES
-         WHERE TABLE_SCHEMA = ? AND TABLE_TYPE = 'BASE TABLE'
-         ORDER BY TABLE_NAME`,
-        [schema],
-      ),
-      conn.query<mysql.RowDataPacket[]>(
-        `SELECT TABLE_NAME AS tbl, COLUMN_NAME AS col, COLUMN_TYPE AS col_type,
-                DATA_TYPE AS data_type,
-                IF(COLUMN_KEY = 'PRI', 1, 0) AS is_pk,
-                IF(IS_NULLABLE = 'YES', 1, 0) AS nullable,
-                COLUMN_DEFAULT AS col_default,
-                EXTRA AS extra,
-                COLUMN_COMMENT AS comment
-         FROM information_schema.COLUMNS
-         WHERE TABLE_SCHEMA = ?
-         ORDER BY TABLE_NAME, ORDINAL_POSITION`,
-        [schema],
-      ),
-      conn.query<mysql.RowDataPacket[]>(
-        `SELECT TABLE_NAME AS name FROM information_schema.VIEWS
-         WHERE TABLE_SCHEMA = ? ORDER BY TABLE_NAME`,
-        [schema],
-      ),
-      conn.query<mysql.RowDataPacket[]>(
-        `SELECT ROUTINE_NAME AS name FROM information_schema.ROUTINES
-         WHERE ROUTINE_SCHEMA = ? AND ROUTINE_TYPE = 'PROCEDURE'
-         ORDER BY ROUTINE_NAME`,
-        [schema],
-      ),
-      conn.query<mysql.RowDataPacket[]>(
-        `SELECT TRIGGER_NAME AS name FROM information_schema.TRIGGERS
-         WHERE TRIGGER_SCHEMA = ? ORDER BY TRIGGER_NAME`,
-        [schema],
-      ),
-    ]);
-
-    const colsByTable = new Map<string, {
-      name: string;
-      type: string;
-      dataType: string;
-      pk: boolean;
-      nullable: boolean;
-      default: string | null;
-      autoIncrement: boolean;
-      comment: string;
-    }[]>();
-    for (const col of columns) {
-      const tname = col['tbl'] as string;
-      if (!colsByTable.has(tname)) colsByTable.set(tname, []);
-      const extra = ((col['extra'] as string) ?? '').toLowerCase();
-      colsByTable.get(tname)!.push({
-        name: col['col'] as string,
-        type: col['col_type'] as string,
-        dataType: ((col['data_type'] as string) ?? '').toLowerCase(),
-        pk: Boolean(col['is_pk']),
-        nullable: Boolean(col['nullable']),
-        default: (col['col_default'] as string | null) ?? null,
-        autoIncrement: extra.includes('auto_increment'),
-        comment: (col['comment'] as string) ?? '',
-      });
-    }
-
-    res.json({
-      tables: tables.map(t => ({
-        name: t['name'] as string,
-        rows: t['row_count'] as number,
-        comment: (t['comment'] as string) ?? '',
-        columns: colsByTable.get(t['name'] as string) ?? [],
-      })),
-      views: views.map(v => v['name'] as string),
-      procedures: procedures.map(p => p['name'] as string),
-      triggers: triggers.map(t => t['name'] as string),
-    });
+    const info = await getDriver().getSchema(schema);
+    res.json(info);
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     res.status(500).json({ error: message });
-  } finally {
-    conn.release();
   }
 };

--- a/server/src/routes/tableDdl.ts
+++ b/server/src/routes/tableDdl.ts
@@ -1,19 +1,16 @@
 import type { RequestHandler } from 'express';
-import type { RowDataPacket } from 'mysql2/promise';
-import { getPool } from '../db.js';
-
-const escapeIdent = (s: string) => '`' + s.replace(/`/g, '') + '`';
+import { getDriver } from '../db.js';
 
 export const getTableDdl: RequestHandler = async (req, res) => {
   const schema = req.query['schema'] as string | undefined;
   const table = req.query['table'] as string | undefined;
   const type = (req.query['type'] as string | undefined) ?? 'table';
 
-  if (!schema || !schema.trim()) {
+  if (!schema?.trim()) {
     res.status(400).json({ error: 'schema query param is required.' });
     return;
   }
-  if (!table || !table.trim()) {
+  if (!table?.trim()) {
     res.status(400).json({ error: 'table query param is required.' });
     return;
   }
@@ -23,36 +20,10 @@ export const getTableDdl: RequestHandler = async (req, res) => {
   }
 
   try {
-    const pool = getPool();
-    const qualified = `${escapeIdent(schema)}.${escapeIdent(table)}`;
-
-    let sql: string;
-    if (type === 'procedure') {
-      sql = `SHOW CREATE PROCEDURE ${qualified}`;
-    } else if (type === 'trigger') {
-      // Schema-qualified form requires MySQL 8.0+
-      sql = `SHOW CREATE TRIGGER ${qualified}`;
-    } else {
-      // 'table' or 'view' — SHOW CREATE TABLE works for both
-      sql = `SHOW CREATE TABLE ${qualified}`;
-    }
-
-    const [rows] = await pool.query<RowDataPacket[]>(sql);
-    if (rows.length === 0) {
-      res.status(404).json({ error: `No DDL returned for ${qualified}.` });
-      return;
-    }
-    const row = rows[0] as Record<string, unknown>;
-    const ddl = (
-      row['Create Table'] ??
-      row['Create View'] ??
-      row['Create Procedure'] ??
-      row['SQL Original Statement'] ??   // SHOW CREATE TRIGGER
-      ''
-    ) as string;
+    const ddl = await getDriver().getTableDdl(schema, table, type as 'table' | 'view' | 'procedure' | 'trigger');
     res.json({ ddl });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
-    res.status(400).json({ error: message });
+    res.status(message.includes('No DDL returned') ? 404 : 400).json({ error: message });
   }
 };

--- a/server/src/routes/updateCell.ts
+++ b/server/src/routes/updateCell.ts
@@ -1,13 +1,10 @@
 import type { RequestHandler } from 'express';
-import type { ResultSetHeader } from 'mysql2/promise';
-import { getPool } from '../db.js';
+import { getDriver } from '../db.js';
 
 interface WhereClause {
   column: string;
   value: string | number | null;
 }
-
-const escapeIdent = (s: string) => '`' + s.replace(/`/g, '') + '`';
 
 export const postUpdateCell: RequestHandler = async (req, res) => {
   const { schema, table, where, column, value } = req.body as {
@@ -35,18 +32,18 @@ export const postUpdateCell: RequestHandler = async (req, res) => {
     return;
   }
 
+  const driver = getDriver();
   const qualifiedTable = schema
-    ? `${escapeIdent(schema)}.${escapeIdent(table)}`
-    : escapeIdent(table);
+    ? `${driver.escapeIdent(schema)}.${driver.escapeIdent(table)}`
+    : driver.escapeIdent(table);
 
-  const whereClause = where.map(w => `${escapeIdent(w.column)} = ?`).join(' AND ');
-  const sql = `UPDATE ${qualifiedTable} SET ${escapeIdent(column)} = ? WHERE ${whereClause} LIMIT 1`;
+  const whereClause = where.map(w => `${driver.escapeIdent(w.column)} = ?`).join(' AND ');
+  const sql = `UPDATE ${qualifiedTable} SET ${driver.escapeIdent(column)} = ? WHERE ${whereClause}${driver.rowLimitClause(1)}`;
   const params = [value === undefined ? null : value, ...where.map(w => w.value)];
 
   try {
-    const pool = getPool();
-    const [result] = await pool.query(sql, params) as [ResultSetHeader, unknown];
-    res.json({ affectedRows: result.affectedRows ?? 0, changedRows: (result as unknown as { changedRows?: number }).changedRows ?? 0, sql });
+    const result = await driver.query(sql, params);
+    res.json({ affectedRows: result.affectedRows ?? 0, sql });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     res.status(400).json({ error: message });

--- a/server/vitest.config.ts
+++ b/server/vitest.config.ts
@@ -4,5 +4,6 @@ export default defineConfig({
   test: {
     environment: 'node',
     include: ['src/**/*.test.ts'],
+    exclude: ['src/**/*.integration.test.ts'],
   },
 });

--- a/src/api.ts
+++ b/src/api.ts
@@ -108,7 +108,7 @@ export const api = {
   },
 
   updateCell(schema: string, table: string, where: DeleteRowWhere[], column: string, value: string | number | boolean | null) {
-    return request<{ affectedRows: number; changedRows: number; sql: string }>('/api/update-cell', {
+    return request<{ affectedRows: number; sql: string }>('/api/update-cell', {
       method: 'POST',
       body: JSON.stringify({ schema, table, where, column, value }),
     });


### PR DESCRIPTION
## Summary

- Replaced all direct mysql2 pool usage in routes with the DbDriver abstraction (getDriver())
- Added rowLimitClause(n) to DbDriver interface so MySQL emits LIMIT 1 on DML while Postgres omits it
- Rewrote mcp.ts to use driver methods (getSchemas, getSchema, query) - fully dialect-agnostic
- Updated dropTable.ts, query.ts, schema.ts, tableDdl.ts, insertRow.ts, updateCell.ts, deleteRow.ts
- Added Postgres integration test suite (19 tests) with separate vitest config and Docker Compose service
- Excluded integration tests from the default npm test run

Closes #92, #93, #94, #95, #96, #97

## Test plan

- [ ] npm test in server/ passes (7/7 unit tests)
- [ ] Postgres integration tests pass (19/19)
- [ ] MySQL integration tests pass
- [ ] TypeScript compiles cleanly

Generated with [Claude Code](https://claude.com/claude-code)