### PR TITLE
feat: add DB type selector to connection UI

### DIFF
--- a/server/src/routes/connect.test.ts
+++ b/server/src/routes/connect.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+
+vi.mock('../db.js', () => ({
+  connect: vi.fn().mockResolvedValue(undefined),
+  testConnection: vi.fn().mockResolvedValue(undefined),
+  disconnect: vi.fn().mockResolvedValue(undefined),
+  isConnected: vi.fn().mockReturnValue(true),
+  getActiveConfig: vi.fn().mockReturnValue(null),
+}));
+
+import { connect, testConnection } from '../db.js';
+import { postConnect, postTestConnect } from './connect.js';
+
+function makeApp() {
+  const app = express();
+  app.use(express.json());
+  app.post('/api/connect', postConnect);
+  app.post('/api/connect/test', postTestConnect);
+  return app;
+}
+
+describe('postConnect — db type plumbing', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("defaults to type 'mysql' and port 3306 when type is omitted", async () => {
+    const res = await request(makeApp())
+      .post('/api/connect')
+      .send({ host: 'h', user: 'u', password: 'p' });
+    expect(res.status).toBe(200);
+    expect(connect).toHaveBeenCalledWith(expect.objectContaining({ type: 'mysql', port: 3306 }));
+  });
+
+  it("forwards type 'postgres' and uses port 5432 by default", async () => {
+    const res = await request(makeApp())
+      .post('/api/connect')
+      .send({ host: 'h', user: 'u', password: 'p', type: 'postgres' });
+    expect(res.status).toBe(200);
+    expect(connect).toHaveBeenCalledWith(expect.objectContaining({ type: 'postgres', port: 5432 }));
+  });
+
+  it('honors an explicit port over the type-default', async () => {
+    await request(makeApp())
+      .post('/api/connect')
+      .send({ host: 'h', user: 'u', password: 'p', type: 'postgres', port: 9999 });
+    expect(connect).toHaveBeenCalledWith(expect.objectContaining({ type: 'postgres', port: 9999 }));
+  });
+
+  it('returns 400 for unknown type', async () => {
+    const res = await request(makeApp())
+      .post('/api/connect')
+      .send({ host: 'h', user: 'u', password: 'p', type: 'mariadb' });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/unsupported db type/i);
+    expect(connect).not.toHaveBeenCalled();
+  });
+});
+
+describe('postTestConnect — db type plumbing', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("forwards type 'postgres' through to testConnection()", async () => {
+    const res = await request(makeApp())
+      .post('/api/connect/test')
+      .send({ host: 'h', user: 'u', password: 'p', type: 'postgres' });
+    expect(res.status).toBe(200);
+    expect(testConnection).toHaveBeenCalledWith(expect.objectContaining({ type: 'postgres', port: 5432 }));
+  });
+
+  it("defaults to type 'mysql' when type is omitted", async () => {
+    await request(makeApp())
+      .post('/api/connect/test')
+      .send({ host: 'h', user: 'u', password: 'p' });
+    expect(testConnection).toHaveBeenCalledWith(expect.objectContaining({ type: 'mysql', port: 3306 }));
+  });
+
+  it('returns 400 for unknown type', async () => {
+    const res = await request(makeApp())
+      .post('/api/connect/test')
+      .send({ host: 'h', user: 'u', password: 'p', type: 42 });
+    expect(res.status).toBe(400);
+    expect(testConnection).not.toHaveBeenCalled();
+  });
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -111,6 +111,7 @@ export default function App() {
       if (friendly) {
         saveConnection({
           name: friendly,
+          type: form.type,
           host: form.host,
           port: form.port,
           user: form.user,

--- a/src/api.ts
+++ b/src/api.ts
@@ -54,7 +54,7 @@ async function request<T>(path: string, init?: RequestInit): Promise<T> {
 }
 
 export const api = {
-  connect(form: { host: string; port: string; user: string; password: string; database: string; ssl: boolean; sslVerify: boolean }) {
+  connect(form: { type: 'mysql' | 'postgres'; host: string; port: string; user: string; password: string; database: string; ssl: boolean; sslVerify: boolean }) {
     const { ssl, sslVerify, ...rest } = form;
     const sslMode = !ssl ? undefined : sslVerify ? 'verify-full' : 'require';
     return request<{ ok: boolean; connectionName: string }>('/api/connect', {
@@ -63,7 +63,7 @@ export const api = {
     });
   },
 
-  testConnection(form: { host: string; port: string; user: string; password: string; database: string; ssl: boolean; sslVerify: boolean }) {
+  testConnection(form: { type: 'mysql' | 'postgres'; host: string; port: string; user: string; password: string; database: string; ssl: boolean; sslVerify: boolean }) {
     const { ssl, sslVerify, ...rest } = form;
     const sslMode = !ssl ? undefined : sslVerify ? 'verify-full' : 'require';
     return request<{ ok: boolean }>('/api/connect/test', {

--- a/src/components/ConnectionManager.tsx
+++ b/src/components/ConnectionManager.tsx
@@ -95,14 +95,17 @@ export function ConnectionManager({ onConnect, isConnecting, error, onDismiss, t
     setTestResult(null);
   };
 
-  const setDbType = (t: 'mysql' | 'postgres') => {
-    setForm(p => ({
-      ...p,
-      type: t,
-      port: p.port === '3306' || p.port === '5432' || p.port === ''
-        ? (t === 'mysql' ? '3306' : '5432')
-        : p.port,
-    }));
+  const defaultPort = (type: 'mysql' | 'postgres') => type === 'postgres' ? '5432' : '3306';
+  const setDbType = (next: 'mysql' | 'postgres') => {
+    setForm(p => {
+      const prevDefault = defaultPort(p.type);
+      const portIsPrevDefault = p.port === '' || p.port === prevDefault;
+      return {
+        ...p,
+        type: next,
+        port: portIsPrevDefault ? defaultPort(next) : p.port,
+      };
+    });
     setTestResult(null);
   };
 

--- a/src/components/ConnectionManager.tsx
+++ b/src/components/ConnectionManager.tsx
@@ -7,6 +7,7 @@ import { electronAPI } from '../electronAPI';
 
 export interface ConnectionForm {
   name: string;
+  type: 'mysql' | 'postgres';
   host: string;
   port: string;
   user: string;
@@ -30,9 +31,10 @@ interface ConnectionManagerProps {
 export function ConnectionManager({ onConnect, isConnecting, error, onDismiss, t }: ConnectionManagerProps) {
   const [saved, setSaved] = useState<SavedConnection[]>(() => listSavedConnections());
   const initialForm: ConnectionForm = saved[0]
-    ? { ...saved[0], password: '', sslVerify: saved[0].sslVerify ?? false, savePassword: saved[0].savePassword ?? false }
+    ? { ...saved[0], type: saved[0].type ?? 'mysql', password: '', sslVerify: saved[0].sslVerify ?? false, savePassword: saved[0].savePassword ?? false }
     : {
         name: 'Local MySQL',
+        type: 'mysql',
         host: import.meta.env['VITE_DEFAULT_HOST'] ?? 'localhost',
         port: import.meta.env['VITE_DEFAULT_PORT'] ?? '3306',
         user: import.meta.env['VITE_DEFAULT_USER'] ?? 'root',
@@ -93,8 +95,19 @@ export function ConnectionManager({ onConnect, isConnecting, error, onDismiss, t
     setTestResult(null);
   };
 
+  const setDbType = (t: 'mysql' | 'postgres') => {
+    setForm(p => ({
+      ...p,
+      type: t,
+      port: p.port === '3306' || p.port === '5432' || p.port === ''
+        ? (t === 'mysql' ? '3306' : '5432')
+        : p.port,
+    }));
+    setTestResult(null);
+  };
+
   const applySaved = (entry: SavedConnection) => {
-    setForm({ ...entry, password: '', sslVerify: entry.sslVerify ?? false, savePassword: entry.savePassword ?? false });
+    setForm({ ...entry, type: entry.type ?? 'mysql', password: '', sslVerify: entry.sslVerify ?? false, savePassword: entry.savePassword ?? false });
     setAppliedSaved(entry.name);
     setSuggestOpen(false);
     if (entry.savePassword && electronAPI) {
@@ -160,7 +173,7 @@ export function ConnectionManager({ onConnect, isConnecting, error, onDismiss, t
           </svg>
           <div>
             <div style={s.title}>New connection</div>
-            <div style={s.subtitle}>Connect to a MySQL server</div>
+            <div style={s.subtitle}>Connect to a {form.type === 'postgres' ? 'PostgreSQL' : 'MySQL'} server</div>
           </div>
         </div>
 
@@ -169,6 +182,33 @@ export function ConnectionManager({ onConnect, isConnecting, error, onDismiss, t
           autoComplete="on"
         >
           <div style={s.body}>
+            <div style={s.field}>
+              <label style={s.label}>Database type</label>
+              <div style={{ display: 'flex', gap: 6 }}>
+                {(['mysql', 'postgres'] as const).map(dbType => {
+                  const active = form.type === dbType;
+                  return (
+                    <button
+                      key={dbType}
+                      type="button"
+                      onClick={() => setDbType(dbType)}
+                      style={{
+                        height: 30, padding: '0 14px',
+                        background: active ? t.accent : t.bgInput,
+                        border: `1px solid ${active ? t.accent : t.border}`,
+                        borderRadius: 5, fontSize: 12, fontWeight: active ? 600 : 400,
+                        color: active ? t.textInverse : t.textSecondary,
+                        cursor: 'pointer', fontFamily: '"IBM Plex Sans", sans-serif',
+                        transition: 'background 120ms, color 120ms, border-color 120ms',
+                      }}
+                    >
+                      {dbType === 'mysql' ? 'MySQL' : 'PostgreSQL'}
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+
             <div style={s.field}>
               <label style={s.label}>
                 Connection name
@@ -269,7 +309,7 @@ export function ConnectionManager({ onConnect, isConnecting, error, onDismiss, t
                   autoComplete="off"
                   value={form.port}
                   onChange={e => set('port', e.target.value)}
-                  placeholder="3306"
+                  placeholder={form.type === 'postgres' ? '5432' : '3306'}
                 />
               </div>
             </div>
@@ -379,7 +419,7 @@ export function ConnectionManager({ onConnect, isConnecting, error, onDismiss, t
                 <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke={t.colorSuccess} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
                   <polyline points="20 6 9 17 4 12"/>
                 </svg>
-                <span>Connection successful — {form.user}@{form.host}:{form.port || 3306}</span>
+                <span>Connection successful — {form.user}@{form.host}:{form.port || (form.type === 'postgres' ? 5432 : 3306)}</span>
               </div>
             )}
             {testResult && !testResult.ok && (

--- a/src/savedConnections.ts
+++ b/src/savedConnections.ts
@@ -1,5 +1,6 @@
 export interface SavedConnection {
   name: string;
+  type?: 'mysql' | 'postgres';
   host: string;
   port: string;
   user: string;


### PR DESCRIPTION
## Summary

- Added `type: "mysql" | "postgres"` field to `SavedConnection` (optional, defaults to `"mysql"` for backward compatibility with existing saved connections)
- Added `type` to `ConnectionForm` in `ConnectionManager`
- Connection modal now shows **MySQL / PostgreSQL** toggle buttons at the top of the form
- Switching DB type auto-updates the port when it is still the default (3306 to 5432 and back)
- Modal subtitle updates to reflect the selected DB type
- `api.ts` forwards `type` in connect and testConnection request bodies
- `server/src/routes/connect.ts` extracts `type` from the request and passes it to `connect()` and `testConnection()`
- `server/src/db.ts` `ConnectionConfig` accepts optional `type` field
- `server/vitest.config.ts` excludes integration tests from the default `npm test` run

Closes #98, #99

## Test plan

- [ ] TypeScript compiles cleanly (frontend + server)
- [ ] `npm test` in `server/` passes (11/11 unit tests)
- [ ] MySQL/PostgreSQL toggle appears in connection modal
- [ ] Switching to PostgreSQL changes port from 3306 to 5432 (and back)
- [ ] Subtitle changes to "Connect to a PostgreSQL server" when Postgres is selected
- [ ] Connecting to MySQL still works end-to-end

Generated with [Claude Code](https://claude.com/claude-code)
