### PR TITLE
feat: savedConnections - add mongodb type and connectionString (#112)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -119,6 +119,7 @@ export default function App() {
           ssl: form.ssl,
           sslVerify: form.sslVerify,
           savePassword: form.savePassword,
+          ...(form.connectionString ? { connectionString: form.connectionString } : {}),
         });
         if (electronAPI) {
           if (form.savePassword && form.password) {

--- a/src/api.ts
+++ b/src/api.ts
@@ -54,7 +54,7 @@ async function request<T>(path: string, init?: RequestInit): Promise<T> {
 }
 
 export const api = {
-  connect(form: { type: 'mysql' | 'postgres'; host: string; port: string; user: string; password: string; database: string; ssl: boolean; sslVerify: boolean }) {
+  connect(form: { type: 'mysql' | 'postgres'; host: string; port: string; user: string; password: string; database: string; ssl: boolean; sslVerify: boolean; connectionString?: string }) {
     const { ssl, sslVerify, ...rest } = form;
     const sslMode = !ssl ? undefined : sslVerify ? 'verify-full' : 'require';
     return request<{ ok: boolean; connectionName: string }>('/api/connect', {

--- a/src/components/ConnectionManager.tsx
+++ b/src/components/ConnectionManager.tsx
@@ -30,8 +30,9 @@ interface ConnectionManagerProps {
 
 export function ConnectionManager({ onConnect, isConnecting, error, onDismiss, t }: ConnectionManagerProps) {
   const [saved, setSaved] = useState<SavedConnection[]>(() => listSavedConnections());
+  const formType = (t: SavedConnection['type']): 'mysql' | 'postgres' => t === 'postgres' ? 'postgres' : 'mysql';
   const initialForm: ConnectionForm = saved[0]
-    ? { ...saved[0], type: saved[0].type ?? 'mysql', password: '', sslVerify: saved[0].sslVerify ?? false, savePassword: saved[0].savePassword ?? false }
+    ? { ...saved[0], type: formType(saved[0].type), password: '', sslVerify: saved[0].sslVerify ?? false, savePassword: saved[0].savePassword ?? false }
     : {
         name: 'Local MySQL',
         type: 'mysql',
@@ -110,7 +111,7 @@ export function ConnectionManager({ onConnect, isConnecting, error, onDismiss, t
   };
 
   const applySaved = (entry: SavedConnection) => {
-    setForm({ ...entry, type: entry.type ?? 'mysql', password: '', sslVerify: entry.sslVerify ?? false, savePassword: entry.savePassword ?? false });
+    setForm({ ...entry, type: formType(entry.type), password: '', sslVerify: entry.sslVerify ?? false, savePassword: entry.savePassword ?? false });
     setAppliedSaved(entry.name);
     setSuggestOpen(false);
     if (entry.savePassword && electronAPI) {

--- a/src/components/ConnectionManager.tsx
+++ b/src/components/ConnectionManager.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import type { CSSProperties } from 'react';
 import type { Theme } from '../theme';
 import { api } from '../api';
@@ -18,6 +18,10 @@ export interface ConnectionForm {
   // Only meaningful in Electron — when true, the password is persisted via
   // safeStorage and reloaded the next time this connection is opened.
   savePassword: boolean;
+  // Opaque pass-through for mongodb-only entries — carried from a saved entry
+  // so re-save round-trips it. Not editable in this form; #113 will replace
+  // this with a real mongodb form and remove this field.
+  connectionString?: string;
 }
 
 interface ConnectionManagerProps {
@@ -30,9 +34,20 @@ interface ConnectionManagerProps {
 
 export function ConnectionManager({ onConnect, isConnecting, error, onDismiss, t }: ConnectionManagerProps) {
   const [saved, setSaved] = useState<SavedConnection[]>(() => listSavedConnections());
-  const formType = (t: SavedConnection['type']): 'mysql' | 'postgres' => t === 'postgres' ? 'postgres' : 'mysql';
+  // Carries opaque mongodb connectionStrings from saved entries through the form
+  // so re-save preserves them. Keyed by connection name.
+  const connectionStringsRef = useRef<Map<string, string>>(new Map());
+  const formType = (saved: SavedConnection['type']): 'mysql' | 'postgres' => {
+    switch (saved) {
+      case 'postgres': return 'postgres';
+      case 'mysql':
+      case 'mongodb':
+      case undefined:
+        return 'mysql';
+    }
+  };
   const initialForm: ConnectionForm = saved[0]
-    ? { ...saved[0], type: formType(saved[0].type), password: '', sslVerify: saved[0].sslVerify ?? false, savePassword: saved[0].savePassword ?? false }
+    ? { ...saved[0], type: formType(saved[0].type), password: '', sslVerify: saved[0].sslVerify ?? false, savePassword: saved[0].savePassword ?? false, connectionString: saved[0].connectionString }
     : {
         name: 'Local MySQL',
         type: 'mysql',
@@ -42,6 +57,12 @@ export function ConnectionManager({ onConnect, isConnecting, error, onDismiss, t
         password: '', database: '', ssl: false, sslVerify: true, savePassword: false,
       };
   const [form, setForm] = useState<ConnectionForm>(initialForm);
+  // Seed the carry-forward map from any saved entry that already has a connectionString.
+  if (connectionStringsRef.current.size === 0) {
+    for (const entry of saved) {
+      if (entry.connectionString) connectionStringsRef.current.set(entry.name, entry.connectionString);
+    }
+  }
   // Track the saved entry currently reflected in the form, so we only auto-populate once per match.
   const [appliedSaved, setAppliedSaved] = useState<string>(saved[0]?.name ?? '');
   const [suggestOpen, setSuggestOpen] = useState(false);
@@ -111,7 +132,8 @@ export function ConnectionManager({ onConnect, isConnecting, error, onDismiss, t
   };
 
   const applySaved = (entry: SavedConnection) => {
-    setForm({ ...entry, type: formType(entry.type), password: '', sslVerify: entry.sslVerify ?? false, savePassword: entry.savePassword ?? false });
+    if (entry.connectionString) connectionStringsRef.current.set(entry.name, entry.connectionString);
+    setForm({ ...entry, type: formType(entry.type), password: '', sslVerify: entry.sslVerify ?? false, savePassword: entry.savePassword ?? false, connectionString: entry.connectionString });
     setAppliedSaved(entry.name);
     setSuggestOpen(false);
     if (entry.savePassword && electronAPI) {
@@ -182,7 +204,12 @@ export function ConnectionManager({ onConnect, isConnecting, error, onDismiss, t
         </div>
 
         <form
-          onSubmit={(e) => { e.preventDefault(); if (!isConnecting) onConnect(form); }}
+          onSubmit={(e) => {
+            e.preventDefault();
+            if (isConnecting) return;
+            const carried = connectionStringsRef.current.get(form.name.trim());
+            onConnect(carried ? { ...form, connectionString: carried } : form);
+          }}
           autoComplete="on"
         >
           <div style={s.body}>
@@ -268,7 +295,11 @@ export function ConnectionManager({ onConnect, isConnecting, error, onDismiss, t
                             <div style={{ minWidth: 0 }}>
                               <div style={{ fontSize: 12, color: t.textPrimary, fontWeight: 500, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{c.name}</div>
                               <div style={{ fontSize: 11, color: t.textMuted, fontFamily: 'monospace', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                                {c.user}@{c.host}:{c.port}
+                                {(c.user || c.host || c.port)
+                                  ? <>{c.user}@{c.host}:{c.port}</>
+                                  : c.connectionString
+                                    ? <>{(() => { try { return new URL(c.connectionString!).host || c.connectionString; } catch { return c.connectionString; } })()}</>
+                                    : null}
                                 {c.database && <span style={{ marginLeft: 6 }}>· {c.database}</span>}
                                 {c.ssl && <span style={{ marginLeft: 6, color: t.accent }}>· SSL</span>}
                               </div>

--- a/src/savedConnections.ts
+++ b/src/savedConnections.ts
@@ -1,6 +1,6 @@
 export interface SavedConnection {
   name: string;
-  type?: 'mysql' | 'postgres';
+  type?: 'mysql' | 'postgres' | 'mongodb';
   host: string;
   port: string;
   user: string;
@@ -9,6 +9,8 @@ export interface SavedConnection {
   sslVerify?: boolean;
   // Whether the password is stored in the OS keychain (Electron only).
   savePassword?: boolean;
+  // Optional MongoDB connection string (mongodb:// or mongodb+srv://).
+  connectionString?: string;
 }
 
 const KEY = 'helix.connections';

--- a/src/savedConnections.ts
+++ b/src/savedConnections.ts
@@ -9,7 +9,10 @@ export interface SavedConnection {
   sslVerify?: boolean;
   // Whether the password is stored in the OS keychain (Electron only).
   savePassword?: boolean;
-  // Optional MongoDB connection string (mongodb:// or mongodb+srv://).
+  /**
+   * MongoDB-only invariant: this field is meaningful only when `type === 'mongodb'`.
+   * Non-mongodb writers MUST omit it. (#113 will tighten this with a discriminated union.)
+   */
   connectionString?: string;
 }
 


### PR DESCRIPTION
## Summary

Extends `SavedConnection` (frontend localStorage helper) so MongoDB entries can be persisted alongside existing MySQL/PostgreSQL ones. Backend wiring for `'mongodb'` already landed in PR #119.

Closes #112

## Changes

- `src/savedConnections.ts` — add `'mongodb'` to the optional `type` union, add optional `connectionString?: string` (with a JSDoc invariant noting it is mongodb-only).
- `src/components/ConnectionManager.tsx` — extract a `formType()` helper (exhaustive switch over `'mysql' | 'postgres' | 'mongodb' | undefined`, parameter renamed from `t` so it doesn't shadow the `t: Theme` prop) at the two existing `entry.type ?? 'mysql'` sites so the wider union narrows cleanly to the form's `'mysql' | 'postgres'`. MongoDB-typed saved entries fall back to the mysql form for now; the full mongodb form UI lands in #113.
- `src/components/ConnectionManager.tsx` — carry mongodb `connectionString` opaquely from the saved entry through the form via a name-keyed `useRef<Map>`, seeded from `applySaved` and from the initial saved entry, then augment the submit payload so re-save preserves the field through the UI flow. `App.handleConnect` forwards `form.connectionString` into both the `/api/connect` body and the `saveConnection()` call.
- `src/components/ConnectionManager.tsx` — autocomplete row only renders the `user@host:port` line when at least one of those is truthy. For mongodb-only entries (where only `connectionString` is set) it falls back to the URL host extracted from the connection string, avoiding a bare `@:` rendering.

## Acceptance criteria

- [x] `'mongodb'` added to the `type` union on `SavedConnection`
- [x] Optional `connectionString?: string` field added with mongodb-only JSDoc invariant
- [x] Existing saved entries (no `type`) continue to default to `'mysql'`
- [x] localStorage round-trip remains stable (no migration needed)
- [x] **UI re-save round-trip** preserves `connectionString` (storage round-trip already worked; the second commit also makes the in-memory form carry it through onConnect → saveConnection)

## Test plan

- [x] `npm run build` (root: tsc + Vite) — clean
- [x] `cd server && npm run build` — clean (no server changes, sanity only)
- [x] Logic smoke: legacy entry without `type` resolves to `mysql`; postgres entry preserved; mongodb entry round-trips with `connectionString` intact through both storage and the UI form.
- [x] Browser smoke (mongodb-only entry injected via DevTools): autocomplete row renders the URL host instead of `@:`; clicking Connect emits a `/api/connect` body containing `connectionString`; localStorage entry retains `connectionString` after the failed connect attempt.
- [ ] Manual: open the app, save a connection (mysql or postgres), refresh, confirm it loads. Older entries (no `type`) still load as mysql.
