### PR TITLE
feat: MongoDBDriver union-of-keys field sampling (#118)

### DIFF
--- a/server/src/drivers/mongodb.test.ts
+++ b/server/src/drivers/mongodb.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Document } from 'mongodb';
 
 const mockCursor = {
   project: vi.fn(),
@@ -556,25 +557,50 @@ describe('MongoDBDriver – getSchemas', () => {
   });
 });
 
+/**
+ * Build a stub collection whose `find().sort().limit().toArray()` chain resolves
+ * to the supplied docs. The returned object exposes spies on each link so tests
+ * can assert deterministic-sort + sample-size wiring.
+ */
+function makeSampleColl(docs: Document[], count: number) {
+  const toArray = vi.fn().mockResolvedValue(docs);
+  const limit = vi.fn(() => ({ toArray }));
+  const sort = vi.fn(() => ({ limit }));
+  const find = vi.fn(() => ({ sort }));
+  return {
+    find,
+    sort,
+    limit,
+    toArray,
+    estimatedDocumentCount: vi.fn().mockResolvedValue(count),
+  };
+}
+
 describe('MongoDBDriver – getSchema (field inference)', () => {
-  it('samples one document per collection and marks columns as inferred', async () => {
+  it('samples documents with deterministic sort and SAMPLE_SIZE limit', async () => {
     mockListCursor.toArray.mockResolvedValueOnce([
       { name: 'users', type: 'collection' },
       { name: 'orders_v', type: 'view' },
     ]);
 
-    const usersColl = {
-      findOne: vi.fn().mockResolvedValueOnce({
-        _id: new ObjectIdCtor('aaaaaaaaaaaaaaaaaaaaaaaa'),
-        name: 'Ann',
-        age: 30,
-        joined: new Date('2024-01-01T00:00:00.000Z'),
-      }),
-      estimatedDocumentCount: vi.fn().mockResolvedValueOnce(7),
-    };
+    const usersColl = makeSampleColl(
+      [
+        {
+          _id: new ObjectIdCtor('aaaaaaaaaaaaaaaaaaaaaaaa'),
+          name: 'Ann',
+          age: 30,
+          joined: new Date('2024-01-01T00:00:00.000Z'),
+        },
+      ],
+      7,
+    );
     mockDb.collection.mockReturnValueOnce(usersColl as unknown as typeof mockCollection);
 
     const schema = await makeDriver().getSchema('shop');
+    expect(usersColl.find).toHaveBeenCalledWith({});
+    expect(usersColl.sort).toHaveBeenCalledWith({ _id: -1 });
+    expect(usersColl.limit).toHaveBeenCalledWith(50);
+
     expect(schema.views).toEqual(['orders_v']);
     expect(schema.tables).toHaveLength(1);
     const t = schema.tables[0];
@@ -584,21 +610,101 @@ describe('MongoDBDriver – getSchema (field inference)', () => {
     const cmap = Object.fromEntries(t.columns.map((c) => [c.name, c]));
     expect(cmap['_id'].pk).toBe(true);
     expect(cmap['_id'].dataType).toBe('objectId');
+    expect(cmap['_id'].nullable).toBe(false);
     expect(cmap['name'].dataType).toBe('string');
     expect(cmap['age'].dataType).toBe('int');
     expect(cmap['joined'].dataType).toBe('date');
   });
 
+  it('returns the union of keys across sampled docs', async () => {
+    mockListCursor.toArray.mockResolvedValueOnce([
+      { name: 'users', type: 'collection' },
+    ]);
+    const usersColl = makeSampleColl(
+      [
+        { _id: new ObjectIdCtor('a'.repeat(24)), name: 'A', age: 25 },
+        { _id: new ObjectIdCtor('b'.repeat(24)), name: 'B', email: 'b@x.com' },
+      ],
+      2,
+    );
+    mockDb.collection.mockReturnValueOnce(usersColl as unknown as typeof mockCollection);
+
+    const schema = await makeDriver().getSchema('shop');
+    const names = schema.tables[0].columns.map((c) => c.name).sort();
+    expect(names).toEqual(['_id', 'age', 'email', 'name']);
+  });
+
+  it('marks fields nullable when present in some but not all sampled docs', async () => {
+    mockListCursor.toArray.mockResolvedValueOnce([
+      { name: 'users', type: 'collection' },
+    ]);
+    const usersColl = makeSampleColl(
+      [
+        { _id: new ObjectIdCtor('a'.repeat(24)), name: 'A', age: 25 },
+        { _id: new ObjectIdCtor('b'.repeat(24)), name: 'B' },
+      ],
+      2,
+    );
+    mockDb.collection.mockReturnValueOnce(usersColl as unknown as typeof mockCollection);
+
+    const schema = await makeDriver().getSchema('shop');
+    const cmap = Object.fromEntries(
+      schema.tables[0].columns.map((c) => [c.name, c]),
+    );
+    // present in every doc → nullable false
+    expect(cmap['name'].nullable).toBe(false);
+    // present in only one doc → nullable true
+    expect(cmap['age'].nullable).toBe(true);
+    // _id is always non-nullable regardless of sample
+    expect(cmap['_id'].nullable).toBe(false);
+  });
+
+  it('reports type conflicts via comment and picks the most-frequent type', async () => {
+    mockListCursor.toArray.mockResolvedValueOnce([
+      { name: 'users', type: 'collection' },
+    ]);
+    const usersColl = makeSampleColl(
+      [
+        { _id: new ObjectIdCtor('a'.repeat(24)), age: 25 },
+        { _id: new ObjectIdCtor('b'.repeat(24)), age: 30 },
+        { _id: new ObjectIdCtor('c'.repeat(24)), age: 'thirty' },
+      ],
+      3,
+    );
+    mockDb.collection.mockReturnValueOnce(usersColl as unknown as typeof mockCollection);
+
+    const schema = await makeDriver().getSchema('shop');
+    const age = schema.tables[0].columns.find((c) => c.name === 'age')!;
+    expect(age.dataType).toBe('int'); // 2 ints beat 1 string
+    expect(age.comment).toBe('types: int, string');
+  });
+
+  it('falls back to first-seen type on a tie', async () => {
+    mockListCursor.toArray.mockResolvedValueOnce([
+      { name: 'users', type: 'collection' },
+    ]);
+    const usersColl = makeSampleColl(
+      [
+        { _id: new ObjectIdCtor('a'.repeat(24)), v: 'one' },
+        { _id: new ObjectIdCtor('b'.repeat(24)), v: 2 },
+      ],
+      2,
+    );
+    mockDb.collection.mockReturnValueOnce(usersColl as unknown as typeof mockCollection);
+
+    const schema = await makeDriver().getSchema('shop');
+    const v = schema.tables[0].columns.find((c) => c.name === 'v')!;
+    expect(v.dataType).toBe('string');
+    expect(v.comment).toBe('types: string, int');
+  });
+
   it('emits a placeholder _id column when a collection is empty', async () => {
     mockListCursor.toArray.mockResolvedValueOnce([{ name: 'empty', type: 'collection' }]);
-    const emptyColl = {
-      findOne: vi.fn().mockResolvedValueOnce(null),
-      estimatedDocumentCount: vi.fn().mockResolvedValueOnce(0),
-    };
+    const emptyColl = makeSampleColl([], 0);
     mockDb.collection.mockReturnValueOnce(emptyColl as unknown as typeof mockCollection);
     const schema = await makeDriver().getSchema('shop');
     expect(schema.tables[0].columns).toEqual([
-      expect.objectContaining({ name: '_id', pk: true, inferred: true }),
+      expect.objectContaining({ name: '_id', pk: true, inferred: true, nullable: false }),
     ]);
   });
 });
@@ -610,13 +716,24 @@ describe('MongoDBDriver – getTable', () => {
     expect(r).toBeNull();
   });
 
-  it('returns inferred columns when the collection exists', async () => {
+  it('returns inferred columns from union-of-keys sampling', async () => {
     mockListCursor.toArray.mockResolvedValueOnce([{ name: 'users', type: 'collection' }]);
-    mockCollection.findOne.mockResolvedValueOnce({ name: 'X' });
-    mockCollection.estimatedDocumentCount.mockResolvedValueOnce(3);
+    const usersColl = makeSampleColl(
+      [
+        { _id: new ObjectIdCtor('a'.repeat(24)), name: 'X' },
+        { _id: new ObjectIdCtor('b'.repeat(24)), name: 'Y', email: 'y@x.com' },
+      ],
+      3,
+    );
+    mockDb.collection.mockReturnValueOnce(usersColl as unknown as typeof mockCollection);
     const r = await makeDriver().getTable('shop', 'users');
+    expect(usersColl.sort).toHaveBeenCalledWith({ _id: -1 });
+    expect(usersColl.limit).toHaveBeenCalledWith(50);
     expect(r?.name).toBe('users');
-    expect(r?.columns.find((c) => c.name === 'name')?.inferred).toBe(true);
+    const cmap = Object.fromEntries(r!.columns.map((c) => [c.name, c]));
+    expect(cmap['name'].inferred).toBe(true);
+    expect(cmap['name'].nullable).toBe(false); // in both docs
+    expect(cmap['email'].nullable).toBe(true); // only in one doc
   });
 });
 

--- a/server/src/drivers/mongodb.ts
+++ b/server/src/drivers/mongodb.ts
@@ -38,6 +38,13 @@ interface MqlRequest {
 
 const SYSTEM_DBS = new Set(['admin', 'local', 'config']);
 
+// 50 docs is a compromise between schema coverage and per-collection latency
+// during getSchema (which fans out across every collection in the database).
+// We sort by `{_id: -1}` so the sample is deterministic and biased toward
+// recent writes — newer fields in evolving collections are more likely to
+// surface than if we picked an arbitrary natural-order page.
+const SAMPLE_SIZE = 50;
+
 function buildMongoUri(config: ConnectionConfig): string {
   if (config.connectionString) return config.connectionString;
   const user = config.user ?? '';
@@ -357,21 +364,18 @@ export class MongoDBDriver implements DbDriver {
     const baseCollections = collections.filter((c) => c.type !== 'view');
     const views = collections.filter((c) => c.type === 'view').map((c) => c.name);
 
-    // Best-effort field inference: we sample a single document and mark every
-    // column inferred:true. Fields that appear only on later documents are
-    // invisible to this pass. Tracked in #118 (union-of-keys sampling).
     const tables: TableInfo[] = await Promise.all(
       baseCollections.map(async (c) => {
         const coll = db.collection(c.name);
-        const [sample, count] = await Promise.all([
-          coll.findOne({}),
+        const [docs, count] = await Promise.all([
+          this.sampleDocs(coll),
           coll.estimatedDocumentCount().catch(() => 0),
         ]);
         return {
           name: c.name,
           rows: count,
           comment: '',
-          columns: this.inferColumns(sample),
+          columns: this.inferColumnsFromSample(docs),
         };
       }),
     );
@@ -390,20 +394,24 @@ export class MongoDBDriver implements DbDriver {
     const list = await db.listCollections({ name: table }, { nameOnly: false }).toArray();
     if (list.length === 0) return null;
     const coll = db.collection(table);
-    const [sample, count] = await Promise.all([
-      coll.findOne({}),
+    const [docs, count] = await Promise.all([
+      this.sampleDocs(coll),
       coll.estimatedDocumentCount().catch(() => 0),
     ]);
     return {
       name: table,
       rows: count,
       comment: '',
-      columns: this.inferColumns(sample),
+      columns: this.inferColumnsFromSample(docs),
     };
   }
 
-  private inferColumns(sample: Document | null): ColumnInfo[] {
-    if (!sample) {
+  private async sampleDocs(coll: ReturnType<Db['collection']>): Promise<Document[]> {
+    return coll.find({}).sort({ _id: -1 }).limit(SAMPLE_SIZE).toArray();
+  }
+
+  private inferColumnsFromSample(docs: Document[]): ColumnInfo[] {
+    if (docs.length === 0) {
       return [
         {
           name: '_id', type: 'objectId', dataType: 'objectId',
@@ -412,17 +420,56 @@ export class MongoDBDriver implements DbDriver {
         },
       ];
     }
-    return Object.keys(sample).map((name) => {
-      const dataType = inferDataType(sample[name]);
+
+    // Track first-seen order so the column list is stable, and per-type counts
+    // so we can pick the dominant dataType while surfacing conflicts.
+    const order: string[] = [];
+    const seen = new Set<string>();
+    const presence = new Map<string, number>();
+    const typeCounts = new Map<string, Map<string, number>>();
+    const typeOrder = new Map<string, string[]>();
+
+    for (const doc of docs) {
+      for (const name of Object.keys(doc)) {
+        if (!seen.has(name)) {
+          seen.add(name);
+          order.push(name);
+          typeCounts.set(name, new Map());
+          typeOrder.set(name, []);
+        }
+        presence.set(name, (presence.get(name) ?? 0) + 1);
+        const t = inferDataType(doc[name]);
+        const counts = typeCounts.get(name)!;
+        if (!counts.has(t)) typeOrder.get(name)!.push(t);
+        counts.set(t, (counts.get(t) ?? 0) + 1);
+      }
+    }
+
+    return order.map((name) => {
+      const counts = typeCounts.get(name)!;
+      const firstSeen = typeOrder.get(name)!;
+      // Most-frequent type wins; ties broken by first-seen order.
+      let dataType = firstSeen[0];
+      let best = counts.get(dataType)!;
+      for (const t of firstSeen) {
+        const c = counts.get(t)!;
+        if (c > best) {
+          best = c;
+          dataType = t;
+        }
+      }
+      const comment =
+        firstSeen.length > 1 ? `types: ${firstSeen.join(', ')}` : '';
+      const isId = name === '_id';
       return {
         name,
         type: dataType,
         dataType,
-        pk: name === '_id',
-        nullable: name !== '_id',
+        pk: isId,
+        nullable: isId ? false : (presence.get(name)! < docs.length),
         default: null,
         autoIncrement: false,
-        comment: '',
+        comment,
         inferred: true,
       };
     });


### PR DESCRIPTION
Closes #118.

Follow-up from PR #117 review (comment 3164075737).

## Summary

`MongoDBDriver` now infers collection schema by sampling up to 50 of the most-recent documents and taking the union of their keys, replacing the old single-`findOne()` pass. Both `getSchema` and `getTable` go through a shared `inferColumnsFromSample` helper.

## Acceptance criteria

- [x] `getSchema` and `getTable` sample N documents (default 50, module-level `SAMPLE_SIZE`)
- [x] Field list is the union of keys across the sample
- [x] `ColumnInfo.dataType` reflects the dominant type; conflicts surfaced via `comment: "types: a, b, ..."`
- [x] `nullable` is `false` only when the field is present in every sampled doc (`_id` stays hard-coded)
- [x] Existing tests still pass; new tests cover union-of-keys, nullable derivation, type-conflict comment, deterministic sort, and tie-breaking

## Design choices

- **Sample size 50** — picked at module scope; balances schema coverage vs. per-collection latency in `getSchema` fanout.
- **Sort `{_id: -1}` + `limit(50)`** — deterministic and recent-biased; uses the always-indexed `_id`.
- **Type conflicts** — most-frequent type wins, ties broken by first-seen order. The `comment` field lists every observed type in first-seen order so the order is stable across re-runs.
- **`_id`** — always `pk: true`, `nullable: false`. Empty collections still emit the placeholder `_id` column.

## Test plan

- [x] `cd server && npm run build` clean
- [x] `cd server && npm test` — 109 passed (55 in `mongodb.test.ts`)
- [x] Live smoke against a temp `mongo:7` container, seeded with `[{name:'A', age:25}, {name:'B', email:'b@x.com'}, {name:'C', age:'thirty'}]`. `getSchema` returned `_id`, `name`, `age`, `email` (the old single-doc path would have missed `email`); `age.comment` was `"types: string, int"`; `name.nullable` was `false`, `age.nullable` and `email.nullable` were `true`.
