### PR TITLE
Dismiss Update cell / Delete row confirmations on Escape

### DIFF
--- a/src/components/ResultsTable.tsx
+++ b/src/components/ResultsTable.tsx
@@ -252,6 +252,25 @@ export function ResultsTable({ results, isRunning, error, executionTime, activeS
     return () => window.removeEventListener('keydown', onKey);
   }, []);
 
+  // Escape dismisses Update cell / Delete row confirmations (when not mid-flight)
+  useEffect(() => {
+    if (!confirmDelete && !confirmUpdate) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key !== 'Escape') return;
+      if (confirmUpdate && !confirmUpdate.saving) {
+        e.preventDefault();
+        setConfirmUpdate(null);
+        return;
+      }
+      if (confirmDelete && !deleting) {
+        e.preventDefault();
+        setConfirmDelete(null);
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [confirmDelete, confirmUpdate, deleting]);
+
   useEffect(() => {
     if (filterOpen) { filterInputRef.current?.focus(); filterInputRef.current?.select(); }
   }, [filterOpen]);


### PR DESCRIPTION
Closes #38

## Summary
- The Update cell and Delete row confirmation dialogs only closed via the overlay click or Cancel button — Escape did nothing.
- Added a window \`keydown\` listener (mounted only while one of the dialogs is open) that closes whichever dialog is mounted, ignoring Escape while the underlying mutation is in flight.
- The Drop table dialog already handled Escape via its own input \`onKeyDown\` and is unaffected.

## Test plan
- [ ] Right-click a row → Delete row → confirmation appears → press **Escape** → dialog closes; row not deleted.
- [ ] Double-click a cell → edit → Enter → confirmation appears → press **Escape** → dialog closes.
- [ ] While the spinner is showing on the confirmation button, Escape is ignored (mutation completes normally).
- [ ] Drop table dialog still dismisses on Escape (unchanged behaviour).

🤖 Generated with [Claude Code](https://claude.com/claude-code)