### PR TITLE
fix: render <select> for enum columns in Insert Row dialog

### DIFF
--- a/src/components/InsertRowDialog.tsx
+++ b/src/components/InsertRowDialog.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useMemo } from 'react';
 import type { CSSProperties } from 'react';
 import type { Theme } from '../theme';
 import type { SchemaColumn } from '../api';
-import { buildInsertSql } from '../lib/sql';
+import { buildInsertSql, parseEnumValues } from '../lib/sql';
 
 type CellValue = string | number | boolean | null;
 type EditKind = 'boolean' | 'number' | 'date' | 'datetime' | 'time' | 'text';
@@ -156,12 +156,14 @@ export function InsertRowDialog({ table, columns, onSubmit, onClose, t }: Insert
               )}
               {editable.map(col => {
                 const kind = editKindForColumn(col);
+                const enumValues = col.dataType === 'enum' ? parseEnumValues(col.type) : null;
                 const inputType = kind === 'number' ? 'number'
                   : kind === 'date' ? 'date'
                   : kind === 'datetime' ? 'datetime-local'
                   : kind === 'time' ? 'time'
                   : 'text';
                 const required = !col.nullable && col.default === null;
+                const hasBlankOption = col.default !== null || col.nullable;
                 const blankLabel = col.default !== null ? `default: ${col.default}`
                   : col.nullable ? 'NULL'
                   : '';
@@ -181,11 +183,28 @@ export function InsertRowDialog({ table, columns, onSubmit, onClose, t }: Insert
                           onChange={(e) => setDrafts(p => ({ ...p, [col.name]: e.target.value }))}
                           style={s.input}
                         >
-                          {(col.default !== null || col.nullable) && (
+                          {hasBlankOption && (
                             <option value="">{blankLabel}</option>
                           )}
                           <option value="true">true</option>
                           <option value="false">false</option>
+                        </select>
+                      ) : enumValues ? (
+                        <select
+                          value={drafts[col.name] ?? ''}
+                          onChange={(e) => setDrafts(p => ({ ...p, [col.name]: e.target.value }))}
+                          style={s.input}
+                        >
+                          {hasBlankOption ? (
+                            <option value="">{blankLabel}</option>
+                          ) : (
+                            // Disabled placeholder keeps the visible state aligned with the
+                            // empty draft, so the browser doesn't silently surface the first
+                            // enum value while still routing through the "Required column"
+                            // validator if the user hits Review SQL without picking.
+                            <option value="" disabled>— select —</option>
+                          )}
+                          {enumValues.map(v => <option key={v} value={v}>{v}</option>)}
                         </select>
                       ) : (
                         <input

--- a/src/lib/sql.test.ts
+++ b/src/lib/sql.test.ts
@@ -1,5 +1,36 @@
 import { describe, it, expect } from 'vitest';
-import { formatSqlValue, buildInsertSql } from './sql';
+import { formatSqlValue, buildInsertSql, parseEnumValues } from './sql';
+
+describe('parseEnumValues', () => {
+  it('parses a standard enum type', () => {
+    expect(parseEnumValues("enum('active','inactive','pending')")).toEqual(['active', 'inactive', 'pending']);
+  });
+
+  it('parses a single-value enum', () => {
+    expect(parseEnumValues("enum('only')")).toEqual(['only']);
+  });
+
+  it('unescapes single quotes inside values', () => {
+    expect(parseEnumValues("enum('O\\'Brien','Smith')")).toEqual(["O'Brien", 'Smith']);
+  });
+
+  it('unescapes backslashes inside values', () => {
+    expect(parseEnumValues("enum('C:\\\\path')")).toEqual(['C:\\path']);
+  });
+
+  it('returns null for non-enum types', () => {
+    expect(parseEnumValues('varchar(100)')).toBeNull();
+    expect(parseEnumValues('int')).toBeNull();
+  });
+
+  it('returns null for an empty string', () => {
+    expect(parseEnumValues('')).toBeNull();
+  });
+
+  it('is case-insensitive for the ENUM keyword', () => {
+    expect(parseEnumValues("ENUM('a','b')")).toEqual(['a', 'b']);
+  });
+});
 
 describe('formatSqlValue', () => {
   it('renders NULL for null', () => {

--- a/src/lib/sql.ts
+++ b/src/lib/sql.ts
@@ -1,5 +1,17 @@
 type CellValue = string | number | boolean | null;
 
+export function parseEnumValues(type: string): string[] | null {
+  const match = type.match(/^enum\((.+)\)$/i);
+  if (!match) return null;
+  const values: string[] = [];
+  const re = /'((?:[^'\\]|\\.)*)'/g;
+  let m;
+  while ((m = re.exec(match[1])) !== null) {
+    values.push(m[1].replace(/\\'/g, "'").replace(/\\\\/g, '\\'));
+  }
+  return values.length > 0 ? values : null;
+}
+
 export function formatSqlValue(v: CellValue): string {
   if (v === null) return 'NULL';
   if (typeof v === 'string') return `'${v.replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`;


### PR DESCRIPTION
## Summary

- Enum columns in the Insert Row dialog were plain text inputs, requiring users to guess valid values
- Now detects `enum('a','b','c')` columns via `dataType === 'enum'` and renders a native `<select>` with the parsed options
- Columns with a default or nullable get a leading blank option (labelled `default: active` or `NULL`); required enums have no blank option

## Implementation

- Added `parseEnumValues(type: string): string[] | null` to `src/lib/sql.ts` — parses the full `enum('active','inactive','pending')` type string, handles escaped single quotes and backslashes
- 7 new unit tests for `parseEnumValues` (standard, single-value, escaped quotes/backslashes, non-enum returns null, case-insensitive)

## Test plan

- [ ] Open Insert Row on a table with an enum column — verify a `<select>` renders instead of a text input
- [ ] Confirm all enum values appear as options
- [ ] Nullable/defaulted enum: verify a blank leading option appears
- [ ] Required enum (NOT NULL, no default): verify no blank option
- [ ] Select a value, click Review SQL — verify the selected value appears correctly quoted in the INSERT statement
- [ ] `npm test` passes (19 tests)

Generated with [Claude Code](https://claude.com/claude-code)