### PR TITLE
feat: add MongoDB to docker-compose and integration test suite

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,3 +25,13 @@ services:
       interval: 2s
       timeout: 5s
       retries: 20
+
+  mongo-test:
+    image: mongo:7
+    ports:
+      - "27018:27017"
+    healthcheck:
+      test: ["CMD", "mongosh", "--quiet", "--eval", "db.adminCommand('ping').ok"]
+      interval: 2s
+      timeout: 5s
+      retries: 20

--- a/server/package.json
+++ b/server/package.json
@@ -10,7 +10,9 @@
     "build": "tsc",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:integration": "vitest run --config vitest.integration.config.ts"
+    "test:integration": "vitest run --config vitest.integration.config.ts",
+    "test:integration-pg": "vitest run --config vitest.integration-pg.config.ts",
+    "test:integration-mongo": "vitest run --config vitest.integration-mongo.config.ts"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",

--- a/server/src/drivers/mongodb.integration.test.ts
+++ b/server/src/drivers/mongodb.integration.test.ts
@@ -1,0 +1,285 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { MongoClient } from 'mongodb';
+import { MongoDBDriver } from './mongodb.js';
+
+const MONGO_CONFIG = {
+  host: process.env['MONGO_HOST'] ?? 'localhost',
+  port: Number(process.env['MONGO_PORT'] ?? 27018),
+  type: 'mongodb' as const,
+};
+
+let driver: MongoDBDriver;
+let raw: MongoClient;
+
+beforeAll(async () => {
+  driver = new MongoDBDriver(MONGO_CONFIG);
+  raw = new MongoClient(`mongodb://${MONGO_CONFIG.host}:${MONGO_CONFIG.port}/`);
+  await raw.connect();
+});
+
+afterAll(async () => {
+  await raw.close();
+  await driver.end();
+});
+
+beforeEach(async () => {
+  await raw.db('helix_test').collection('users').deleteMany({});
+});
+
+afterEach(async () => {
+  await raw.db('helix_test').collection('users').deleteMany({});
+});
+
+// ---------------------------------------------------------------------------
+// ping
+// ---------------------------------------------------------------------------
+
+describe('MongoDBDriver – ping', () => {
+  it('resolves without error when connected', async () => {
+    await expect(driver.ping()).resolves.toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getSchemas
+// ---------------------------------------------------------------------------
+
+describe('MongoDBDriver – getSchemas', () => {
+  it('returns user databases and excludes system databases', async () => {
+    const schemas = await driver.getSchemas();
+    expect(schemas).toContain('helix_test');
+    expect(schemas).not.toContain('admin');
+    expect(schemas).not.toContain('local');
+    expect(schemas).not.toContain('config');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getSchema
+// ---------------------------------------------------------------------------
+
+describe('MongoDBDriver – getSchema', () => {
+  it('returns collections with inferred columns from a sample document', async () => {
+    await raw.db('helix_test').collection('users').insertOne({ name: 'Alice', age: 30 });
+    const info = await driver.getSchema('helix_test');
+    const users = info.tables.find(t => t.name === 'users');
+    expect(users).toBeDefined();
+    const names = users!.columns.map(c => c.name);
+    expect(names).toContain('_id');
+    expect(names).toContain('name');
+    expect(names).toContain('age');
+  });
+
+  it('returns _id-only columns for an empty collection', async () => {
+    const info = await driver.getSchema('helix_test');
+    const users = info.tables.find(t => t.name === 'users');
+    expect(users).toBeDefined();
+    expect(users!.columns.map(c => c.name)).toEqual(['_id']);
+  });
+
+  it('marks _id column as pk', async () => {
+    await raw.db('helix_test').collection('users').insertOne({ name: 'Bob' });
+    const info = await driver.getSchema('helix_test');
+    const idCol = info.tables.find(t => t.name === 'users')!.columns.find(c => c.name === '_id');
+    expect(idCol!.pk).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// query – find
+// ---------------------------------------------------------------------------
+
+describe('MongoDBDriver – query (find)', () => {
+  it('returns empty rows when collection is empty', async () => {
+    const result = await driver.query(
+      JSON.stringify({ collection: 'users', operation: 'find' }),
+      [],
+      'helix_test',
+    );
+    expect(result.rows).toEqual([]);
+  });
+
+  it('returns inserted documents', async () => {
+    await raw.db('helix_test').collection('users').insertMany([
+      { name: 'Alice', age: 30 },
+      { name: 'Bob', age: 25 },
+    ]);
+    const result = await driver.query(
+      JSON.stringify({ collection: 'users', operation: 'find', sort: { name: 1 } }),
+      [],
+      'helix_test',
+    );
+    expect(result.rows).toHaveLength(2);
+    expect(result.rows[0]).toMatchObject({ name: 'Alice', age: 30 });
+    expect(result.rows[1]).toMatchObject({ name: 'Bob', age: 25 });
+  });
+
+  it('serializes ObjectId _id as a hex string', async () => {
+    await raw.db('helix_test').collection('users').insertOne({ name: 'Carol' });
+    const result = await driver.query(
+      JSON.stringify({ collection: 'users', operation: 'find' }),
+      [],
+      'helix_test',
+    );
+    expect(typeof result.rows[0]!['_id']).toBe('string');
+    expect(result.rows[0]!['_id']).toMatch(/^[a-f0-9]{24}$/);
+  });
+
+  it('applies limit', async () => {
+    await raw.db('helix_test').collection('users').insertMany([
+      { name: 'A' }, { name: 'B' }, { name: 'C' },
+    ]);
+    const result = await driver.query(
+      JSON.stringify({ collection: 'users', operation: 'find', limit: 2 }),
+      [],
+      'helix_test',
+    );
+    expect(result.rows).toHaveLength(2);
+  });
+
+  it('populates columnMeta with correct names', async () => {
+    await raw.db('helix_test').collection('users').insertOne({ name: 'Dave', age: 40 });
+    const result = await driver.query(
+      JSON.stringify({ collection: 'users', operation: 'find' }),
+      [],
+      'helix_test',
+    );
+    const names = result.columnMeta.map(c => c.name);
+    expect(names).toContain('_id');
+    expect(names).toContain('name');
+    expect(names).toContain('age');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// query – count
+// ---------------------------------------------------------------------------
+
+describe('MongoDBDriver – query (count)', () => {
+  it('returns 0 for an empty collection', async () => {
+    const result = await driver.query(
+      JSON.stringify({ collection: 'users', operation: 'count' }),
+      [],
+      'helix_test',
+    );
+    expect(result.rows[0]).toMatchObject({ count: 0 });
+  });
+
+  it('returns correct count after inserts', async () => {
+    await raw.db('helix_test').collection('users').insertMany([{ name: 'A' }, { name: 'B' }]);
+    const result = await driver.query(
+      JSON.stringify({ collection: 'users', operation: 'count' }),
+      [],
+      'helix_test',
+    );
+    expect(result.rows[0]).toMatchObject({ count: 2 });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// query – insertOne
+// ---------------------------------------------------------------------------
+
+describe('MongoDBDriver – query (insertOne)', () => {
+  it('inserts a document and reports affectedRows: 1', async () => {
+    const result = await driver.query(
+      JSON.stringify({ collection: 'users', operation: 'insertOne', document: { name: 'Eve', age: 22 } }),
+      [],
+      'helix_test',
+    );
+    expect(result.affectedRows).toBe(1);
+    const doc = await raw.db('helix_test').collection('users').findOne({ name: 'Eve' });
+    expect(doc).not.toBeNull();
+    expect(doc!['age']).toBe(22);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// query – updateOne
+// ---------------------------------------------------------------------------
+
+describe('MongoDBDriver – query (updateOne)', () => {
+  it('updates a document by id and reports affectedRows: 1', async () => {
+    const { insertedId } = await raw.db('helix_test').collection('users').insertOne({ name: 'Frank', age: 30 });
+    const result = await driver.query(
+      JSON.stringify({
+        collection: 'users',
+        operation: 'updateOne',
+        id: insertedId.toHexString(),
+        update: { $set: { age: 31 } },
+      }),
+      [],
+      'helix_test',
+    );
+    expect(result.affectedRows).toBe(1);
+    const doc = await raw.db('helix_test').collection('users').findOne({ _id: insertedId });
+    expect(doc!['age']).toBe(31);
+  });
+
+  it('reports affectedRows: 0 for a non-existent id', async () => {
+    const result = await driver.query(
+      JSON.stringify({
+        collection: 'users',
+        operation: 'updateOne',
+        id: '000000000000000000000000',
+        update: { $set: { age: 99 } },
+      }),
+      [],
+      'helix_test',
+    );
+    expect(result.affectedRows).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// query – deleteOne
+// ---------------------------------------------------------------------------
+
+describe('MongoDBDriver – query (deleteOne)', () => {
+  it('deletes a document by id and reports affectedRows: 1', async () => {
+    const { insertedId } = await raw.db('helix_test').collection('users').insertOne({ name: 'Grace' });
+    const result = await driver.query(
+      JSON.stringify({
+        collection: 'users',
+        operation: 'deleteOne',
+        id: insertedId.toHexString(),
+      }),
+      [],
+      'helix_test',
+    );
+    expect(result.affectedRows).toBe(1);
+    const doc = await raw.db('helix_test').collection('users').findOne({ _id: insertedId });
+    expect(doc).toBeNull();
+  });
+
+  it('reports affectedRows: 0 for a non-existent id', async () => {
+    const result = await driver.query(
+      JSON.stringify({
+        collection: 'users',
+        operation: 'deleteOne',
+        id: '000000000000000000000000',
+      }),
+      [],
+      'helix_test',
+    );
+    expect(result.affectedRows).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getCollectionInfo
+// ---------------------------------------------------------------------------
+
+describe('MongoDBDriver – getCollectionInfo', () => {
+  it('returns indexes including the default _id index', async () => {
+    const info = await driver.getCollectionInfo('helix_test', 'users');
+    expect(info).not.toBeNull();
+    const idIndex = info!.indexes.find((i: Record<string, unknown>) => '_id' in (i['key'] as object));
+    expect(idIndex).toBeDefined();
+  });
+
+  it('returns null for a non-existent collection', async () => {
+    const info = await driver.getCollectionInfo('helix_test', 'nonexistent_collection');
+    expect(info).toBeNull();
+  });
+});

--- a/server/src/test-setup/global-setup-mongo.ts
+++ b/server/src/test-setup/global-setup-mongo.ts
@@ -1,0 +1,49 @@
+import { MongoClient } from 'mongodb';
+
+const TIMEOUT_MS = 30_000;
+const POLL_MS = 500;
+
+const uri = `mongodb://${process.env['MONGO_HOST'] ?? 'localhost'}:${process.env['MONGO_PORT'] ?? 27018}/`;
+
+async function waitForMongo(): Promise<MongoClient> {
+  const deadline = Date.now() + TIMEOUT_MS;
+  let lastError: unknown;
+  while (Date.now() < deadline) {
+    const client = new MongoClient(uri, { serverSelectionTimeoutMS: 1000 });
+    try {
+      await client.connect();
+      await client.db('admin').command({ ping: 1 });
+      return client;
+    } catch (err) {
+      lastError = err;
+      await client.close().catch(() => {});
+    }
+    await new Promise(r => setTimeout(r, POLL_MS));
+  }
+  throw new Error(`MongoDB not reachable after ${TIMEOUT_MS}ms: ${lastError}`);
+}
+
+export async function setup() {
+  const client = await waitForMongo();
+  try {
+    const db = client.db('helix_test');
+    await db.dropDatabase();
+    await db.createCollection('users');
+    await db.collection('users').createIndex({ name: 1 });
+    // Insert and remove a sentinel so listDatabases shows helix_test immediately.
+    await db.collection('users').insertOne({ _setup: true });
+    await db.collection('users').deleteMany({ _setup: true });
+  } finally {
+    await client.close();
+  }
+}
+
+export async function teardown() {
+  const client = new MongoClient(uri);
+  try {
+    await client.connect();
+    await client.db('helix_test').dropDatabase();
+  } finally {
+    await client.close();
+  }
+}

--- a/server/src/test-setup/global-setup.ts
+++ b/server/src/test-setup/global-setup.ts
@@ -44,6 +44,14 @@ export async function setup() {
         age  INT,
         bio  TEXT
       );
+
+      CREATE TABLE orders (
+        id         INT AUTO_INCREMENT PRIMARY KEY,
+        user_id    INT,
+        total      DECIMAL(10,2) NOT NULL,
+        created_at DATETIME DEFAULT NOW(),
+        INDEX idx_orders_user_id (user_id)
+      );
     `);
   } finally {
     await conn.end();

--- a/server/vitest.integration-mongo.config.ts
+++ b/server/vitest.integration-mongo.config.ts
@@ -3,8 +3,8 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     environment: 'node',
-    include: ['src/drivers/postgres.integration.test.ts'],
-    globalSetup: './src/test-setup/global-setup-postgres.ts',
+    include: ['src/drivers/mongodb.integration.test.ts'],
+    globalSetup: './src/test-setup/global-setup-mongo.ts',
     testTimeout: 15000,
     hookTimeout: 15000,
     pool: 'forks',

--- a/server/vitest.integration.config.ts
+++ b/server/vitest.integration.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     environment: 'node',
-    include: ['src/**/*.integration.test.ts'],
+    include: ['src/routes/*.integration.test.ts'],
     globalSetup: './src/test-setup/global-setup.ts',
     testTimeout: 15000,
     hookTimeout: 15000,


### PR DESCRIPTION
## Summary

- Add `mongo-test` service (Mongo 7, port `27018:27017`) to `docker-compose.yml` — all three test databases (MySQL, PostgreSQL, MongoDB) are now in one `docker compose up`
- Add `global-setup-mongo.ts`: waits for Mongo to be reachable, drops/recreates `helix_test`, seeds a sentinel document so `listDatabases` sees the DB before any test writes
- Add `mongodb.integration.test.ts`: 19 tests covering `ping`, `getSchemas`, `getSchema`, `query` (find / count / insertOne / updateOne / deleteOne), and `getCollectionInfo`
- Add `vitest.integration-mongo.config.ts` and `test:integration-mongo` npm script
- Add `test:integration-pg` npm script for the existing Postgres suite (it had a config but no script)
- Fix `global-setup.ts` (MySQL) to also create the `orders` table that the CRUD integration tests truncate in `beforeEach`
- Narrow glob patterns in MySQL and PG integration configs so each config picks up only its own test file

## Test plan

```bash
docker compose up -d --wait        # all three services healthy
cd server
npm test                           # 105 unit tests — all pass
npm run test:integration           # 16 MySQL integration tests — all pass
npm run test:integration-pg        # 19 Postgres integration tests — all pass
npm run test:integration-mongo     # 19 MongoDB integration tests — all pass
```
