### PR TITLE
feat: QueryEditor MQL mode for MongoDB (#114)

### DIFF
--- a/server/src/routes/connect.test.ts
+++ b/server/src/routes/connect.test.ts
@@ -8,6 +8,7 @@ vi.mock('../db.js', () => ({
   disconnect: vi.fn().mockResolvedValue(undefined),
   isConnected: vi.fn().mockReturnValue(true),
   getActiveConfig: vi.fn().mockReturnValue(null),
+  getDriver: vi.fn().mockReturnValue({ queryMode: 'sql' }),
 }));
 
 import { connect, testConnection } from '../db.js';

--- a/server/src/routes/connect.ts
+++ b/server/src/routes/connect.ts
@@ -1,6 +1,6 @@
 import type { RequestHandler } from 'express';
 import type { ConnectionConfig } from '../drivers/interface.js';
-import { connect, disconnect, isConnected, getActiveConfig, testConnection } from '../db.js';
+import { connect, disconnect, isConnected, getActiveConfig, getDriver, testConnection } from '../db.js';
 
 type DbType = 'mysql' | 'postgres' | 'mongodb';
 
@@ -149,7 +149,11 @@ export const postConnect: RequestHandler = async (req, res) => {
 
   try {
     await connect(config);
-    res.json({ ok: true, connectionName: connectionLabel(config) });
+    res.json({
+      ok: true,
+      connectionName: connectionLabel(config),
+      queryMode: getDriver().queryMode,
+    });
   } catch (err) {
     res.status(400).json({ error: friendlyConnectError(err, config.host, config.port, config.type) });
   }
@@ -178,8 +182,10 @@ export const postTestConnect: RequestHandler = async (req, res) => {
 
 export const getStatus: RequestHandler = (_req, res) => {
   const config = getActiveConfig();
+  const connected = isConnected();
   res.json({
-    connected: isConnected(),
+    connected,
     connectionName: config ? connectionLabel(config) : null,
+    queryMode: connected ? getDriver().queryMode : null,
   });
 };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -219,8 +219,13 @@ export default function App() {
     if (queryMode === 'mql') {
       try {
         mqlPayload = JSON.parse(text);
-      } catch {
-        // Editor surfaces the parse error inline; bail without firing a request.
+      } catch (err) {
+        // Surface the error so callers that bypass QueryEditor.handleRunClick still see it.
+        setQueryError(err instanceof Error ? err.message : String(err));
+        return;
+      }
+      if (typeof mqlPayload !== 'object' || mqlPayload === null || Array.isArray(mqlPayload)) {
+        setQueryError('MQL request must be a JSON object (e.g. { "collection": "...", "operation": "find" }).');
         return;
       }
     }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,7 +8,7 @@ import { QueryEditor } from './components/QueryEditor';
 import { ResultsTable, type QueryResults } from './components/ResultsTable';
 import { ConnectionManager, type ConnectionForm } from './components/ConnectionManager';
 import { api } from './api';
-import type { SchemaData } from './api';
+import type { SchemaData, QueryMode } from './api';
 import { saveConnection } from './savedConnections';
 import { electronAPI } from './electronAPI';
 import { addHistoryEntry, listHistory, deleteHistoryEntry, clearHistory, type HistoryEntry } from './queryHistory';
@@ -46,6 +46,7 @@ export default function App() {
   }, [themeName]);
 
   const [connected, setConnected] = useState(false);
+  const [queryMode, setQueryMode] = useState<QueryMode>('sql');
   const [showConnectionModal, setShowConnectionModal] = useState(true);
   const [isConnecting, setIsConnecting] = useState(false);
   const [connectionError, setConnectionError] = useState<string | null>(null);
@@ -100,6 +101,7 @@ export default function App() {
       const friendly = form.name.trim();
       setConnectionName(friendly || res.connectionName);
       setConnectionHost(res.connectionName);
+      setQueryMode(res.queryMode);
       setHistory(listHistory(res.connectionName));
       setSavedQueries(listSavedQueries(res.connectionName));
       setSchemas(list);
@@ -142,6 +144,7 @@ export default function App() {
   const handleDisconnect = async () => {
     try { await api.disconnect(); } catch { /* ignore */ }
     setConnected(false);
+    setQueryMode('sql');
     setShowConnectionModal(true);
     setConnectionName('Not connected');
     setConnectionHost(null);
@@ -209,8 +212,18 @@ export default function App() {
 
   const handleRun = async () => {
     if (isRunning) return;
-    const sql = currentTab?.query?.trim();
-    if (!sql) return;
+    const text = currentTab?.query?.trim();
+    if (!text) return;
+
+    let mqlPayload: unknown = null;
+    if (queryMode === 'mql') {
+      try {
+        mqlPayload = JSON.parse(text);
+      } catch {
+        // Editor surfaces the parse error inline; bail without firing a request.
+        return;
+      }
+    }
 
     setIsRunning(true);
     setResults(null);
@@ -219,12 +232,14 @@ export default function App() {
 
     const started = Date.now();
     try {
-      const res = await api.query(sql, activeSchema);
+      const res = queryMode === 'mql'
+        ? await api.queryMql(mqlPayload, activeSchema)
+        : await api.query(text, activeSchema);
       setResults({ columns: res.columns, columnMeta: res.columnMeta, rows: res.rows });
       setExecTime(res.executionTime);
       if (connectionHost) {
         const entry = addHistoryEntry(connectionHost, {
-          sql, schema: activeSchema, executedAt: started,
+          sql: text, schema: activeSchema, executedAt: started,
           durationMs: res.executionTime, status: 'ok', rowCount: res.rows.length,
         });
         if (entry) setHistory(prev => [entry, ...prev].slice(0, 100));
@@ -234,7 +249,7 @@ export default function App() {
       setQueryError(message);
       if (connectionHost) {
         const entry = addHistoryEntry(connectionHost, {
-          sql, schema: activeSchema, executedAt: started,
+          sql: text, schema: activeSchema, executedAt: started,
           durationMs: Date.now() - started, status: 'error', error: message,
         });
         if (entry) setHistory(prev => [entry, ...prev].slice(0, 100));
@@ -306,7 +321,12 @@ export default function App() {
 
   const handleTableSelect = (name: string) => {
     setActiveTable(name);
-    addTab(`${name}.sql`, `SELECT *\nFROM \`${name}\`\nLIMIT 100;`);
+    if (queryMode === 'mql') {
+      const body = JSON.stringify({ collection: name, operation: 'find', filter: {}, limit: 100 }, null, 2);
+      addTab(`${name}.json`, body);
+    } else {
+      addTab(`${name}.sql`, `SELECT *\nFROM \`${name}\`\nLIMIT 100;`);
+    }
   };
 
   const switchTab = (id: string) => {
@@ -393,6 +413,7 @@ export default function App() {
               onChange={handleQueryChange}
               onRun={handleRun}
               isRunning={isRunning}
+              queryMode={queryMode}
               activeSchema={activeSchema}
               schemaData={schemaData}
               runtimeError={queryError}

--- a/src/api.ts
+++ b/src/api.ts
@@ -90,9 +90,11 @@ async function request<T>(path: string, init?: RequestInit): Promise<T> {
   return body;
 }
 
+export type QueryMode = 'sql' | 'mql';
+
 export const api = {
   connect(form: ConnectFormInput) {
-    return request<{ ok: boolean; connectionName: string }>('/api/connect', {
+    return request<{ ok: boolean; connectionName: string; queryMode: QueryMode }>('/api/connect', {
       method: 'POST',
       body: JSON.stringify(buildConnectBody(form)),
     });
@@ -110,7 +112,7 @@ export const api = {
   },
 
   status() {
-    return request<{ connected: boolean; connectionName: string | null }>('/api/connect/status');
+    return request<{ connected: boolean; connectionName: string | null; queryMode: QueryMode | null }>('/api/connect/status');
   },
 
   schemas() {
@@ -130,6 +132,13 @@ export const api = {
     return request<QueryResults & { columnMeta?: ColumnMeta[]; executionTime: number; affectedRows?: number; insertId?: number }>(
       '/api/query',
       { method: 'POST', body: JSON.stringify({ sql, schema }) }
+    );
+  },
+
+  queryMql(mql: unknown, schema: string) {
+    return request<QueryResults & { columnMeta?: ColumnMeta[]; executionTime: number; affectedRows?: number; insertId?: number }>(
+      '/api/query',
+      { method: 'POST', body: JSON.stringify({ mql, schema }) }
     );
   },
 

--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -156,7 +156,7 @@ export function QueryEditor({
 
   const now = Date.now();
 
-  const [formatError, setFormatError] = useState<string | null>(null);
+  const [editorError, setEditorError] = useState<{ kind: 'format' | 'run'; message: string } | null>(null);
 
   const handleFormat = () => {
     if (!value.trim()) return;
@@ -165,17 +165,17 @@ export function QueryEditor({
         const parsed = JSON.parse(value);
         const formatted = JSON.stringify(parsed, null, 2);
         if (formatted !== value) onChange(formatted);
-        setFormatError(null);
+        setEditorError(null);
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
-        setFormatError(message);
+        setEditorError({ kind: 'format', message });
       }
       return;
     }
     try {
       const formatted = formatSql(value, { language: 'mysql', keywordCase: 'upper', tabWidth: 2 });
       if (formatted !== value) onChange(formatted);
-      setFormatError(null);
+      setEditorError(null);
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       handleFormatError(message);
@@ -237,9 +237,9 @@ export function QueryEditor({
 
   const handleFormatError = (message: string) => {
     const loc = locateError(message, value);
-    if (!loc) { setFormatError(message); return; }
+    if (!loc) { setEditorError({ kind: 'format', message }); return; }
     const snippet = buildSnippet(value, loc.lineStart, loc.lineEnd, loc.caret);
-    setFormatError(`${message}\nNear (line ${loc.line}): ${snippet}`);
+    setEditorError({ kind: 'format', message: `${message}\nNear (line ${loc.line}): ${snippet}` });
     selectErrorLine(loc.lineStart, loc.lineEnd);
   };
 
@@ -258,9 +258,9 @@ export function QueryEditor({
     if (isMql && value.trim()) {
       try {
         JSON.parse(value);
-        setFormatError(null);
+        setEditorError(null);
       } catch (err) {
-        setFormatError(err instanceof Error ? err.message : String(err));
+        setEditorError({ kind: 'run', message: err instanceof Error ? err.message : String(err) });
         return;
       }
     }
@@ -587,9 +587,10 @@ export function QueryEditor({
           </span>
         </div>
       )}
-      {formatError && (() => {
-        const [headline, ...rest] = formatError.split('\n');
+      {editorError && (() => {
+        const [headline, ...rest] = editorError.message.split('\n');
         const nearLine = rest.find(l => l.startsWith('Near'));
+        const prefix = editorError.kind === 'run' ? 'Parse failed' : 'Format failed';
         return (
         <div
           role="alert"
@@ -605,7 +606,7 @@ export function QueryEditor({
           }}
         >
           <div style={{ flex: 1, display: 'flex', flexDirection: 'column', gap: 2 }}>
-            <span>Format failed: {headline}</span>
+            <span>{prefix}: {headline}</span>
             {nearLine && (
               <span style={{ fontFamily: '"JetBrains Mono", monospace', color: t.textSecondary, fontSize: 10.5 }}>
                 {nearLine}
@@ -613,7 +614,7 @@ export function QueryEditor({
             )}
           </div>
           <button
-            onClick={() => setFormatError(null)}
+            onClick={() => setEditorError(null)}
             aria-label="Dismiss"
             style={{
               background: 'none', border: 'none', color: t.textMuted,
@@ -651,7 +652,24 @@ export function QueryEditor({
                     { collection: name, operation: 'find', filter: {}, limit: 100 },
                     null, 2,
                   );
-                  onChange(snippet);
+                  if (!value.trim()) {
+                    onChange(snippet);
+                  } else {
+                    const el = textareaRef.current;
+                    const start = el?.selectionStart ?? value.length;
+                    const end = el?.selectionEnd ?? value.length;
+                    const next = value.substring(0, start) + snippet + value.substring(end);
+                    onChange(next);
+                    requestAnimationFrame(() => {
+                      const node = textareaRef.current;
+                      if (!node) return;
+                      node.focus();
+                      const caret = start + snippet.length;
+                      node.setSelectionRange(caret, caret);
+                    });
+                  }
+                  // Reset the select so the same option can be picked again.
+                  e.target.value = '';
                 }}
                 style={{
                   background: t.bgBase, color: t.textPrimary,
@@ -677,7 +695,10 @@ export function QueryEditor({
         <textarea
           ref={textareaRef}
           value={value}
-          onChange={e => onChange(e.target.value)}
+          onChange={e => {
+            if (editorError) setEditorError(null);
+            onChange(e.target.value);
+          }}
           onKeyDown={handleKeyDown}
           style={s.textarea}
           spellCheck={false}

--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -29,6 +29,7 @@ interface QueryEditorProps {
   onChange: (val: string) => void;
   onRun: () => void;
   isRunning: boolean;
+  queryMode?: 'sql' | 'mql';
   activeSchema: string;
   schemaData?: SchemaData;
   runtimeError?: string | null;
@@ -72,11 +73,12 @@ const ToolBtn = ({ title, onClick, active, children, t }: { title: string; onCli
 );
 
 export function QueryEditor({
-  value, onChange, onRun, isRunning, activeSchema, schemaData, runtimeError,
+  value, onChange, onRun, isRunning, queryMode = 'sql', activeSchema, schemaData, runtimeError,
   history = [], onReopenHistory, onDeleteHistoryEntry, onClearHistory,
   savedQueries = [], onSaveQuery, onDeleteSavedQuery, onRenameSavedQuery, onReopenSavedQuery,
   t,
 }: QueryEditorProps) {
+  const isMql = queryMode === 'mql';
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
   const [historyOpen, setHistoryOpen] = useState(false);
@@ -158,6 +160,18 @@ export function QueryEditor({
 
   const handleFormat = () => {
     if (!value.trim()) return;
+    if (isMql) {
+      try {
+        const parsed = JSON.parse(value);
+        const formatted = JSON.stringify(parsed, null, 2);
+        if (formatted !== value) onChange(formatted);
+        setFormatError(null);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        setFormatError(message);
+      }
+      return;
+    }
     try {
       const formatted = formatSql(value, { language: 'mysql', keywordCase: 'upper', tabWidth: 2 });
       if (formatted !== value) onChange(formatted);
@@ -232,7 +246,7 @@ export function QueryEditor({
   // Highlight the error line in the editor when a run error comes in from App.
   // The message itself is rendered by ResultsTable, so we don't show the format-error strip here.
   useEffect(() => {
-    if (!runtimeError) return;
+    if (!runtimeError || isMql) return;
     const loc = locateError(runtimeError, value);
     if (!loc) return;
     selectErrorLine(loc.lineStart, loc.lineEnd);
@@ -240,10 +254,23 @@ export function QueryEditor({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [runtimeError]);
 
+  const handleRunClick = () => {
+    if (isMql && value.trim()) {
+      try {
+        JSON.parse(value);
+        setFormatError(null);
+      } catch (err) {
+        setFormatError(err instanceof Error ? err.message : String(err));
+        return;
+      }
+    }
+    onRun();
+  };
+
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
       e.preventDefault();
-      onRun();
+      handleRunClick();
       return;
     }
     if (e.shiftKey && e.altKey && e.code === 'KeyF') {
@@ -281,12 +308,12 @@ export function QueryEditor({
     } as CSSProperties,
   };
 
-  const largeTableWarn = detectLargeTable(value, schemaData);
+  const largeTableWarn = isMql ? null : detectLargeTable(value, schemaData);
 
   return (
     <div style={s.root}>
       <div style={s.toolbar}>
-        <button style={{ ...s.runBtn, opacity: isRunning ? 0.85 : 1 }} onClick={onRun} data-tooltip={isRunning ? 'Stop query' : `Run query (${RUN_SHORTCUT})`}>
+        <button style={{ ...s.runBtn, opacity: isRunning ? 0.85 : 1 }} onClick={handleRunClick} data-tooltip={isRunning ? 'Stop query' : `Run query (${RUN_SHORTCUT})`}>
           {isRunning
             ? <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><rect x="6" y="6" width="12" height="12"/></svg>
             : <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><polygon points="5 3 19 12 5 21 5 3"/></svg>}
@@ -294,7 +321,7 @@ export function QueryEditor({
           <span style={{ fontSize: 10, opacity: 0.65 }}>{RUN_SHORTCUT}</span>
         </button>
         <div style={s.sep}/>
-        <ToolBtn title={`Format SQL (${FORMAT_SHORTCUT})`} t={t} onClick={handleFormat}>
+        <ToolBtn title={`${isMql ? 'Format JSON' : 'Format SQL'} (${FORMAT_SHORTCUT})`} t={t} onClick={handleFormat}>
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
             <line x1="21" y1="10" x2="7" y2="10"/><line x1="21" y1="6" x2="3" y2="6"/><line x1="21" y1="14" x2="3" y2="14"/><line x1="21" y1="18" x2="7" y2="18"/>
           </svg>
@@ -597,6 +624,50 @@ export function QueryEditor({
         </div>
         );
       })()}
+      {isMql && (
+        <div
+          style={{
+            display: 'flex', alignItems: 'center', gap: 10, padding: '6px 12px',
+            background: t.bgElevated, borderBottom: `1px solid ${t.border}`,
+            fontFamily: '"IBM Plex Sans", sans-serif', fontSize: 11, color: t.textSecondary,
+            flexShrink: 0,
+          }}
+        >
+          <span>MQL request — JSON object, e.g.{' '}
+            <code style={{ fontFamily: '"JetBrains Mono", monospace', color: t.textPrimary }}>
+              {'{ "collection": "users", "operation": "find", "filter": {} }'}
+            </code>
+          </span>
+          {schemaData && schemaData.tables.length > 0 && (
+            <>
+              <span style={{ flex: 1 }} />
+              <label style={{ color: t.textMuted }}>Insert collection:</label>
+              <select
+                value=""
+                onChange={(e) => {
+                  const name = e.target.value;
+                  if (!name) return;
+                  const snippet = JSON.stringify(
+                    { collection: name, operation: 'find', filter: {}, limit: 100 },
+                    null, 2,
+                  );
+                  onChange(snippet);
+                }}
+                style={{
+                  background: t.bgBase, color: t.textPrimary,
+                  border: `1px solid ${t.border}`, borderRadius: 3,
+                  fontSize: 11, fontFamily: 'inherit', padding: '2px 6px', outline: 'none',
+                }}
+              >
+                <option value="">— pick —</option>
+                {schemaData.tables.map(tbl => (
+                  <option key={tbl.name} value={tbl.name}>{tbl.name}</option>
+                ))}
+              </select>
+            </>
+          )}
+        </div>
+      )}
       <div style={s.editorWrap}>
         <div style={s.lineNums} aria-hidden="true">
           {value.split('\n').map((_, i) => (


### PR DESCRIPTION
Closes #114.

Switches the query editor into MQL mode whenever the active driver reports `queryMode === 'mql'`. SQL behaviour for MySQL/Postgres is untouched.

## What changed

**Backend**
- `/api/connect` and `/api/connect/status` now include `queryMode` from the active driver (`'sql' | 'mql' | null`).

**Frontend**
- `App` stores `queryMode` from the connect response and passes it to `QueryEditor`.
- `App.handleRun` parses the editor text as JSON when in MQL mode and POSTs `{ mql, schema }` via the new `api.queryMql` helper. SQL connections still POST `{ sql, schema }`.
- `App.handleTableSelect` seeds new tabs with a `find` snippet (instead of `SELECT *`) for MongoDB connections.
- `QueryEditor`:
  - Renders an MQL helper bar with a JSON example and a collection picker (populated from the schema).
  - The collection picker pre-fills the editor with `{ collection, operation: "find", filter: {}, limit: 100 }`.
  - The Format button rebinds to JSON pretty-print in MQL mode and its tooltip flips to "Format JSON".
  - Run validates as JSON before firing; parse errors show in the existing inline error strip and the request is not sent.
  - SQL-only behaviours (large-table warning, runtime-error line highlight) are gated on SQL mode.

## Acceptance criteria
- [x] Editor switches to JSON syntax/handling (not SQL formatting) when queryMode is `mql`.
- [x] Helper text above the editor shows an MQL example.
- [x] Collection selector dropdown populated from the current schema's collections.
- [x] Submitting sends a parsed MQL object to `/api/query` (not a string).
- [x] SQL behaviour for MySQL/Postgres is unchanged.

## Test plan
Browser smoke against an ephemeral local mongo (port 27017, db `smoke`, collections `users` + `orders`):
- [x] Connecting to mongodb returns `queryMode: "mql"` from `/api/connect`.
- [x] After connect: helper bar with `{ "collection": "users", "operation": "find", "filter": {} }` example is visible; collection dropdown lists `users`, `orders`.
- [x] Editing to invalid JSON and clicking Run shows an inline error and fires no `/api/query` request (verified via DevTools network inspection).
- [x] Valid `{ collection: "users", operation: "find", filter: { age: { $gt: 25 } } }` returns 200; UI shows Alice + Carol (age 30 + 41), excludes Bob (age 24).
- [x] `cd server && npm run build` clean; `npm run build` (frontend) clean; `cd server && npm test` 99 passing.

Note: the mongo result rendering is intentionally raw — `ResultsGrid` flattening for MongoDB documents is downstream in #115.