### PR TITLE
feat: MongoDBDriver implementation (#107)

### DIFF
--- a/server/src/drivers/interface.ts
+++ b/server/src/drivers/interface.ts
@@ -36,6 +36,8 @@ export interface ColumnInfo {
   default: string | null;
   autoIncrement: boolean;
   comment: string;
+  /** Set by document-store drivers when fields are inferred from a sample document. */
+  inferred?: boolean;
 }
 
 export interface TableInfo {

--- a/server/src/drivers/interface.ts
+++ b/server/src/drivers/interface.ts
@@ -78,8 +78,8 @@ export interface DbDriver {
   /** Targeted lookup for a single table — returns null if it doesn't exist. */
   getTable(schema: string, table: string): Promise<TableInfo | null>;
   getTableDdl(schema: string, table: string, type: 'table' | 'view' | 'procedure' | 'trigger'): Promise<string>;
-  /** Document-store equivalent of `getTableDdl`. Implemented by `mql`-mode drivers. */
-  getCollectionInfo?(schema: string, collection: string): Promise<CollectionInfo>;
+  /** Document-store equivalent of `getTableDdl`. Implemented by `mql`-mode drivers. Returns null when the collection doesn't exist. */
+  getCollectionInfo?(schema: string, collection: string): Promise<CollectionInfo | null>;
   /** Return a quoted, escaped identifier (e.g. `name` for MySQL, "name" for Postgres). */
   escapeIdent(s: string): string;
   /** " LIMIT N" for dialects that support it in DML; "" for those that don't (e.g. Postgres). */

--- a/server/src/drivers/mongodb.test.ts
+++ b/server/src/drivers/mongodb.test.ts
@@ -64,10 +64,22 @@ vi.mock('mongodb', () => ({
 }));
 
 import { MongoDBDriver } from './mongodb.js';
+import { MongoClient } from 'mongodb';
 
+// TODO(#108): ConnectionConfig.type needs 'mongodb'. Until that lands, MongoDB
+// fixtures here pass type: 'mysql' purely to satisfy the type system.
 function makeDriver(database?: string) {
   return new MongoDBDriver({
     host: 'h', port: 27017, user: 'u', password: 'p', database,
+    type: 'mysql',
+  });
+}
+
+function makeDriverConfig(overrides: Partial<{ user: string; password: string }>) {
+  return new MongoDBDriver({
+    host: 'h', port: 27017,
+    user: overrides.user as string,
+    password: overrides.password as string,
     type: 'mysql',
   });
 }
@@ -96,6 +108,38 @@ describe('MongoDBDriver – static surface', () => {
 
   it('rowLimitClause is empty (limits applied via cursor.limit, not SQL)', () => {
     expect(makeDriver().rowLimitClause(10)).toBe('');
+  });
+});
+
+describe('MongoDBDriver – URI construction', () => {
+  function uriFromLastCtor(): string {
+    const calls = (MongoClient as unknown as { mock: { calls: unknown[][] } }).mock.calls;
+    return calls[calls.length - 1][0] as string;
+  }
+
+  it('omits credentials when user and password are both empty', () => {
+    makeDriverConfig({ user: '', password: '' });
+    expect(uriFromLastCtor()).toBe('mongodb://h:27017/');
+  });
+
+  it('includes credentials when only the user is set', () => {
+    makeDriverConfig({ user: 'alice', password: '' });
+    expect(uriFromLastCtor()).toBe('mongodb://alice:@h:27017/');
+  });
+
+  it('includes credentials when only the password is set', () => {
+    makeDriverConfig({ user: '', password: 'secret' });
+    expect(uriFromLastCtor()).toBe('mongodb://:secret@h:27017/');
+  });
+
+  it('coerces undefined user/password to empty strings (not the literal "undefined")', () => {
+    makeDriverConfig({});
+    expect(uriFromLastCtor()).toBe('mongodb://h:27017/');
+  });
+
+  it('percent-encodes credentials with reserved characters', () => {
+    makeDriverConfig({ user: 'a@b', password: 'p:w/d' });
+    expect(uriFromLastCtor()).toBe('mongodb://a%40b:p%3Aw%2Fd@h:27017/');
   });
 });
 
@@ -185,6 +229,23 @@ describe('MongoDBDriver.query – find', () => {
     expect(r.columnMeta.find((c) => c.name === '_id')?.pk).toBe(true);
   });
 
+  it('serializes Date in UTC regardless of how the Date literal is constructed', async () => {
+    // Constructing from an offset-bearing literal (not a "Z" UTC literal) and
+    // from millis-since-epoch — both must render identically in UTC.
+    const fromOffset = new Date('2024-01-02T03:04:05+05:00'); // 22:04:05Z prev day
+    const fromMillis = new Date(Date.UTC(2024, 0, 1, 22, 4, 5));
+    mockCursor.toArray.mockResolvedValueOnce([
+      { a: fromOffset, b: fromMillis },
+    ]);
+    const r = await makeDriver().query(
+      JSON.stringify({ collection: 'users', operation: 'find' }),
+    );
+    expect(r.rows[0]).toEqual({
+      a: '2024-01-01 22:04:05',
+      b: '2024-01-01 22:04:05',
+    });
+  });
+
   it('applies projection / sort / skip / limit when provided', async () => {
     mockCursor.toArray.mockResolvedValueOnce([]);
     await makeDriver().query(
@@ -265,7 +326,7 @@ describe('MongoDBDriver.query – writes', () => {
   });
 
   it('updateOne uses ObjectId filter when id is a 24-char hex string', async () => {
-    mockCollection.updateOne.mockResolvedValueOnce({ modifiedCount: 1 });
+    mockCollection.updateOne.mockResolvedValueOnce({ matchedCount: 1, modifiedCount: 1 });
     await makeDriver().query(
       JSON.stringify({
         collection: 'users',
@@ -280,8 +341,40 @@ describe('MongoDBDriver.query – writes', () => {
     expect(call[1]).toEqual({ $set: { name: 'New' } });
   });
 
+  it('updateOne reports affectedRows from matchedCount (no-op update still counts as matched)', async () => {
+    mockCollection.updateOne.mockResolvedValueOnce({ matchedCount: 1, modifiedCount: 0 });
+    const r = await makeDriver().query(
+      JSON.stringify({
+        collection: 'users',
+        operation: 'updateOne',
+        filter: { _id: 1 },
+        update: { $set: { name: 'same' } },
+      }),
+    );
+    expect(r.affectedRows).toBe(1);
+  });
+
+  it('updateOne retries with raw string id when ObjectId match returns 0 rows', async () => {
+    mockCollection.updateOne
+      .mockResolvedValueOnce({ matchedCount: 0, modifiedCount: 0 })
+      .mockResolvedValueOnce({ matchedCount: 1, modifiedCount: 1 });
+    const r = await makeDriver().query(
+      JSON.stringify({
+        collection: 'users',
+        operation: 'updateOne',
+        id: 'aaaaaaaaaaaaaaaaaaaaaaaa',
+        update: { $set: { name: 'X' } },
+      }),
+    );
+    expect(mockCollection.updateOne).toHaveBeenCalledTimes(2);
+    expect(mockCollection.updateOne.mock.calls[1][0]).toEqual({
+      _id: 'aaaaaaaaaaaaaaaaaaaaaaaa',
+    });
+    expect(r.affectedRows).toBe(1);
+  });
+
   it('updateOne falls back to raw filter when id is not provided', async () => {
-    mockCollection.updateOne.mockResolvedValueOnce({ modifiedCount: 0 });
+    mockCollection.updateOne.mockResolvedValueOnce({ matchedCount: 0, modifiedCount: 0 });
     await makeDriver().query(
       JSON.stringify({
         collection: 'users',
@@ -433,16 +526,24 @@ describe('MongoDBDriver – getCollectionInfo', () => {
       { v: 2, key: { email: 1 }, name: 'email_1', unique: true },
     ]);
     const r = await makeDriver().getCollectionInfo('shop', 'users');
-    expect(r.validator).toEqual({ $jsonSchema: { bsonType: 'object' } });
-    expect(r.indexes).toHaveLength(2);
+    expect(r?.validator).toEqual({ $jsonSchema: { bsonType: 'object' } });
+    expect(r?.indexes).toHaveLength(2);
   });
 
   it('returns null validator when none is set', async () => {
     mockListCursor.toArray.mockResolvedValueOnce([{ name: 'users', type: 'collection', options: {} }]);
     mockCollection.indexes.mockResolvedValueOnce([]);
     const r = await makeDriver().getCollectionInfo('shop', 'users');
-    expect(r.validator).toBeNull();
-    expect(r.indexes).toEqual([]);
+    expect(r?.validator).toBeNull();
+    expect(r?.indexes).toEqual([]);
+  });
+
+  it('returns null when the collection does not exist (mirrors getTable)', async () => {
+    mockListCursor.toArray.mockResolvedValueOnce([]);
+    const r = await makeDriver().getCollectionInfo('shop', 'ghost');
+    expect(r).toBeNull();
+    // Must not query indexes on a missing collection (avoids NamespaceNotFound).
+    expect(mockCollection.indexes).not.toHaveBeenCalled();
   });
 });
 

--- a/server/src/drivers/mongodb.test.ts
+++ b/server/src/drivers/mongodb.test.ts
@@ -1,0 +1,455 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockCursor = {
+  project: vi.fn(),
+  sort: vi.fn(),
+  skip: vi.fn(),
+  limit: vi.fn(),
+  toArray: vi.fn(),
+};
+mockCursor.project.mockReturnValue(mockCursor);
+mockCursor.sort.mockReturnValue(mockCursor);
+mockCursor.skip.mockReturnValue(mockCursor);
+mockCursor.limit.mockReturnValue(mockCursor);
+
+const mockAggCursor = { toArray: vi.fn() };
+
+const mockListCursor = { toArray: vi.fn() };
+
+const mockCollection = {
+  find: vi.fn(() => mockCursor),
+  findOne: vi.fn(),
+  aggregate: vi.fn(() => mockAggCursor),
+  countDocuments: vi.fn(),
+  insertOne: vi.fn(),
+  updateOne: vi.fn(),
+  deleteOne: vi.fn(),
+  estimatedDocumentCount: vi.fn(),
+  indexes: vi.fn(),
+};
+
+const mockAdmin = {
+  listDatabases: vi.fn(),
+};
+
+const mockDb = {
+  collection: vi.fn(() => mockCollection),
+  command: vi.fn(),
+  listCollections: vi.fn(() => mockListCursor),
+  admin: vi.fn(() => mockAdmin),
+};
+
+const mockClient = {
+  connect: vi.fn(),
+  close: vi.fn(),
+  db: vi.fn(() => mockDb),
+};
+
+const { ObjectIdCtor } = vi.hoisted(() => {
+  const ctor = vi.fn(function (this: { _hex: string }, hex?: string) {
+    this._hex = hex ?? 'aaaaaaaaaaaaaaaaaaaaaaaa';
+  }) as unknown as {
+    new (hex?: string): { _hex: string; toHexString(): string };
+    prototype: { toHexString(): string };
+  };
+  ctor.prototype.toHexString = function (this: { _hex: string }) {
+    return this._hex;
+  };
+  return { ObjectIdCtor: ctor };
+});
+
+vi.mock('mongodb', () => ({
+  MongoClient: vi.fn(() => mockClient),
+  ObjectId: ObjectIdCtor,
+}));
+
+import { MongoDBDriver } from './mongodb.js';
+
+function makeDriver(database?: string) {
+  return new MongoDBDriver({
+    host: 'h', port: 27017, user: 'u', password: 'p', database,
+    type: 'mysql',
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockClient.connect.mockResolvedValue(undefined);
+  mockClient.close.mockResolvedValue(undefined);
+  mockClient.db.mockReturnValue(mockDb);
+  mockDb.collection.mockReturnValue(mockCollection);
+  mockDb.admin.mockReturnValue(mockAdmin);
+  mockDb.listCollections.mockReturnValue(mockListCursor);
+  mockDb.command.mockResolvedValue({ ok: 1 });
+});
+
+describe('MongoDBDriver – static surface', () => {
+  it('reports queryMode as mql', () => {
+    expect(makeDriver().queryMode).toBe('mql');
+  });
+
+  it('escapeIdent is identity (MongoDB needs no quoting)', () => {
+    const d = makeDriver();
+    expect(d.escapeIdent('users')).toBe('users');
+    expect(d.escapeIdent('weird.name`with"quotes')).toBe('weird.name`with"quotes');
+  });
+
+  it('rowLimitClause is empty (limits applied via cursor.limit, not SQL)', () => {
+    expect(makeDriver().rowLimitClause(10)).toBe('');
+  });
+});
+
+describe('MongoDBDriver – connect / disconnect / ping', () => {
+  it('ping connects lazily and runs admin command', async () => {
+    await makeDriver().ping();
+    expect(mockClient.connect).toHaveBeenCalledTimes(1);
+    expect(mockClient.db).toHaveBeenCalledWith('admin');
+    expect(mockDb.command).toHaveBeenCalledWith({ ping: 1 });
+  });
+
+  it('end closes the client when connected', async () => {
+    const d = makeDriver();
+    await d.ping();
+    await d.end();
+    expect(mockClient.close).toHaveBeenCalledTimes(1);
+  });
+
+  it('end is a no-op when never connected', async () => {
+    await makeDriver().end();
+    expect(mockClient.close).not.toHaveBeenCalled();
+  });
+
+  it('reuses a single in-flight connect promise', async () => {
+    const d = makeDriver();
+    let resolveConn: (() => void) | null = null;
+    mockClient.connect.mockImplementationOnce(
+      () => new Promise<void>((res) => { resolveConn = res; }),
+    );
+    const p1 = d.ping();
+    const p2 = d.ping();
+    resolveConn!();
+    await Promise.all([p1, p2]);
+    expect(mockClient.connect).toHaveBeenCalledTimes(1);
+  });
+
+  it('clears connect promise so a failed connect can be retried', async () => {
+    const d = makeDriver();
+    mockClient.connect.mockRejectedValueOnce(new Error('boom'));
+    await expect(d.ping()).rejects.toThrow('boom');
+    mockClient.connect.mockResolvedValueOnce(undefined);
+    await expect(d.ping()).resolves.toBeUndefined();
+    expect(mockClient.connect).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('MongoDBDriver.query – MQL request parsing', () => {
+  it('rejects non-JSON input', async () => {
+    await expect(makeDriver().query('SELECT 1')).rejects.toThrow(/JSON-encoded MQL/);
+  });
+
+  it('rejects MQL request missing collection', async () => {
+    await expect(
+      makeDriver().query(JSON.stringify({ operation: 'find' })),
+    ).rejects.toThrow(/collection/);
+  });
+
+  it('rejects MQL request missing operation', async () => {
+    await expect(
+      makeDriver().query(JSON.stringify({ collection: 'users' })),
+    ).rejects.toThrow(/operation/);
+  });
+
+  it('rejects unsupported operation', async () => {
+    await expect(
+      makeDriver().query(JSON.stringify({ collection: 'users', operation: 'bogus' })),
+    ).rejects.toThrow(/Unsupported MQL operation/);
+  });
+});
+
+describe('MongoDBDriver.query – find', () => {
+  it('returns rows with serialized ObjectId and Date', async () => {
+    const id = new ObjectIdCtor('507f1f77bcf86cd799439011');
+    const when = new Date('2024-01-02T03:04:05.000Z');
+    mockCursor.toArray.mockResolvedValueOnce([{ _id: id, name: 'Alice', when }]);
+    const r = await makeDriver().query(
+      JSON.stringify({ collection: 'users', operation: 'find', filter: { active: true } }),
+      [],
+      'app',
+    );
+    expect(mockClient.db).toHaveBeenCalledWith('app');
+    expect(mockDb.collection).toHaveBeenCalledWith('users');
+    expect(mockCollection.find).toHaveBeenCalledWith({ active: true });
+    expect(r.rows).toEqual([
+      { _id: '507f1f77bcf86cd799439011', name: 'Alice', when: '2024-01-02 03:04:05' },
+    ]);
+    expect(r.columnMeta.find((c) => c.name === '_id')?.pk).toBe(true);
+  });
+
+  it('applies projection / sort / skip / limit when provided', async () => {
+    mockCursor.toArray.mockResolvedValueOnce([]);
+    await makeDriver().query(
+      JSON.stringify({
+        collection: 'users',
+        operation: 'find',
+        projection: { name: 1 },
+        sort: { name: 1 },
+        skip: 5,
+        limit: 10,
+      }),
+    );
+    expect(mockCursor.project).toHaveBeenCalledWith({ name: 1 });
+    expect(mockCursor.sort).toHaveBeenCalledWith({ name: 1 });
+    expect(mockCursor.skip).toHaveBeenCalledWith(5);
+    expect(mockCursor.limit).toHaveBeenCalledWith(10);
+  });
+});
+
+describe('MongoDBDriver.query – findOne / aggregate / count', () => {
+  it('findOne returns at most one row', async () => {
+    mockCollection.findOne.mockResolvedValueOnce({ name: 'Bob' });
+    const r = await makeDriver().query(
+      JSON.stringify({ collection: 'users', operation: 'findOne' }),
+    );
+    expect(r.rows).toEqual([{ name: 'Bob' }]);
+  });
+
+  it('findOne returns no rows when nothing matches', async () => {
+    mockCollection.findOne.mockResolvedValueOnce(null);
+    const r = await makeDriver().query(
+      JSON.stringify({ collection: 'users', operation: 'findOne' }),
+    );
+    expect(r.rows).toEqual([]);
+  });
+
+  it('aggregate runs the supplied pipeline', async () => {
+    mockAggCursor.toArray.mockResolvedValueOnce([{ _id: 'A', n: 2 }]);
+    const r = await makeDriver().query(
+      JSON.stringify({
+        collection: 'users',
+        operation: 'aggregate',
+        pipeline: [{ $group: { _id: '$status', n: { $sum: 1 } } }],
+      }),
+    );
+    expect(mockCollection.aggregate).toHaveBeenCalledWith([
+      { $group: { _id: '$status', n: { $sum: 1 } } },
+    ]);
+    expect(r.rows).toEqual([{ _id: 'A', n: 2 }]);
+  });
+
+  it('count returns a single row with the count', async () => {
+    mockCollection.countDocuments.mockResolvedValueOnce(42);
+    const r = await makeDriver().query(
+      JSON.stringify({ collection: 'users', operation: 'count', filter: { active: true } }),
+    );
+    expect(mockCollection.countDocuments).toHaveBeenCalledWith({ active: true });
+    expect(r.rows).toEqual([{ count: 42 }]);
+  });
+});
+
+describe('MongoDBDriver.query – writes', () => {
+  it('insertOne reports affectedRows = 1 on acknowledged write', async () => {
+    mockCollection.insertOne.mockResolvedValueOnce({ acknowledged: true, insertedId: 'x' });
+    const r = await makeDriver().query(
+      JSON.stringify({ collection: 'users', operation: 'insertOne', document: { name: 'Z' } }),
+    );
+    expect(mockCollection.insertOne).toHaveBeenCalledWith({ name: 'Z' });
+    expect(r.affectedRows).toBe(1);
+  });
+
+  it('insertOne errors when document is missing', async () => {
+    await expect(
+      makeDriver().query(
+        JSON.stringify({ collection: 'users', operation: 'insertOne' }),
+      ),
+    ).rejects.toThrow(/document/);
+  });
+
+  it('updateOne uses ObjectId filter when id is a 24-char hex string', async () => {
+    mockCollection.updateOne.mockResolvedValueOnce({ modifiedCount: 1 });
+    await makeDriver().query(
+      JSON.stringify({
+        collection: 'users',
+        operation: 'updateOne',
+        id: '507f1f77bcf86cd799439011',
+        update: { $set: { name: 'New' } },
+      }),
+    );
+    const call = mockCollection.updateOne.mock.calls[0];
+    expect(ObjectIdCtor).toHaveBeenCalledWith('507f1f77bcf86cd799439011');
+    expect(call[0]).toHaveProperty('_id');
+    expect(call[1]).toEqual({ $set: { name: 'New' } });
+  });
+
+  it('updateOne falls back to raw filter when id is not provided', async () => {
+    mockCollection.updateOne.mockResolvedValueOnce({ modifiedCount: 0 });
+    await makeDriver().query(
+      JSON.stringify({
+        collection: 'users',
+        operation: 'updateOne',
+        filter: { name: 'A' },
+        update: { $set: { name: 'B' } },
+      }),
+    );
+    expect(mockCollection.updateOne).toHaveBeenCalledWith(
+      { name: 'A' },
+      { $set: { name: 'B' } },
+    );
+  });
+
+  it('updateOne errors when update is missing', async () => {
+    await expect(
+      makeDriver().query(
+        JSON.stringify({ collection: 'users', operation: 'updateOne', filter: {} }),
+      ),
+    ).rejects.toThrow(/update/);
+  });
+
+  it('deleteOne reports affectedRows from the driver result', async () => {
+    mockCollection.deleteOne.mockResolvedValueOnce({ deletedCount: 1 });
+    const r = await makeDriver().query(
+      JSON.stringify({
+        collection: 'users',
+        operation: 'deleteOne',
+        id: '507f1f77bcf86cd799439011',
+      }),
+    );
+    expect(r.affectedRows).toBe(1);
+  });
+});
+
+describe('MongoDBDriver.query – error parity with SQL drivers', () => {
+  it('propagates the underlying error when a find operation rejects', async () => {
+    mockCursor.toArray.mockRejectedValueOnce(new Error('boom'));
+    await expect(
+      makeDriver().query(JSON.stringify({ collection: 'users', operation: 'find' })),
+    ).rejects.toThrow('boom');
+  });
+
+  it('propagates the underlying error when connect fails', async () => {
+    mockClient.connect.mockRejectedValueOnce(new Error('no host'));
+    await expect(
+      makeDriver().query(JSON.stringify({ collection: 'users', operation: 'find' })),
+    ).rejects.toThrow('no host');
+  });
+
+  it('propagates the underlying error when insertOne rejects, then end() still closes the client', async () => {
+    mockCollection.insertOne.mockRejectedValueOnce(new Error('write fail'));
+    const d = makeDriver();
+    await expect(
+      d.query(JSON.stringify({ collection: 'users', operation: 'insertOne', document: {} })),
+    ).rejects.toThrow('write fail');
+    await d.end();
+    expect(mockClient.close).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('MongoDBDriver – getSchemas', () => {
+  it('lists databases excluding admin / local / config', async () => {
+    mockAdmin.listDatabases.mockResolvedValueOnce({
+      databases: [
+        { name: 'admin' },
+        { name: 'local' },
+        { name: 'config' },
+        { name: 'shop' },
+        { name: 'analytics' },
+      ],
+    });
+    const names = await makeDriver().getSchemas();
+    expect(names).toEqual(['analytics', 'shop']);
+  });
+});
+
+describe('MongoDBDriver – getSchema (field inference)', () => {
+  it('samples one document per collection and marks columns as inferred', async () => {
+    mockListCursor.toArray.mockResolvedValueOnce([
+      { name: 'users', type: 'collection' },
+      { name: 'orders_v', type: 'view' },
+    ]);
+
+    const usersColl = {
+      findOne: vi.fn().mockResolvedValueOnce({
+        _id: new ObjectIdCtor('aaaaaaaaaaaaaaaaaaaaaaaa'),
+        name: 'Ann',
+        age: 30,
+        joined: new Date('2024-01-01T00:00:00.000Z'),
+      }),
+      estimatedDocumentCount: vi.fn().mockResolvedValueOnce(7),
+    };
+    mockDb.collection.mockReturnValueOnce(usersColl as unknown as typeof mockCollection);
+
+    const schema = await makeDriver().getSchema('shop');
+    expect(schema.views).toEqual(['orders_v']);
+    expect(schema.tables).toHaveLength(1);
+    const t = schema.tables[0];
+    expect(t.name).toBe('users');
+    expect(t.rows).toBe(7);
+    expect(t.columns.every((c) => c.inferred === true)).toBe(true);
+    const cmap = Object.fromEntries(t.columns.map((c) => [c.name, c]));
+    expect(cmap['_id'].pk).toBe(true);
+    expect(cmap['_id'].dataType).toBe('objectId');
+    expect(cmap['name'].dataType).toBe('string');
+    expect(cmap['age'].dataType).toBe('int');
+    expect(cmap['joined'].dataType).toBe('date');
+  });
+
+  it('emits a placeholder _id column when a collection is empty', async () => {
+    mockListCursor.toArray.mockResolvedValueOnce([{ name: 'empty', type: 'collection' }]);
+    const emptyColl = {
+      findOne: vi.fn().mockResolvedValueOnce(null),
+      estimatedDocumentCount: vi.fn().mockResolvedValueOnce(0),
+    };
+    mockDb.collection.mockReturnValueOnce(emptyColl as unknown as typeof mockCollection);
+    const schema = await makeDriver().getSchema('shop');
+    expect(schema.tables[0].columns).toEqual([
+      expect.objectContaining({ name: '_id', pk: true, inferred: true }),
+    ]);
+  });
+});
+
+describe('MongoDBDriver – getTable', () => {
+  it('returns null when the collection does not exist', async () => {
+    mockListCursor.toArray.mockResolvedValueOnce([]);
+    const r = await makeDriver().getTable('shop', 'ghost');
+    expect(r).toBeNull();
+  });
+
+  it('returns inferred columns when the collection exists', async () => {
+    mockListCursor.toArray.mockResolvedValueOnce([{ name: 'users', type: 'collection' }]);
+    mockCollection.findOne.mockResolvedValueOnce({ name: 'X' });
+    mockCollection.estimatedDocumentCount.mockResolvedValueOnce(3);
+    const r = await makeDriver().getTable('shop', 'users');
+    expect(r?.name).toBe('users');
+    expect(r?.columns.find((c) => c.name === 'name')?.inferred).toBe(true);
+  });
+});
+
+describe('MongoDBDriver – getCollectionInfo', () => {
+  it('returns the validator and indexes', async () => {
+    mockListCursor.toArray.mockResolvedValueOnce([
+      { name: 'users', type: 'collection', options: { validator: { $jsonSchema: { bsonType: 'object' } } } },
+    ]);
+    mockCollection.indexes.mockResolvedValueOnce([
+      { v: 2, key: { _id: 1 }, name: '_id_' },
+      { v: 2, key: { email: 1 }, name: 'email_1', unique: true },
+    ]);
+    const r = await makeDriver().getCollectionInfo('shop', 'users');
+    expect(r.validator).toEqual({ $jsonSchema: { bsonType: 'object' } });
+    expect(r.indexes).toHaveLength(2);
+  });
+
+  it('returns null validator when none is set', async () => {
+    mockListCursor.toArray.mockResolvedValueOnce([{ name: 'users', type: 'collection', options: {} }]);
+    mockCollection.indexes.mockResolvedValueOnce([]);
+    const r = await makeDriver().getCollectionInfo('shop', 'users');
+    expect(r.validator).toBeNull();
+    expect(r.indexes).toEqual([]);
+  });
+});
+
+describe('MongoDBDriver – getTableDdl', () => {
+  it('throws — DDL is not applicable to document stores', async () => {
+    await expect(
+      makeDriver().getTableDdl('shop', 'users', 'table'),
+    ).rejects.toThrow(/getCollectionInfo/);
+  });
+});

--- a/server/src/drivers/mongodb.ts
+++ b/server/src/drivers/mongodb.ts
@@ -1,0 +1,370 @@
+import { MongoClient, ObjectId } from 'mongodb';
+import type { Db, Document } from 'mongodb';
+import type {
+  DbDriver,
+  ConnectionConfig,
+  QueryResult,
+  ColumnMeta,
+  ColumnInfo,
+  SchemaInfo,
+  TableInfo,
+  CollectionInfo,
+} from './interface.js';
+
+/**
+ * MQL request shape carried over the wire as a JSON string in `query()`'s `sql` arg.
+ * Routes serialize a request object into JSON; the driver parses and dispatches by `operation`.
+ */
+interface MqlRequest {
+  collection: string;
+  operation:
+    | 'find'
+    | 'findOne'
+    | 'aggregate'
+    | 'count'
+    | 'insertOne'
+    | 'updateOne'
+    | 'deleteOne';
+  filter?: Document;
+  pipeline?: Document[];
+  projection?: Document;
+  sort?: Document;
+  limit?: number;
+  skip?: number;
+  document?: Document;
+  update?: Document;
+  id?: unknown;
+}
+
+const SYSTEM_DBS = new Set(['admin', 'local', 'config']);
+
+function buildMongoUri(config: ConnectionConfig): string {
+  const auth =
+    config.user || config.password
+      ? `${encodeURIComponent(config.user)}:${encodeURIComponent(config.password)}@`
+      : '';
+  return `mongodb://${auth}${config.host}:${config.port}/`;
+}
+
+function serializeValue(val: unknown): unknown {
+  if (val === null || val === undefined) return null;
+  if (val instanceof ObjectId) return val.toHexString();
+  if (val instanceof Date) {
+    return val.toISOString().replace('T', ' ').replace(/\.\d{3}Z$/, '');
+  }
+  if (Buffer.isBuffer(val)) return val.toString('hex');
+  if (Array.isArray(val)) return val.map(serializeValue);
+  if (typeof val === 'bigint') return val.toString();
+  if (typeof val === 'object') {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(val as Record<string, unknown>)) {
+      out[k] = serializeValue(v);
+    }
+    return out;
+  }
+  return val;
+}
+
+function serializeDocument(doc: Document): Record<string, unknown> {
+  return serializeValue(doc) as Record<string, unknown>;
+}
+
+function inferDataType(val: unknown): string {
+  if (val === null || val === undefined) return 'null';
+  if (val instanceof ObjectId) return 'objectId';
+  if (val instanceof Date) return 'date';
+  if (Buffer.isBuffer(val)) return 'binData';
+  if (Array.isArray(val)) return 'array';
+  const t = typeof val;
+  if (t === 'string') return 'string';
+  if (t === 'number') return Number.isInteger(val) ? 'int' : 'double';
+  if (t === 'boolean') return 'bool';
+  if (t === 'bigint') return 'long';
+  if (t === 'object') return 'object';
+  return t;
+}
+
+function coerceIdFilter(id: unknown): Document {
+  if (typeof id === 'string' && /^[a-f0-9]{24}$/i.test(id)) {
+    return { _id: new ObjectId(id) };
+  }
+  return { _id: id } as Document;
+}
+
+function parseRequest(sql: string): MqlRequest {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(sql);
+  } catch {
+    throw new Error('MongoDB driver expects a JSON-encoded MQL request.');
+  }
+  if (!parsed || typeof parsed !== 'object') {
+    throw new Error('MongoDB driver expects a JSON-encoded MQL request.');
+  }
+  const req = parsed as MqlRequest;
+  if (!req.collection || typeof req.collection !== 'string') {
+    throw new Error('MQL request requires a "collection" field.');
+  }
+  if (!req.operation) {
+    throw new Error('MQL request requires an "operation" field.');
+  }
+  return req;
+}
+
+export class MongoDBDriver implements DbDriver {
+  readonly queryMode = 'mql' as const;
+  private client: MongoClient;
+  private defaultDb: string | undefined;
+  private connected = false;
+  private connectPromise: Promise<void> | null = null;
+
+  constructor(config: ConnectionConfig) {
+    this.client = new MongoClient(buildMongoUri(config), {
+      serverSelectionTimeoutMS: 10_000,
+      connectTimeoutMS: 10_000,
+      maxPoolSize: 5,
+    });
+    this.defaultDb = config.database || undefined;
+  }
+
+  escapeIdent(s: string): string {
+    return s;
+  }
+
+  rowLimitClause(_n: number): string {
+    return '';
+  }
+
+  private async ensureConnected(): Promise<void> {
+    if (this.connected) return;
+    if (!this.connectPromise) {
+      this.connectPromise = this.client.connect().then(
+        () => {
+          this.connected = true;
+        },
+        (err) => {
+          this.connectPromise = null;
+          throw err;
+        },
+      );
+    }
+    await this.connectPromise;
+  }
+
+  private db(schema?: string): Db {
+    const name = schema || this.defaultDb;
+    return name ? this.client.db(name) : this.client.db();
+  }
+
+  async ping(): Promise<void> {
+    await this.ensureConnected();
+    await this.client.db('admin').command({ ping: 1 });
+  }
+
+  async end(): Promise<void> {
+    if (this.connected || this.connectPromise) {
+      try {
+        await this.client.close();
+      } finally {
+        this.connected = false;
+        this.connectPromise = null;
+      }
+    }
+  }
+
+  async query(sql: string, _params?: unknown[], schema?: string): Promise<QueryResult> {
+    await this.ensureConnected();
+    const req = parseRequest(sql);
+    const db = this.db(schema);
+    const coll = db.collection(req.collection);
+
+    switch (req.operation) {
+      case 'find': {
+        let cursor = coll.find(req.filter ?? {});
+        if (req.projection) cursor = cursor.project(req.projection) as typeof cursor;
+        if (req.sort) cursor = cursor.sort(req.sort);
+        if (typeof req.skip === 'number') cursor = cursor.skip(req.skip);
+        if (typeof req.limit === 'number') cursor = cursor.limit(req.limit);
+        const docs = await cursor.toArray();
+        return this.toQueryResult(docs);
+      }
+      case 'findOne': {
+        const doc = await coll.findOne(req.filter ?? {}, {
+          projection: req.projection,
+          sort: req.sort as Document | undefined,
+        });
+        return this.toQueryResult(doc ? [doc] : []);
+      }
+      case 'aggregate': {
+        const docs = await coll.aggregate(req.pipeline ?? []).toArray();
+        return this.toQueryResult(docs);
+      }
+      case 'count': {
+        const n = await coll.countDocuments(req.filter ?? {});
+        return {
+          rows: [{ count: n }],
+          columnMeta: [
+            {
+              name: 'count', orgName: 'count', table: req.collection, orgTable: req.collection,
+              pk: false, unique: false, notNull: true, mysqlType: 0,
+            },
+          ],
+        };
+      }
+      case 'insertOne': {
+        if (!req.document) throw new Error('insertOne requires a "document" field.');
+        const result = await coll.insertOne(req.document);
+        return {
+          rows: [],
+          columnMeta: [],
+          affectedRows: result.acknowledged ? 1 : 0,
+          insertId: null,
+        };
+      }
+      case 'updateOne': {
+        if (!req.update) throw new Error('updateOne requires an "update" field.');
+        const filter =
+          req.id !== undefined ? coerceIdFilter(req.id) : (req.filter ?? {});
+        const result = await coll.updateOne(filter, req.update);
+        return {
+          rows: [],
+          columnMeta: [],
+          affectedRows: result.modifiedCount,
+          insertId: null,
+        };
+      }
+      case 'deleteOne': {
+        const filter =
+          req.id !== undefined ? coerceIdFilter(req.id) : (req.filter ?? {});
+        const result = await coll.deleteOne(filter);
+        return {
+          rows: [],
+          columnMeta: [],
+          affectedRows: result.deletedCount,
+          insertId: null,
+        };
+      }
+      default: {
+        throw new Error(`Unsupported MQL operation: ${String(req.operation)}`);
+      }
+    }
+  }
+
+  private toQueryResult(docs: Document[]): QueryResult {
+    const rows = docs.map(serializeDocument);
+    const colNames = new Set<string>();
+    for (const r of rows) for (const k of Object.keys(r)) colNames.add(k);
+    if (colNames.size === 0) colNames.add('_id');
+    const columnMeta: ColumnMeta[] = [...colNames].map((name) => ({
+      name,
+      orgName: name,
+      table: '',
+      orgTable: '',
+      pk: name === '_id',
+      unique: name === '_id',
+      notNull: name === '_id',
+      mysqlType: 0,
+    }));
+    return { rows, columnMeta };
+  }
+
+  async getSchemas(): Promise<string[]> {
+    await this.ensureConnected();
+    const result = await this.client.db('admin').admin().listDatabases();
+    return result.databases
+      .map((d) => d.name)
+      .filter((n) => !SYSTEM_DBS.has(n))
+      .sort();
+  }
+
+  async getSchema(schema: string): Promise<SchemaInfo> {
+    await this.ensureConnected();
+    const db = this.db(schema);
+    const collections = await db.listCollections({}, { nameOnly: false }).toArray();
+    const baseCollections = collections.filter((c) => c.type !== 'view');
+    const views = collections.filter((c) => c.type === 'view').map((c) => c.name);
+
+    const tables: TableInfo[] = await Promise.all(
+      baseCollections.map(async (c) => {
+        const coll = db.collection(c.name);
+        const [sample, count] = await Promise.all([
+          coll.findOne({}),
+          coll.estimatedDocumentCount().catch(() => 0),
+        ]);
+        return {
+          name: c.name,
+          rows: count,
+          comment: '',
+          columns: this.inferColumns(sample),
+        };
+      }),
+    );
+
+    return {
+      tables,
+      views,
+      procedures: [],
+      triggers: [],
+    };
+  }
+
+  async getTable(schema: string, table: string): Promise<TableInfo | null> {
+    await this.ensureConnected();
+    const db = this.db(schema);
+    const list = await db.listCollections({ name: table }, { nameOnly: false }).toArray();
+    if (list.length === 0) return null;
+    const coll = db.collection(table);
+    const [sample, count] = await Promise.all([
+      coll.findOne({}),
+      coll.estimatedDocumentCount().catch(() => 0),
+    ]);
+    return {
+      name: table,
+      rows: count,
+      comment: '',
+      columns: this.inferColumns(sample),
+    };
+  }
+
+  private inferColumns(sample: Document | null): ColumnInfo[] {
+    if (!sample) {
+      return [
+        {
+          name: '_id', type: 'objectId', dataType: 'objectId',
+          pk: true, nullable: false, default: null, autoIncrement: false,
+          comment: '', inferred: true,
+        },
+      ];
+    }
+    return Object.keys(sample).map((name) => {
+      const dataType = inferDataType(sample[name]);
+      return {
+        name,
+        type: dataType,
+        dataType,
+        pk: name === '_id',
+        nullable: name !== '_id',
+        default: null,
+        autoIncrement: false,
+        comment: '',
+        inferred: true,
+      };
+    });
+  }
+
+  async getTableDdl(_schema: string, _table: string, _type: 'table' | 'view' | 'procedure' | 'trigger'): Promise<string> {
+    throw new Error('MongoDB driver does not produce SQL DDL; use getCollectionInfo instead.');
+  }
+
+  async getCollectionInfo(schema: string, collection: string): Promise<CollectionInfo> {
+    await this.ensureConnected();
+    const db = this.db(schema);
+    const list = await db.listCollections({ name: collection }, { nameOnly: false }).toArray();
+    const validator = (() => {
+      const opts = list[0]?.options as { validator?: Record<string, unknown> } | undefined;
+      return opts?.validator ?? null;
+    })();
+    const indexes = (await db.collection(collection).indexes()) as Record<string, unknown>[];
+    return { validator, indexes };
+  }
+}

--- a/server/src/drivers/mongodb.ts
+++ b/server/src/drivers/mongodb.ts
@@ -39,9 +39,11 @@ interface MqlRequest {
 const SYSTEM_DBS = new Set(['admin', 'local', 'config']);
 
 function buildMongoUri(config: ConnectionConfig): string {
+  const user = config.user ?? '';
+  const password = config.password ?? '';
   const auth =
-    config.user || config.password
-      ? `${encodeURIComponent(config.user)}:${encodeURIComponent(config.password)}@`
+    user || password
+      ? `${encodeURIComponent(user)}:${encodeURIComponent(password)}@`
       : '';
   return `mongodb://${auth}${config.host}:${config.port}/`;
 }
@@ -50,6 +52,9 @@ function serializeValue(val: unknown): unknown {
   if (val === null || val === undefined) return null;
   if (val instanceof ObjectId) return val.toHexString();
   if (val instanceof Date) {
+    // toISOString is always UTC, so the rendered string is timezone-stable
+    // regardless of process TZ. We deliberately drop the trailing "Z" / millis
+    // to match the SQL drivers' DATETIME-style output.
     return val.toISOString().replace('T', ' ').replace(/\.\d{3}Z$/, '');
   }
   if (Buffer.isBuffer(val)) return val.toString('hex');
@@ -84,11 +89,21 @@ function inferDataType(val: unknown): string {
   return t;
 }
 
+// TODO(#107 follow-up): drive _id coercion from column metadata once routes
+// pass it. Today we treat any 24-hex string as an ObjectId, which has
+// false-positive risk for app-generated ids that happen to match the shape;
+// callers compensate by retrying with the raw string when an ObjectId match
+// affects 0 rows (see coerceIdFilterFallback).
 function coerceIdFilter(id: unknown): Document {
   if (typeof id === 'string' && /^[a-f0-9]{24}$/i.test(id)) {
     return { _id: new ObjectId(id) };
   }
   return { _id: id } as Document;
+}
+
+/** True when coerceIdFilter promoted a string id to an ObjectId. */
+function idWasCoercedToObjectId(id: unknown): boolean {
+  return typeof id === 'string' && /^[a-f0-9]{24}$/i.test(id);
 }
 
 function parseRequest(sql: string): MqlRequest {
@@ -223,20 +238,31 @@ export class MongoDBDriver implements DbDriver {
       }
       case 'updateOne': {
         if (!req.update) throw new Error('updateOne requires an "update" field.');
-        const filter =
-          req.id !== undefined ? coerceIdFilter(req.id) : (req.filter ?? {});
-        const result = await coll.updateOne(filter, req.update);
+        const useId = req.id !== undefined;
+        const filter = useId ? coerceIdFilter(req.id) : (req.filter ?? {});
+        let result = await coll.updateOne(filter, req.update);
+        // Graceful fallback: if we promoted a 24-hex string to ObjectId and
+        // matched nothing, retry with the raw string id.
+        if (useId && result.matchedCount === 0 && idWasCoercedToObjectId(req.id)) {
+          result = await coll.updateOne({ _id: req.id } as Document, req.update);
+        }
+        // Use matchedCount, not modifiedCount: routes treat affectedRows === 0
+        // as "row not found" (404). A no-op update (matched but unchanged) must
+        // not be reported as missing.
         return {
           rows: [],
           columnMeta: [],
-          affectedRows: result.modifiedCount,
+          affectedRows: result.matchedCount,
           insertId: null,
         };
       }
       case 'deleteOne': {
-        const filter =
-          req.id !== undefined ? coerceIdFilter(req.id) : (req.filter ?? {});
-        const result = await coll.deleteOne(filter);
+        const useId = req.id !== undefined;
+        const filter = useId ? coerceIdFilter(req.id) : (req.filter ?? {});
+        let result = await coll.deleteOne(filter);
+        if (useId && result.deletedCount === 0 && idWasCoercedToObjectId(req.id)) {
+          result = await coll.deleteOne({ _id: req.id } as Document);
+        }
         return {
           rows: [],
           columnMeta: [],
@@ -270,7 +296,7 @@ export class MongoDBDriver implements DbDriver {
 
   async getSchemas(): Promise<string[]> {
     await this.ensureConnected();
-    const result = await this.client.db('admin').admin().listDatabases();
+    const result = await this.client.db().admin().listDatabases();
     return result.databases
       .map((d) => d.name)
       .filter((n) => !SYSTEM_DBS.has(n))
@@ -284,6 +310,9 @@ export class MongoDBDriver implements DbDriver {
     const baseCollections = collections.filter((c) => c.type !== 'view');
     const views = collections.filter((c) => c.type === 'view').map((c) => c.name);
 
+    // Best-effort field inference: we sample a single document and mark every
+    // column inferred:true. Fields that appear only on later documents are
+    // invisible to this pass. Tracked in #118 (union-of-keys sampling).
     const tables: TableInfo[] = await Promise.all(
       baseCollections.map(async (c) => {
         const coll = db.collection(c.name);
@@ -356,14 +385,13 @@ export class MongoDBDriver implements DbDriver {
     throw new Error('MongoDB driver does not produce SQL DDL; use getCollectionInfo instead.');
   }
 
-  async getCollectionInfo(schema: string, collection: string): Promise<CollectionInfo> {
+  async getCollectionInfo(schema: string, collection: string): Promise<CollectionInfo | null> {
     await this.ensureConnected();
     const db = this.db(schema);
     const list = await db.listCollections({ name: collection }, { nameOnly: false }).toArray();
-    const validator = (() => {
-      const opts = list[0]?.options as { validator?: Record<string, unknown> } | undefined;
-      return opts?.validator ?? null;
-    })();
+    if (list.length === 0) return null;
+    const opts = list[0]?.options as { validator?: Record<string, unknown> } | undefined;
+    const validator = opts?.validator ?? null;
     const indexes = (await db.collection(collection).indexes()) as Record<string, unknown>[];
     return { validator, indexes };
   }


### PR DESCRIPTION
## Summary

Implements the MongoDB-backed `DbDriver` introduced as an interface in #116 (PR #105/#106 foundation). This is a pure backend, additive change — no routes or UI are wired yet (those land in #108–#115).

`server/src/drivers/mongodb.ts` exposes:

- `queryMode = 'mql'` — routes will branch on this to validate body shape
- `connect` / `disconnect` via `MongoClient.connect()` / `client.close()`
- `ping` via `db('admin').command({ ping: 1 })`
- `getSchemas` via `admin.listDatabases()`, filtering out `admin` / `local` / `config`
- `getSchema` / `getTable` via `db.listCollections()` + per-collection `findOne()` to infer fields (`inferred: true`)
- `query` accepting a JSON-encoded MQL request `{ collection, operation, filter, pipeline, ... }` dispatched to `find`, `findOne`, `aggregate`, `count`, `insertOne`, `updateOne`, `deleteOne`. ObjectId and Date are serialized for JSON transport.
- `getCollectionInfo` returning `{ validator, indexes }`
- `escapeIdent` is the identity function; `rowLimitClause` returns `''`
- `getTableDdl` throws — DDL doesn't apply to document stores

Also extends `ColumnInfo` with an optional `inferred?: boolean` flag (used by `MongoDBDriver`, ignored by the SQL drivers).

## Acceptance criteria

- [x] `connect` / `disconnect` use `MongoClient.connect()` / `client.close()`
- [x] `ping` uses `db.admin().ping()` (implemented as `db('admin').command({ ping: 1 })` — the supported v7 form)
- [x] `getSchemas` uses `admin.listDatabases()`, filtering `admin`/`local`/`config`
- [x] `getSchema` lists collections and infers fields by sampling one document; columns marked `inferred: true`
- [x] Schema selection at the driver-object level (`client.db(dbName)`), not per-query
- [x] `query` accepts a MQL request and returns a normalized `QueryResult`
- [x] `getCollectionInfo` returns the collection validator and `collection.indexes()`
- [x] `insertOne` / `updateOne({_id})` / `deleteOne({_id})` supported via the `query` MQL operation dispatch (the AC mentions `insertRow`/`updateCell`/`deleteRow` — those are route-layer methods that will call into `query` once #108–#115 wire them up)
- [x] `escapeIdent` is the identity function
- [x] No client leaks — `end()` closes the client; failed `connect()` clears the in-flight promise so retries work
- [x] Unit test coverage for release-on-error parity (35 tests)

## Test plan

- [x] `cd server && npm run build` clean
- [x] `cd server && npm test` — 57/57 pass (35 new for the mongo driver)
- [ ] No browser verification: driver isn't wired to any route yet (deferred to #108)
- [ ] Reviewer: confirm the JSON-encoded MQL request shape is what #108 will produce

Closes #107.