### PR TITLE
fix: drag-aware backdrop dismiss for connection modal

### DIFF
--- a/src/components/ConnectionManager.tsx
+++ b/src/components/ConnectionManager.tsx
@@ -126,13 +126,6 @@ export function ConnectionManager({ onConnect, isConnecting, error, onDismiss, t
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  useEffect(() => {
-    if (!onDismiss || isConnecting) return;
-    const key = (e: KeyboardEvent) => { if (e.key === 'Escape') onDismiss(); };
-    window.addEventListener('keydown', key);
-    return () => window.removeEventListener('keydown', key);
-  }, [onDismiss, isConnecting]);
-
   const isMongoUri = form.type === 'mongodb' && form.mongoMode === 'uri';
 
   const buildSubmitForm = (): ConnectionForm => {
@@ -247,8 +240,8 @@ export function ConnectionManager({ onConnect, isConnecting, error, onDismiss, t
   });
 
   return (
-    <div style={s.overlay} onClick={!isConnecting ? onDismiss : undefined}>
-      <div style={s.modal} onClick={(e) => e.stopPropagation()}>
+    <div style={s.overlay}>
+      <div style={s.modal}>
         <div style={s.header}>
           <svg width="20" height="20" viewBox="0 0 40 40" fill="none">
             <path d="M6 6 C6 6, 20 2, 20 20 C20 38, 6 34, 6 34" stroke={t.accent} strokeWidth="2.5" strokeLinecap="round"/>

--- a/src/components/ConnectionManager.tsx
+++ b/src/components/ConnectionManager.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import type { CSSProperties } from 'react';
 import type { Theme } from '../theme';
 import { api } from '../api';
@@ -104,6 +104,11 @@ export function ConnectionManager({ onConnect, isConnecting, error, onDismiss, t
   const [testing, setTesting] = useState(false);
   const [testResult, setTestResult] = useState<{ ok: true } | { ok: false; error: string } | null>(null);
   const [canSavePassword, setCanSavePassword] = useState(false);
+
+  // Track whether a click began on the backdrop. Only dismiss when both mousedown
+  // and click landed on the backdrop — a drag that starts inside the modal and
+  // releases on the backdrop (e.g. text-selection) must not close the modal.
+  const mouseDownOnBackdrop = useRef(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -240,7 +245,17 @@ export function ConnectionManager({ onConnect, isConnecting, error, onDismiss, t
   });
 
   return (
-    <div style={s.overlay}>
+    <div
+      style={s.overlay}
+      onMouseDown={(e) => { mouseDownOnBackdrop.current = e.target === e.currentTarget; }}
+      onMouseUp={(e) => { if (e.target !== e.currentTarget) mouseDownOnBackdrop.current = false; }}
+      onClick={(e) => {
+        const started = mouseDownOnBackdrop.current;
+        mouseDownOnBackdrop.current = false;
+        if (!onDismiss || isConnecting) return;
+        if (started && e.target === e.currentTarget) onDismiss();
+      }}
+    >
       <div style={s.modal}>
         <div style={s.header}>
           <svg width="20" height="20" viewBox="0 0 40 40" fill="none">


### PR DESCRIPTION
Closes #130

## Summary

The connection modal dismissed on backdrop click and on the Escape key. Both paths dropped the user into a non-functional disconnected app. The drag-select-to-clear-a-field gesture (mousedown inside an input, mouseup past the modal edge) hit the same backdrop click and dismissed the modal.

The fix preserves the deliberate **click-outside-to-close** UX while ignoring drags that merely *end* on the backdrop. Escape no longer dismisses.

## What changed

- Restored `onClick` on the overlay backdrop, but gated it with a drag-aware check: dismiss only when **all three** of `mousedown`, `mouseup`, and `click` land on the backdrop itself.
- Added `onMouseDown` / `onMouseUp` handlers on the overlay that record the press origin into a `useRef<boolean>`; the `onClick` reads and resets it.
- The `onMouseUp` handler clears the ref if the release lands inside the modal — covers the inverse case (mousedown on backdrop, mouseup inside the modal).
- Escape `useEffect` remains removed.
- The modal body no longer needs `onClick={(e) => e.stopPropagation()}` — the overlay's `e.target === e.currentTarget` guard already filters out bubbled clicks from inner elements.

## Behaviour matrix

| Gesture | Result |
|---|---|
| Click on backdrop (no drag) | Dismiss |
| Click inside the modal | Stay open |
| Drag from inside modal, release on backdrop | Stay open |
| Drag from backdrop, release inside modal | Stay open |
| Press Escape | Stay open |
| Cancel button | Dismiss |

## Test plan

- [x] Click on the dark backdrop — modal closes.
- [x] Drag from a text input past the modal edge and release on backdrop — modal stays open.
- [x] Press Escape with focus inside an input — modal stays open.
- [x] Drag from backdrop into the modal and release inside — modal stays open.
- [x] Click Cancel — modal closes.
- [x] `npm run build` clean.
