### PR TITLE
feat: make schema browser sidebar resizable

### DIFF
--- a/src/components/SchemaBrowser.tsx
+++ b/src/components/SchemaBrowser.tsx
@@ -93,24 +93,47 @@ export function SchemaBrowser({ schema, activeTable, onTableSelect, onSchemaChan
   const [resizing, setResizing] = useState(false);
   const dropInputRef = useRef<HTMLInputElement>(null);
 
+  // Holds the teardown for an in-flight drag so the unmount cleanup below can
+  // remove the window listeners and restore body styles even if the user
+  // disconnects (or otherwise unmounts the browser) mid-drag.
+  const dragCleanupRef = useRef<(() => void) | null>(null);
+  useEffect(() => () => { dragCleanupRef.current?.(); }, []);
+
   const onResizeStart = (e: React.MouseEvent) => {
+    if (e.button !== 0) return;
     e.preventDefault();
     setResizing(true);
     const startX = e.clientX;
     const startWidth = width;
     let lastWidth = startWidth;
+
+    // Lock document-level cursor + selection so the browser doesn't start
+    // selecting text — and flip the cursor away from col-resize — once the
+    // pointer leaves the 5px handle during a drag.
+    const prevUserSelect = document.body.style.userSelect;
+    const prevCursor = document.body.style.cursor;
+    document.body.style.userSelect = 'none';
+    document.body.style.cursor = 'col-resize';
+
     const onMove = (ev: MouseEvent) => {
       lastWidth = Math.max(MIN_WIDTH, Math.min(MAX_WIDTH, startWidth + (ev.clientX - startX)));
       setWidth(lastWidth);
     };
-    const onUp = () => {
-      setResizing(false);
+    const cleanup = () => {
       window.removeEventListener('mousemove', onMove);
       window.removeEventListener('mouseup', onUp);
+      document.body.style.userSelect = prevUserSelect;
+      document.body.style.cursor = prevCursor;
+      dragCleanupRef.current = null;
+    };
+    const onUp = () => {
+      setResizing(false);
+      cleanup();
       try { localStorage.setItem(WIDTH_KEY, String(lastWidth)); } catch { /* quota or disabled */ }
     };
     window.addEventListener('mousemove', onMove);
     window.addEventListener('mouseup', onUp);
+    dragCleanupRef.current = cleanup;
   };
 
   useEffect(() => {

--- a/src/components/SchemaBrowser.tsx
+++ b/src/components/SchemaBrowser.tsx
@@ -67,6 +67,21 @@ function NonTableGroupItems({ groupKey, label, schema, filter, t, emptyStyle, ro
   ))}</>;
 }
 
+const WIDTH_KEY = 'helix.schemaBrowser.width';
+const MIN_WIDTH = 160;
+const MAX_WIDTH = 600;
+const DEFAULT_WIDTH = 224;
+
+function readStoredWidth(): number {
+  try {
+    const v = localStorage.getItem(WIDTH_KEY);
+    const n = v ? parseInt(v, 10) : NaN;
+    return Number.isFinite(n) && n >= MIN_WIDTH && n <= MAX_WIDTH ? n : DEFAULT_WIDTH;
+  } catch {
+    return DEFAULT_WIDTH;
+  }
+}
+
 export function SchemaBrowser({ schema, activeTable, onTableSelect, onSchemaChange, schemas, activeSchema, onDropTable, t }: SchemaBrowserProps) {
   const [expanded, setExpanded] = useState({ tables: true, views: false, procedures: false, triggers: false });
   const [expandedTables, setExpandedTables] = useState<Record<string, boolean>>({});
@@ -74,7 +89,29 @@ export function SchemaBrowser({ schema, activeTable, onTableSelect, onSchemaChan
   const [contextMenu, setContextMenu] = useState<{ x: number; y: number; name: string; type: ObjectType } | null>(null);
   const [showSchemaFor, setShowSchemaFor] = useState<{ name: string; type: ObjectType } | null>(null);
   const [confirmDrop, setConfirmDrop] = useState<ConfirmDrop | null>(null);
+  const [width, setWidth] = useState<number>(readStoredWidth);
+  const [resizing, setResizing] = useState(false);
   const dropInputRef = useRef<HTMLInputElement>(null);
+
+  const onResizeStart = (e: React.MouseEvent) => {
+    e.preventDefault();
+    setResizing(true);
+    const startX = e.clientX;
+    const startWidth = width;
+    let lastWidth = startWidth;
+    const onMove = (ev: MouseEvent) => {
+      lastWidth = Math.max(MIN_WIDTH, Math.min(MAX_WIDTH, startWidth + (ev.clientX - startX)));
+      setWidth(lastWidth);
+    };
+    const onUp = () => {
+      setResizing(false);
+      window.removeEventListener('mousemove', onMove);
+      window.removeEventListener('mouseup', onUp);
+      try { localStorage.setItem(WIDTH_KEY, String(lastWidth)); } catch { /* quota or disabled */ }
+    };
+    window.addEventListener('mousemove', onMove);
+    window.addEventListener('mouseup', onUp);
+  };
 
   useEffect(() => {
     if (!contextMenu) return;
@@ -100,7 +137,8 @@ export function SchemaBrowser({ schema, activeTable, onTableSelect, onSchemaChan
   const toggleTable = (name: string) => setExpandedTables(p => ({ ...p, [name]: !p[name] }));
 
   const s = {
-    root: { width: 224, background: t.bgSurface, borderRight: `1px solid ${t.border}`, display: 'flex', flexDirection: 'column', overflow: 'hidden', flexShrink: 0 } as CSSProperties,
+    root: { width, position: 'relative', background: t.bgSurface, borderRight: `1px solid ${t.border}`, display: 'flex', flexDirection: 'column', overflow: 'hidden', flexShrink: 0 } as CSSProperties,
+    resizeHandle: { position: 'absolute', top: 0, right: 0, width: 5, height: '100%', cursor: 'col-resize', zIndex: 10, background: resizing ? t.accent : 'transparent', transition: resizing ? 'none' : 'background 120ms', userSelect: 'none' } as CSSProperties,
     header: { padding: '8px 10px', borderBottom: `1px solid ${t.border}`, display: 'flex', alignItems: 'center', gap: 8, flexShrink: 0, background: t.bgToolbar } as CSSProperties,
     schemaSelect: { flex: 1, background: 'transparent', border: 'none', outline: 'none', font: `500 12px/1 "IBM Plex Sans", sans-serif`, color: t.textPrimary, cursor: 'pointer', minWidth: 0 } as CSSProperties,
     searchWrap: { padding: '6px 10px', borderBottom: `1px solid ${t.borderSubtle}`, display: 'flex', alignItems: 'center', gap: 7, flexShrink: 0 } as CSSProperties,
@@ -131,6 +169,13 @@ export function SchemaBrowser({ schema, activeTable, onTableSelect, onSchemaChan
 
   return (
     <div style={s.root}>
+      <div
+        style={s.resizeHandle}
+        onMouseDown={onResizeStart}
+        onMouseEnter={(e) => { if (!resizing) e.currentTarget.style.background = t.accent; }}
+        onMouseLeave={(e) => { if (!resizing) e.currentTarget.style.background = 'transparent'; }}
+        title="Drag to resize"
+      />
       <div style={s.header}>
         <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke={t.textMuted} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{flexShrink:0}}>
           <ellipse cx="12" cy="5" rx="9" ry="3"/><path d="M21 12c0 1.66-4 3-9 3s-9-1.34-9-3"/><path d="M3 5v14c0 1.66 4 3 9 3s9-1.34 9-3V5"/>


### PR DESCRIPTION
## Summary
- The schema browser sidebar had a fixed 224px width, so long table names were truncated with no way to see the full name. Add a drag-to-resize handle on the right edge.
- 5px hit target with `cursor: col-resize`, highlights in the accent color on hover and during drag.
- Width clamped between 160px (min) and 600px (max), default 224px.
- Persisted to \`localStorage\` (key: \`helix.schemaBrowser.width\`) on mouseup; restored on next load.

## Test plan
- [ ] Connect to any database with a long table name. Default 224px width truncates as before.
- [ ] Drag the right edge of the sidebar wider — long names become readable.
- [ ] Drag past 160px / 600px — width clamps at the limit.
- [ ] Reload the page — chosen width is restored.
- [ ] \`tsc -b\` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)