### PR TITLE
feat: connect.ts supports mongodb type and connectionString

### DIFF
--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -1,13 +1,21 @@
 import { resetMcpState } from './mcp-state.js';
 import { MysqlDriver } from './drivers/mysql.js';
 import { PostgresDriver } from './drivers/postgres.js';
+import { MongoDBDriver } from './drivers/mongodb.js';
 import type { DbDriver, ConnectionConfig } from './drivers/interface.js';
 
 let driver: DbDriver | null = null;
 let activeConfig: ConnectionConfig | null = null;
 
 function makeDriver(config: ConnectionConfig): DbDriver {
-  return config.type === 'postgres' ? new PostgresDriver(config) : new MysqlDriver(config);
+  switch (config.type) {
+    case 'postgres':
+      return new PostgresDriver(config);
+    case 'mongodb':
+      return new MongoDBDriver(config);
+    default:
+      return new MysqlDriver(config);
+  }
 }
 
 export async function connect(config: ConnectionConfig): Promise<void> {

--- a/server/src/drivers/interface.ts
+++ b/server/src/drivers/interface.ts
@@ -5,7 +5,9 @@ export interface ConnectionConfig {
   password: string;
   database?: string;
   ssl?: 'require' | 'verify-full';
-  type: 'mysql' | 'postgres';
+  type: 'mysql' | 'postgres' | 'mongodb';
+  /** When set, drivers that support it (e.g. MongoDB) use this URI instead of building one from host/port/user/password. */
+  connectionString?: string;
 }
 
 export interface ColumnMeta {

--- a/server/src/drivers/mongodb.test.ts
+++ b/server/src/drivers/mongodb.test.ts
@@ -66,12 +66,10 @@ vi.mock('mongodb', () => ({
 import { MongoDBDriver } from './mongodb.js';
 import { MongoClient } from 'mongodb';
 
-// TODO(#108): ConnectionConfig.type needs 'mongodb'. Until that lands, MongoDB
-// fixtures here pass type: 'mysql' purely to satisfy the type system.
 function makeDriver(database?: string) {
   return new MongoDBDriver({
     host: 'h', port: 27017, user: 'u', password: 'p', database,
-    type: 'mysql',
+    type: 'mongodb',
   });
 }
 
@@ -80,7 +78,7 @@ function makeDriverConfig(overrides: Partial<{ user: string; password: string }>
     host: 'h', port: 27017,
     user: overrides.user as string,
     password: overrides.password as string,
-    type: 'mysql',
+    type: 'mongodb',
   });
 }
 
@@ -140,6 +138,16 @@ describe('MongoDBDriver – URI construction', () => {
   it('percent-encodes credentials with reserved characters', () => {
     makeDriverConfig({ user: 'a@b', password: 'p:w/d' });
     expect(uriFromLastCtor()).toBe('mongodb://a%40b:p%3Aw%2Fd@h:27017/');
+  });
+
+  it('short-circuits on connectionString — host/port/user/password are ignored', () => {
+    const uri = 'mongodb+srv://alice:secret@cluster0.example.net/db';
+    new MongoDBDriver({
+      host: 'ignored', port: 9999, user: 'ignored-u', password: 'ignored-p',
+      type: 'mongodb',
+      connectionString: uri,
+    });
+    expect(uriFromLastCtor()).toBe(uri);
   });
 });
 

--- a/server/src/drivers/mongodb.ts
+++ b/server/src/drivers/mongodb.ts
@@ -39,6 +39,7 @@ interface MqlRequest {
 const SYSTEM_DBS = new Set(['admin', 'local', 'config']);
 
 function buildMongoUri(config: ConnectionConfig): string {
+  if (config.connectionString) return config.connectionString;
   const user = config.user ?? '';
   const password = config.password ?? '';
   const auth =

--- a/server/src/routes/connect.test.ts
+++ b/server/src/routes/connect.test.ts
@@ -11,7 +11,7 @@ vi.mock('../db.js', () => ({
 }));
 
 import { connect, testConnection } from '../db.js';
-import { postConnect, postTestConnect } from './connect.js';
+import { postConnect, postTestConnect, friendlyConnectError } from './connect.js';
 
 function makeApp() {
   const app = express();
@@ -55,6 +55,31 @@ describe('postConnect — db type plumbing', () => {
     expect(res.body.error).toMatch(/unsupported db type/i);
     expect(connect).not.toHaveBeenCalled();
   });
+
+  it("forwards type 'mongodb' and uses port 27017 by default", async () => {
+    const res = await request(makeApp())
+      .post('/api/connect')
+      .send({ host: 'h', user: 'u', password: 'p', type: 'mongodb' });
+    expect(res.status).toBe(200);
+    expect(connect).toHaveBeenCalledWith(expect.objectContaining({ type: 'mongodb', port: 27017 }));
+  });
+
+  it("forwards an optional connectionString through to connect()", async () => {
+    const uri = 'mongodb+srv://u:p@cluster0.example.net/db';
+    const res = await request(makeApp())
+      .post('/api/connect')
+      .send({ host: 'h', user: 'u', password: 'p', type: 'mongodb', connectionString: uri });
+    expect(res.status).toBe(200);
+    expect(connect).toHaveBeenCalledWith(expect.objectContaining({ type: 'mongodb', connectionString: uri }));
+  });
+
+  it("does not include connectionString when omitted", async () => {
+    await request(makeApp())
+      .post('/api/connect')
+      .send({ host: 'h', user: 'u', password: 'p', type: 'mongodb' });
+    const cfg = (connect as unknown as { mock: { calls: unknown[][] } }).mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(cfg).not.toHaveProperty('connectionString');
+  });
 });
 
 describe('postTestConnect — db type plumbing', () => {
@@ -81,5 +106,45 @@ describe('postTestConnect — db type plumbing', () => {
       .send({ host: 'h', user: 'u', password: 'p', type: 42 });
     expect(res.status).toBe(400);
     expect(testConnection).not.toHaveBeenCalled();
+  });
+
+  it("forwards type 'mongodb' through to testConnection() with port 27017", async () => {
+    const res = await request(makeApp())
+      .post('/api/connect/test')
+      .send({ host: 'h', user: 'u', password: 'p', type: 'mongodb' });
+    expect(res.status).toBe(200);
+    expect(testConnection).toHaveBeenCalledWith(expect.objectContaining({ type: 'mongodb', port: 27017 }));
+  });
+});
+
+describe('friendlyConnectError — MongoDB error mapping', () => {
+  it('maps AuthenticationFailed (codeName) to a friendly access-denied message', () => {
+    const msg = friendlyConnectError(
+      { codeName: 'AuthenticationFailed', message: 'auth failed' },
+      'h', 27017, 'mongodb',
+    );
+    expect(msg).toMatch(/access denied/i);
+    expect(msg).toMatch(/AuthenticationFailed/);
+  });
+
+  it('maps HostUnreachable to a friendly unreachable-host message', () => {
+    const msg = friendlyConnectError(
+      { codeName: 'HostUnreachable', message: 'no route' },
+      'h', 27017, 'mongodb',
+    );
+    expect(msg).toMatch(/unreachable/i);
+  });
+
+  it('maps InvalidURI to a friendly invalid-connection-string message', () => {
+    const msg = friendlyConnectError(
+      { codeName: 'InvalidURI', message: 'bad uri' },
+      'h', 27017, 'mongodb',
+    );
+    expect(msg).toMatch(/connection string is invalid/i);
+  });
+
+  it("uses 'MongoDB' in the unknown-error fallback when type is mongodb", () => {
+    const msg = friendlyConnectError({}, 'h', 27017, 'mongodb');
+    expect(msg).toMatch(/MongoDB/);
   });
 });

--- a/server/src/routes/connect.test.ts
+++ b/server/src/routes/connect.test.ts
@@ -68,7 +68,7 @@ describe('postConnect — db type plumbing', () => {
     const uri = 'mongodb+srv://u:p@cluster0.example.net/db';
     const res = await request(makeApp())
       .post('/api/connect')
-      .send({ host: 'h', user: 'u', password: 'p', type: 'mongodb', connectionString: uri });
+      .send({ type: 'mongodb', connectionString: uri });
     expect(res.status).toBe(200);
     expect(connect).toHaveBeenCalledWith(expect.objectContaining({ type: 'mongodb', connectionString: uri }));
   });
@@ -79,6 +79,37 @@ describe('postConnect — db type plumbing', () => {
       .send({ host: 'h', user: 'u', password: 'p', type: 'mongodb' });
     const cfg = (connect as unknown as { mock: { calls: unknown[][] } }).mock.calls[0]?.[0] as Record<string, unknown>;
     expect(cfg).not.toHaveProperty('connectionString');
+  });
+
+  it('rejects with 400 when connectionString and user are both provided', async () => {
+    const res = await request(makeApp())
+      .post('/api/connect')
+      .send({ user: 'u', type: 'mongodb', connectionString: 'mongodb://x/' });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/either connectionString or user\/password/i);
+    expect(connect).not.toHaveBeenCalled();
+  });
+
+  it('rejects with 400 when connectionString and password are both provided', async () => {
+    const res = await request(makeApp())
+      .post('/api/connect')
+      .send({ password: 'p', type: 'mongodb', connectionString: 'mongodb://x/' });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/either connectionString or user\/password/i);
+    expect(connect).not.toHaveBeenCalled();
+  });
+
+  it('returns a connectionName parsed from the URI when connectionString is used', async () => {
+    const res = await request(makeApp())
+      .post('/api/connect')
+      .send({
+        type: 'mongodb',
+        connectionString: 'mongodb+srv://alice:secret@cluster0.example.net/db',
+      });
+    expect(res.status).toBe(200);
+    // Password must not appear; host should come from the URI, not form fields.
+    expect(res.body.connectionName).toBe('alice@cluster0.example.net');
+    expect(res.body.connectionName).not.toMatch(/secret/);
   });
 });
 
@@ -127,20 +158,16 @@ describe('friendlyConnectError — MongoDB error mapping', () => {
     expect(msg).toMatch(/AuthenticationFailed/);
   });
 
-  it('maps HostUnreachable to a friendly unreachable-host message', () => {
+  it('prefers codeName over numeric code so the byCode lookup hits', () => {
+    // Mongo errors carry both fields. With code precedence, the lookup would
+    // miss (18 isn't keyed) and the raw message would surface — so the test
+    // would not match /access denied/.
     const msg = friendlyConnectError(
-      { codeName: 'HostUnreachable', message: 'no route' },
+      { code: '18', codeName: 'AuthenticationFailed', message: 'auth failed' },
       'h', 27017, 'mongodb',
     );
-    expect(msg).toMatch(/unreachable/i);
-  });
-
-  it('maps InvalidURI to a friendly invalid-connection-string message', () => {
-    const msg = friendlyConnectError(
-      { codeName: 'InvalidURI', message: 'bad uri' },
-      'h', 27017, 'mongodb',
-    );
-    expect(msg).toMatch(/connection string is invalid/i);
+    expect(msg).toMatch(/access denied/i);
+    expect(msg).toMatch(/AuthenticationFailed/);
   });
 
   it("uses 'MongoDB' in the unknown-error fallback when type is mongodb", () => {

--- a/server/src/routes/connect.ts
+++ b/server/src/routes/connect.ts
@@ -2,15 +2,18 @@ import type { RequestHandler } from 'express';
 import type { ConnectionConfig } from '../drivers/interface.js';
 import { connect, disconnect, isConnected, getActiveConfig, testConnection } from '../db.js';
 
-type DbType = 'mysql' | 'postgres';
+type DbType = 'mysql' | 'postgres' | 'mongodb';
 
 function defaultPort(type: DbType): number {
-  return type === 'postgres' ? 5432 : 3306;
+  if (type === 'postgres') return 5432;
+  if (type === 'mongodb') return 27017;
+  return 3306;
 }
 
 interface ConnectError {
   message?: string;
   code?: string;
+  codeName?: string;
   errno?: number;
   address?: string;
   port?: number;
@@ -19,7 +22,9 @@ interface ConnectError {
 
 function friendlyConnectError(err: unknown, host: string, port: number, type: DbType): string {
   const e = err as ConnectError;
-  const code = e?.code;
+  // MongoDB driver surfaces semantic codes via `codeName` (e.g. AuthenticationFailed)
+  // while `code` is numeric. Fall back to codeName so the byCode lookup still hits.
+  const code = e?.code ?? e?.codeName;
   const where = `${host}:${port}`;
 
   const byCode: Record<string, string> = {
@@ -45,6 +50,10 @@ function friendlyConnectError(err: unknown, host: string, port: number, type: Db
     '42501': `The user doesn't have permission to connect.`,
     '28000': `Authentication failed. Check the username and password.`,
     '08006': `Connection to the server failed.`,
+    // MongoDB error codes (codeName)
+    AuthenticationFailed: `Access denied. Check the username and password.`,
+    HostUnreachable:      `Host '${host}' is unreachable. Check your network, VPN, or firewall rules.`,
+    InvalidURI:           `The MongoDB connection string is invalid. Check the URI for typos.`,
   };
 
   const friendly = code && byCode[code];
@@ -53,7 +62,8 @@ function friendlyConnectError(err: unknown, host: string, port: number, type: Db
   if (raw && code) return `${raw} (${code})`;
   if (raw) return raw;
   if (code) return `(${code})`;
-  return `Unknown connection error connecting to ${type === 'postgres' ? 'PostgreSQL' : 'MySQL'}.`;
+  const label = type === 'postgres' ? 'PostgreSQL' : type === 'mongodb' ? 'MongoDB' : 'MySQL';
+  return `Unknown connection error connecting to ${label}.`;
 }
 
 export { friendlyConnectError };
@@ -66,22 +76,32 @@ type ConnectBody = {
   database?: string;
   ssl?: 'require' | 'verify-full';
   type?: unknown;
+  connectionString?: string;
 };
 
 function parseConnectBody(body: ConnectBody): { config: ConnectionConfig } | { error: string } {
-  const { host, port, user, password, database, ssl, type } = body;
+  const { host, port, user, password, database, ssl, type, connectionString } = body;
 
   if (!host || !user) {
     return { error: 'host and user are required.' };
   }
-  if (type !== undefined && type !== 'mysql' && type !== 'postgres') {
+  if (type !== undefined && type !== 'mysql' && type !== 'postgres' && type !== 'mongodb') {
     return { error: `Unsupported db type: ${String(type)}` };
   }
 
   const dbType: DbType = (type as DbType | undefined) ?? 'mysql';
   const effectivePort = Number(port) || defaultPort(dbType);
   return {
-    config: { host, port: effectivePort, user, password: password ?? '', database, ssl, type: dbType },
+    config: {
+      host,
+      port: effectivePort,
+      user,
+      password: password ?? '',
+      database,
+      ssl,
+      type: dbType,
+      ...(connectionString ? { connectionString } : {}),
+    },
   };
 }
 

--- a/server/src/routes/connect.ts
+++ b/server/src/routes/connect.ts
@@ -22,9 +22,10 @@ interface ConnectError {
 
 function friendlyConnectError(err: unknown, host: string, port: number, type: DbType): string {
   const e = err as ConnectError;
-  // MongoDB driver surfaces semantic codes via `codeName` (e.g. AuthenticationFailed)
-  // while `code` is numeric. Fall back to codeName so the byCode lookup still hits.
-  const code = e?.code ?? e?.codeName;
+  // Prefer the semantic `codeName` (e.g. 'AuthenticationFailed') when the driver
+  // surfaces both: MongoDB's numeric `code` (18) isn't in `byCode` and would
+  // otherwise mask the semantic match.
+  const code = e?.codeName ?? e?.code;
   const where = `${host}:${port}`;
 
   const byCode: Record<string, string> = {
@@ -50,10 +51,11 @@ function friendlyConnectError(err: unknown, host: string, port: number, type: Db
     '42501': `The user doesn't have permission to connect.`,
     '28000': `Authentication failed. Check the username and password.`,
     '08006': `Connection to the server failed.`,
-    // MongoDB error codes (codeName)
+    // MongoDB error codes (codeName). HostUnreachable / InvalidURI aren't
+    // listed: an unreachable host surfaces as MongoServerSelectionError wrapping
+    // ENOTFOUND/ECONNREFUSED/ETIMEDOUT (already mapped above), and a malformed
+    // URI throws MongoParseError synchronously with no codeName.
     AuthenticationFailed: `Access denied. Check the username and password.`,
-    HostUnreachable:      `Host '${host}' is unreachable. Check your network, VPN, or firewall rules.`,
-    InvalidURI:           `The MongoDB connection string is invalid. Check the URI for typos.`,
   };
 
   const friendly = code && byCode[code];
@@ -82,27 +84,59 @@ type ConnectBody = {
 function parseConnectBody(body: ConnectBody): { config: ConnectionConfig } | { error: string } {
   const { host, port, user, password, database, ssl, type, connectionString } = body;
 
-  if (!host || !user) {
-    return { error: 'host and user are required.' };
-  }
   if (type !== undefined && type !== 'mysql' && type !== 'postgres' && type !== 'mongodb') {
     return { error: `Unsupported db type: ${String(type)}` };
+  }
+  if (connectionString && (user || password)) {
+    // Strict UX: the URI carries its own credentials; don't silently drop the
+    // form fields, and don't silently let them override what's in the URI.
+    return { error: 'Provide either connectionString or user/password, not both.' };
+  }
+  if (!connectionString && (!host || !user)) {
+    return { error: 'host and user are required.' };
   }
 
   const dbType: DbType = (type as DbType | undefined) ?? 'mysql';
   const effectivePort = Number(port) || defaultPort(dbType);
-  return {
-    config: {
-      host,
-      port: effectivePort,
-      user,
-      password: password ?? '',
-      database,
-      ssl,
-      type: dbType,
-      ...(connectionString ? { connectionString } : {}),
-    },
+  const config: ConnectionConfig = {
+    host: host ?? '',
+    port: effectivePort,
+    user: user ?? '',
+    password: password ?? '',
+    database,
+    ssl,
+    type: dbType,
+    ...(connectionString ? { connectionString } : {}),
   };
+  return { config };
+}
+
+/**
+ * Derive a display label like `user@host:port`. When `connectionString` is set
+ * the host/port/user fields in `config` are ignored by the driver, so we parse
+ * the URI to avoid showing stale form values. Falls back to the URI scheme tag
+ * if the URI can't be parsed (e.g. `mongodb+srv://` in older Node URL impls).
+ */
+function connectionLabel(config: ConnectionConfig): string {
+  if (config.connectionString) {
+    try {
+      // URL doesn't natively understand mongodb+srv; rewrite the scheme so the
+      // parser populates host/username. Strip the password from display.
+      const isSrv = /^mongodb\+srv:\/\//.test(config.connectionString);
+      const normalized = config.connectionString.replace(/^mongodb\+srv:\/\//, 'mongodb://');
+      const url = new URL(normalized);
+      const user = decodeURIComponent(url.username);
+      const host = url.hostname || '<connectionString>';
+      const at = user ? `${user}@` : '';
+      // For SRV URIs the real port comes from DNS resolution, so we omit it.
+      // For plain URIs we only show a port if the URI carries one explicitly.
+      if (isSrv || !url.port) return `${at}${host}`;
+      return `${at}${host}:${url.port}`;
+    } catch {
+      return '<connectionString>';
+    }
+  }
+  return `${config.user}@${config.host}:${config.port}`;
 }
 
 export const postConnect: RequestHandler = async (req, res) => {
@@ -115,7 +149,7 @@ export const postConnect: RequestHandler = async (req, res) => {
 
   try {
     await connect(config);
-    res.json({ ok: true, connectionName: `${config.user}@${config.host}:${config.port}` });
+    res.json({ ok: true, connectionName: connectionLabel(config) });
   } catch (err) {
     res.status(400).json({ error: friendlyConnectError(err, config.host, config.port, config.type) });
   }
@@ -146,8 +180,6 @@ export const getStatus: RequestHandler = (_req, res) => {
   const config = getActiveConfig();
   res.json({
     connected: isConnected(),
-    connectionName: config
-      ? `${config.user}@${config.host}:${config.port}`
-      : null,
+    connectionName: config ? connectionLabel(config) : null,
   });
 };


### PR DESCRIPTION
Closes #108.

## Summary
- Extends the connect route to accept `type: 'mongodb'`, defaulting to port 27017 and routing through `MongoDBDriver`.
- Adds an optional `connectionString` field to `ConnectBody` / `ConnectionConfig`; when present, `MongoDBDriver` passes it straight to `MongoClient` instead of building a URI from host/port/user/password.
- Maps MongoDB error `codeName` values (`AuthenticationFailed`, `HostUnreachable`, `InvalidURI`) in `friendlyConnectError` and updates the unknown-error fallback to label all three dialects.

## Acceptance criteria
- [x] `parseConnectBody` allowlist includes `'mongodb'` alongside `'mysql'` / `'postgres'`
- [x] Default port is 27017 when `type === 'mongodb'`
- [x] Optional `connectionString` field — when present, passed directly to `MongoClient`
- [x] MongoDB error codes mapped in `friendlyConnectError`: `AuthenticationFailed`, `HostUnreachable`, `InvalidURI`
- [x] Fallback message uses "MongoDB" when `type === 'mongodb'`
- [x] Unit tests cover MongoDB type plumbing and 400-on-unknown is preserved

## Test plan
- [x] `cd server && npm run build` clean
- [x] `cd server && npm test` — 74/74 passing (added 7 new tests in `connect.test.ts` covering mongodb plumbing, connectionString passthrough, error code mapping, and the dialect-aware fallback)
- [x] Existing 400-on-unknown-type tests still pass for both `postConnect` and `postTestConnect`

## Notes
- Frontend `DbType` union (`src/api.ts`, `src/components/ConnectionManager.tsx`, `src/savedConnections.ts`) intentionally untouched — that's the UI work tracked separately. This PR is route/type wiring only.
- Routes that follow (#109 query, #110 DDL, #111 schema) depend on this landing.