### PR TITLE
fix(mongodb): serialize remaining BSON scalar types (#128)

### DIFF
--- a/server/src/drivers/mongodb.test.ts
+++ b/server/src/drivers/mongodb.test.ts
@@ -273,6 +273,90 @@ describe('MongoDBDriver.query – find', () => {
   });
 });
 
+describe('MongoDBDriver.query – BSON scalar serialization', () => {
+  it('serializes Decimal128 to its numeric string (positive, negative, zero)', async () => {
+    const dec = (s: string) => ({ _bsontype: 'Decimal128', toString: () => s });
+    mockCursor.toArray.mockResolvedValueOnce([
+      { a: dec('123.45'), b: dec('-987654321.0000001'), c: dec('0') },
+    ]);
+    const r = await makeDriver().query(
+      JSON.stringify({ collection: 'c', operation: 'find' }),
+    );
+    expect(r.rows[0]).toEqual({ a: '123.45', b: '-987654321.0000001', c: '0' });
+  });
+
+  it('serializes Long to its string form (preserves precision past Number.MAX_SAFE_INTEGER)', async () => {
+    const long = (s: string) => ({ _bsontype: 'Long', toString: () => s });
+    mockCursor.toArray.mockResolvedValueOnce([
+      { big: long('9007199254740993'), max: long('9223372036854775807') },
+    ]);
+    const r = await makeDriver().query(
+      JSON.stringify({ collection: 'c', operation: 'find' }),
+    );
+    expect(r.rows[0]).toEqual({
+      big: '9007199254740993',
+      max: '9223372036854775807',
+    });
+  });
+
+  it('serializes Binary subtype 4 (UUID) to canonical UUID string via toUUID()', async () => {
+    const uuidStr = '550e8400-e29b-41d4-a716-446655440000';
+    const bin = {
+      _bsontype: 'Binary',
+      sub_type: 4,
+      buffer: Buffer.from(uuidStr.replace(/-/g, ''), 'hex'),
+      toUUID: () => ({ toString: () => uuidStr }),
+    };
+    mockCursor.toArray.mockResolvedValueOnce([{ id: bin }]);
+    const r = await makeDriver().query(
+      JSON.stringify({ collection: 'c', operation: 'find' }),
+    );
+    expect(r.rows[0]).toEqual({ id: uuidStr });
+  });
+
+  it('serializes generic Binary as Binary(subType,base64) and handles empty buffer', async () => {
+    const bin = (sub: number, buf: Buffer) => ({
+      _bsontype: 'Binary',
+      sub_type: sub,
+      buffer: buf,
+    });
+    mockCursor.toArray.mockResolvedValueOnce([
+      { hello: bin(0, Buffer.from('hello')), empty: bin(0, Buffer.alloc(0)) },
+    ]);
+    const r = await makeDriver().query(
+      JSON.stringify({ collection: 'c', operation: 'find' }),
+    );
+    expect(r.rows[0]).toEqual({
+      hello: 'Binary(0,aGVsbG8=)',
+      empty: 'Binary(0,)',
+    });
+  });
+
+  it('serializes Timestamp as Timestamp(t, i)', async () => {
+    const ts = { _bsontype: 'Timestamp', t: 1234567890, i: 1 };
+    mockCursor.toArray.mockResolvedValueOnce([{ ts }]);
+    const r = await makeDriver().query(
+      JSON.stringify({ collection: 'c', operation: 'find' }),
+    );
+    expect(r.rows[0]).toEqual({ ts: 'Timestamp(1234567890, 1)' });
+  });
+
+  it('serializes BSON scalars nested inside arrays and sub-documents', async () => {
+    const dec = { _bsontype: 'Decimal128', toString: () => '1.5' };
+    const long = { _bsontype: 'Long', toString: () => '42' };
+    mockCursor.toArray.mockResolvedValueOnce([
+      { items: [{ price: dec }], stats: { count: long } },
+    ]);
+    const r = await makeDriver().query(
+      JSON.stringify({ collection: 'c', operation: 'find' }),
+    );
+    expect(r.rows[0]).toEqual({
+      items: [{ price: '1.5' }],
+      stats: { count: '42' },
+    });
+  });
+});
+
 describe('MongoDBDriver.query – findOne / aggregate / count', () => {
   it('findOne returns at most one row', async () => {
     mockCollection.findOne.mockResolvedValueOnce({ name: 'Bob' });

--- a/server/src/drivers/mongodb.test.ts
+++ b/server/src/drivers/mongodb.test.ts
@@ -274,15 +274,27 @@ describe('MongoDBDriver.query – find', () => {
 });
 
 describe('MongoDBDriver.query – BSON scalar serialization', () => {
-  it('serializes Decimal128 to its numeric string (positive, negative, zero)', async () => {
+  it('serializes Decimal128 to its numeric string (positive, negative, zero, negative zero)', async () => {
     const dec = (s: string) => ({ _bsontype: 'Decimal128', toString: () => s });
     mockCursor.toArray.mockResolvedValueOnce([
-      { a: dec('123.45'), b: dec('-987654321.0000001'), c: dec('0') },
+      {
+        a: dec('123.45'),
+        b: dec('-987654321.0000001'),
+        c: dec('0'),
+        // bson preserves Decimal128's IEEE-754 sign bit, so '-0' is a real
+        // value distinct from '0' (mongosh / Compass render it as '-0').
+        nz: dec('-0'),
+      },
     ]);
     const r = await makeDriver().query(
       JSON.stringify({ collection: 'c', operation: 'find' }),
     );
-    expect(r.rows[0]).toEqual({ a: '123.45', b: '-987654321.0000001', c: '0' });
+    expect(r.rows[0]).toEqual({
+      a: '123.45',
+      b: '-987654321.0000001',
+      c: '0',
+      nz: '-0',
+    });
   });
 
   it('serializes Long to its string form (preserves precision past Number.MAX_SAFE_INTEGER)', async () => {
@@ -328,7 +340,7 @@ describe('MongoDBDriver.query – BSON scalar serialization', () => {
     );
     expect(r.rows[0]).toEqual({
       hello: 'Binary(0,aGVsbG8=)',
-      empty: 'Binary(0,)',
+      empty: 'Binary(0,<empty>)',
     });
   });
 

--- a/server/src/drivers/mongodb.ts
+++ b/server/src/drivers/mongodb.ts
@@ -49,6 +49,29 @@ function buildMongoUri(config: ConnectionConfig): string {
   return `mongodb://${auth}${config.host}:${config.port}/`;
 }
 
+// Detect bson scalar types via their `_bsontype` tag. We avoid `instanceof`
+// here because users may bring their own `bson` build (e.g. a transitive
+// duplicate), which breaks prototype-chain checks; the `_bsontype` getter is
+// the project's documented identity marker.
+function bsonType(val: unknown): string | null {
+  if (val === null || typeof val !== 'object') return null;
+  const t = (val as { _bsontype?: unknown })._bsontype;
+  return typeof t === 'string' ? t : null;
+}
+
+function serializeBinary(val: {
+  sub_type: number;
+  buffer: Buffer | Uint8Array;
+  toUUID?: () => { toString(): string };
+}): string {
+  // Subtype 4 (and the legacy 3) are UUIDs; render canonical hyphenated form.
+  if (val.sub_type === 4 && typeof val.toUUID === 'function') {
+    return val.toUUID().toString();
+  }
+  const buf = Buffer.isBuffer(val.buffer) ? val.buffer : Buffer.from(val.buffer);
+  return `Binary(${val.sub_type},${buf.toString('base64')})`;
+}
+
 function serializeValue(val: unknown): unknown {
   if (val === null || val === undefined) return null;
   if (val instanceof ObjectId) return val.toHexString();
@@ -59,6 +82,20 @@ function serializeValue(val: unknown): unknown {
     return val.toISOString().replace('T', ' ').replace(/\.\d{3}Z$/, '');
   }
   if (Buffer.isBuffer(val)) return val.toString('hex');
+  const tag = bsonType(val);
+  if (tag) {
+    // Order matters: Timestamp extends Long, so check it first.
+    if (tag === 'Timestamp') {
+      const ts = val as { t: number; i: number };
+      return `Timestamp(${ts.t}, ${ts.i})`;
+    }
+    if (tag === 'Decimal128' || tag === 'Long') {
+      return (val as { toString(): string }).toString();
+    }
+    if (tag === 'Binary') {
+      return serializeBinary(val as Parameters<typeof serializeBinary>[0]);
+    }
+  }
   if (Array.isArray(val)) return val.map(serializeValue);
   if (typeof val === 'bigint') return val.toString();
   if (typeof val === 'object') {

--- a/server/src/drivers/mongodb.ts
+++ b/server/src/drivers/mongodb.ts
@@ -64,12 +64,19 @@ function serializeBinary(val: {
   buffer: Buffer | Uint8Array;
   toUUID?: () => { toString(): string };
 }): string {
-  // Subtype 4 (and the legacy 3) are UUIDs; render canonical hyphenated form.
+  // Subtype 4 is the canonical UUID; render the hyphenated form. Subtype 3
+  // (legacy UUID) has non-canonical, driver-specific byte order, so calling
+  // toUUID() on it would silently produce a wrong-looking string — we leave
+  // legacy UUIDs in the generic Binary(3,<base64>) form.
   if (val.sub_type === 4 && typeof val.toUUID === 'function') {
     return val.toUUID().toString();
   }
   const buf = Buffer.isBuffer(val.buffer) ? val.buffer : Buffer.from(val.buffer);
-  return `Binary(${val.sub_type},${buf.toString('base64')})`;
+  const b64 = buf.toString('base64');
+  // Use an explicit empty marker so an empty buffer doesn't render as the
+  // ambiguous `Binary(0,)` (which reads like a malformed function call).
+  const payload = b64.length === 0 ? '<empty>' : b64;
+  return `Binary(${val.sub_type},${payload})`;
 }
 
 function serializeValue(val: unknown): unknown {
@@ -84,7 +91,9 @@ function serializeValue(val: unknown): unknown {
   if (Buffer.isBuffer(val)) return val.toString('hex');
   const tag = bsonType(val);
   if (tag) {
-    // Order matters: Timestamp extends Long, so check it first.
+    // MUST come before Long — Timestamp extends Long in bson 7.x; reordering
+    // (or sorting these branches alphabetically in a refactor) would silently
+    // match Timestamp here and lose the (t, i) tuple.
     if (tag === 'Timestamp') {
       const ts = val as { t: number; i: number };
       return `Timestamp(${ts.t}, ${ts.i})`;


### PR DESCRIPTION
Closes #128

## Summary

After PR #127 (ResultsGrid flatten), MongoDB documents containing `Decimal128`, `Long`, `Binary`, `UUID`, or `Timestamp` fields rendered as JSON-shaped junk (e.g. `{"$numberDecimal":"..."}`) — or, worse, the flatten gate could split them into bogus `field.$numberDecimal` columns.

`server/src/drivers/mongodb.ts#serializeValue` now detects each type via the bson `_bsontype` tag (duck-typed so a duplicate `bson` copy in the dep graph doesn't break `instanceof`) and emits a primitive string.

## Per-type rendering

| Type | Output | Rationale |
|---|---|---|
| `Decimal128` | `value.toString()` | exact numeric form, no precision loss |
| `Long` | `value.toString()` | preserves precision past `Number.MAX_SAFE_INTEGER` |
| `Binary` subtype 4 | canonical UUID via `toUUID().toString()` | matches Compass / mongosh display |
| `Binary` (other subtypes) | `Binary(<subType>,<base64>)` | base64 is compact and round-trippable; subtype is shown so users can tell `0` (generic) from `2` (deprecated) etc. |
| `Timestamp` | `Timestamp(t, i)` | matches mongosh's printed form; `t` (seconds since epoch) and `i` (increment) are the meaningful pair |

`Timestamp` is checked **before** `Long` because `Timestamp extends Long`.

## AC checklist

- [x] `Decimal128` renders as numeric string (positive, negative, zero)
- [x] `Long` renders as string (max int64 covered)
- [x] `Binary` subtype 4 renders as canonical UUID
- [x] Other `Binary` renders as readable string with subtype + base64
- [x] `Timestamp` renders as `Timestamp(t, i)`
- [x] Existing `ObjectId`/`Date`/`null`/`undefined` paths untouched
- [x] Nested arrays / sub-documents recurse correctly

## Test plan

- [x] `cd server && npm run build` — clean
- [x] `cd server && npm test` — 105/105 green (6 new cases under `MongoDBDriver.query – BSON scalar serialization`)
- [ ] Browser smoke: connect to a MongoDB instance, insert a doc containing all 5 BSON types, run `find {}` in MQL mode, verify each cell shows a readable string (not an object/JSON blob)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
