### PR TITLE
feat: run multiple SQL statements in one query

### DIFF
--- a/server/src/drivers/interface.ts
+++ b/server/src/drivers/interface.ts
@@ -75,6 +75,11 @@ export interface DbDriver {
   readonly queryMode: 'sql' | 'mql';
   /** Run a query, optionally switching schema first (atomically on one connection). */
   query(sql: string, params?: unknown[], schema?: string): Promise<QueryResult>;
+  /**
+   * Run one or more semicolon-separated statements and return a result per statement.
+   * Implemented by sql-mode drivers; mql-mode drivers can omit it.
+   */
+  queryAll?(sql: string, schema?: string): Promise<QueryResult[]>;
   getSchemas(): Promise<string[]>;
   getSchema(schema: string): Promise<SchemaInfo>;
   /** Targeted lookup for a single table — returns null if it doesn't exist. */

--- a/server/src/drivers/mysql.test.ts
+++ b/server/src/drivers/mysql.test.ts
@@ -141,3 +141,43 @@ describe('MysqlDriver.recyclePool', () => {
     expect(opts.keepAliveInitialDelay).toBe(10_000);
   });
 });
+
+describe('MysqlDriver.queryAll – multi-statement results', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPool.getConnection.mockResolvedValue(mockConn);
+  });
+
+  it('returns one result per statement when mysql2 returns parallel arrays', async () => {
+    // mysql2's shape for multi-statement responses: arrays-of-arrays for both rows and fields.
+    mockConn.query.mockResolvedValueOnce([
+      [
+        [{ a: 1 }],
+        [{ b: 2 }],
+      ],
+      [
+        [{ name: 'a' }],
+        [{ name: 'b' }],
+      ],
+    ]);
+    const results = await makeDriver().queryAll('SELECT 1 AS a; SELECT 2 AS b');
+    expect(results).toHaveLength(2);
+    expect(results[0].rows).toEqual([{ a: 1 }]);
+    expect(results[1].rows).toEqual([{ b: 2 }]);
+    expect(mockConn.release).toHaveBeenCalledTimes(1);
+  });
+
+  it('wraps a single-statement response in a one-element array', async () => {
+    mockConn.query.mockResolvedValueOnce([[{ id: 1 }], [{ name: 'id' }]]);
+    const results = await makeDriver().queryAll('SELECT 1 AS id');
+    expect(results).toHaveLength(1);
+    expect(results[0].rows).toEqual([{ id: 1 }]);
+    expect(mockConn.release).toHaveBeenCalledTimes(1);
+  });
+
+  it('releases the connection when queryAll rejects', async () => {
+    mockConn.query.mockRejectedValueOnce(new Error('multi boom'));
+    await expect(makeDriver().queryAll('SELECT 1; SELECT 2')).rejects.toThrow('multi boom');
+    expect(mockConn.release).toHaveBeenCalledTimes(1);
+  });
+});

--- a/server/src/drivers/mysql.ts
+++ b/server/src/drivers/mysql.ts
@@ -15,12 +15,72 @@ function buildMysqlPoolOptions(config: ConnectionConfig): mysql.PoolOptions {
     waitForConnections: true,
     connectionLimit: 5,
     connectTimeout: 10_000,
+    multipleStatements: true,
     // OS-level TCP keepalive — without this, dead sockets after macOS sleep
     // are only surfaced by the kernel's default ~2-hour timer, which causes
     // the first post-resume query to hang. See #145.
     enableKeepAlive: true,
     keepAliveInitialDelay: 10_000,
   };
+}
+
+const MYSQL_NOT_NULL_FLAG = 1;
+const MYSQL_PRI_KEY_FLAG = 2;
+const MYSQL_UNIQUE_KEY_FLAG = 4;
+
+function buildMysqlResult(rows: RowDataPacket[] | ResultSetHeader, fields: FieldPacket[]): QueryResult {
+  if (!Array.isArray(rows)) {
+    const result = rows as ResultSetHeader;
+    return {
+      rows: [],
+      columnMeta: [],
+      affectedRows: result.affectedRows ?? 0,
+      insertId: result.insertId ?? null,
+    };
+  }
+
+  const columnMeta: ColumnMeta[] = fields.map(f => {
+    let flagsNum = 0;
+    if (typeof f.flags === 'number') {
+      flagsNum = f.flags;
+    } else if (Array.isArray(f.flags)) {
+      if ((f.flags as string[]).includes('NOT_NULL')) flagsNum |= MYSQL_NOT_NULL_FLAG;
+      if ((f.flags as string[]).includes('PRI_KEY')) flagsNum |= MYSQL_PRI_KEY_FLAG;
+      if ((f.flags as string[]).includes('UNIQUE_KEY')) flagsNum |= MYSQL_UNIQUE_KEY_FLAG;
+    }
+    return {
+      name: f.name,
+      orgName: f.orgName ?? f.name,
+      table: f.table ?? '',
+      orgTable: f.orgTable ?? '',
+      pk: (flagsNum & MYSQL_PRI_KEY_FLAG) === MYSQL_PRI_KEY_FLAG,
+      unique: (flagsNum & MYSQL_UNIQUE_KEY_FLAG) === MYSQL_UNIQUE_KEY_FLAG,
+      notNull: (flagsNum & MYSQL_NOT_NULL_FLAG) === MYSQL_NOT_NULL_FLAG,
+      mysqlType: f.columnType ?? f.type ?? 0,
+    };
+  });
+
+  const columns = fields.map(f => f.name);
+  const serializedRows = (rows as RowDataPacket[]).map(row => {
+    const out: Record<string, unknown> = {};
+    for (const col of columns) {
+      const val = row[col];
+      if (val === null || val === undefined) {
+        out[col] = null;
+      } else if (Buffer.isBuffer(val)) {
+        out[col] = val.toString('hex');
+      } else if (val instanceof Date) {
+        out[col] = val.toISOString().replace('T', ' ').replace(/\.\d{3}Z$/, '');
+      } else if (typeof val === 'bigint') {
+        out[col] = val.toString();
+      } else {
+        out[col] = val;
+      }
+    }
+    return out;
+  });
+
+  return { rows: serializedRows, columnMeta };
 }
 
 export class MysqlDriver implements DbDriver {
@@ -91,63 +151,41 @@ export class MysqlDriver implements DbDriver {
       }
 
       const [rows, fields] = await conn.query(sql, params) as [RowDataPacket[] | ResultSetHeader, FieldPacket[]];
-
-      if (!Array.isArray(rows)) {
-        const result = rows as ResultSetHeader;
-        return {
-          rows: [],
-          columnMeta: [],
-          affectedRows: result.affectedRows ?? 0,
-          insertId: result.insertId ?? null,
-        };
+      // With multipleStatements enabled, mysql2 returns arrays-of-arrays when
+      // the SQL contains more than one statement. Internal callers (insertRow,
+      // updateCell, deleteRow, …) only ever pass single statements, so flatten
+      // the multi-result shape down to the first set here for the legacy contract.
+      // Multi-statement user input goes through `queryAll` instead.
+      if (Array.isArray(rows) && rows.length > 0 && Array.isArray((rows as unknown[])[0])) {
+        const firstRows = (rows as unknown as RowDataPacket[][])[0];
+        const firstFields = (fields as unknown as FieldPacket[][])[0] ?? [];
+        return buildMysqlResult(firstRows, firstFields);
       }
+      return buildMysqlResult(rows, fields);
+    } finally {
+      conn.release();
+    }
+  }
 
-      const NOT_NULL_FLAG = 1;
-      const PRI_KEY_FLAG = 2;
-      const UNIQUE_KEY_FLAG = 4;
-
-      const columnMeta: ColumnMeta[] = fields.map(f => {
-        let flagsNum = 0;
-        if (typeof f.flags === 'number') {
-          flagsNum = f.flags;
-        } else if (Array.isArray(f.flags)) {
-          if ((f.flags as string[]).includes('NOT_NULL')) flagsNum |= NOT_NULL_FLAG;
-          if ((f.flags as string[]).includes('PRI_KEY')) flagsNum |= PRI_KEY_FLAG;
-          if ((f.flags as string[]).includes('UNIQUE_KEY')) flagsNum |= UNIQUE_KEY_FLAG;
-        }
-        return {
-          name: f.name,
-          orgName: f.orgName ?? f.name,
-          table: f.table ?? '',
-          orgTable: f.orgTable ?? '',
-          pk: (flagsNum & PRI_KEY_FLAG) === PRI_KEY_FLAG,
-          unique: (flagsNum & UNIQUE_KEY_FLAG) === UNIQUE_KEY_FLAG,
-          notNull: (flagsNum & NOT_NULL_FLAG) === NOT_NULL_FLAG,
-          mysqlType: f.columnType ?? f.type ?? 0,
-        };
-      });
-
-      const columns = fields.map(f => f.name);
-      const serializedRows = (rows as RowDataPacket[]).map(row => {
-        const out: Record<string, unknown> = {};
-        for (const col of columns) {
-          const val = row[col];
-          if (val === null || val === undefined) {
-            out[col] = null;
-          } else if (Buffer.isBuffer(val)) {
-            out[col] = val.toString('hex');
-          } else if (val instanceof Date) {
-            out[col] = val.toISOString().replace('T', ' ').replace(/\.\d{3}Z$/, '');
-          } else if (typeof val === 'bigint') {
-            out[col] = val.toString();
-          } else {
-            out[col] = val;
-          }
-        }
-        return out;
-      });
-
-      return { rows: serializedRows, columnMeta };
+  async queryAll(sql: string, schema?: string): Promise<QueryResult[]> {
+    const conn = await this.pool.getConnection();
+    try {
+      if (schema) {
+        await conn.query(`USE \`${schema.replace(/`/g, '')}\``);
+      }
+      const [rawRows, rawFields] = await conn.query(sql) as [
+        RowDataPacket[] | ResultSetHeader | (RowDataPacket[] | ResultSetHeader)[],
+        FieldPacket[] | FieldPacket[][],
+      ];
+      // Single statement: mysql2 returns the result directly. Multi-statement: it
+      // returns parallel arrays — one rowset and one fields array per statement.
+      const isMulti = Array.isArray(rawRows) && rawRows.length > 0 && Array.isArray((rawRows as unknown[])[0]);
+      if (!isMulti) {
+        return [buildMysqlResult(rawRows as RowDataPacket[] | ResultSetHeader, rawFields as FieldPacket[])];
+      }
+      const rowSets = rawRows as (RowDataPacket[] | ResultSetHeader)[];
+      const fieldSets = rawFields as FieldPacket[][];
+      return rowSets.map((r, i) => buildMysqlResult(r, fieldSets[i] ?? []));
     } finally {
       conn.release();
     }

--- a/server/src/drivers/postgres.ts
+++ b/server/src/drivers/postgres.ts
@@ -20,6 +20,45 @@ function buildPgPoolConfig(config: ConnectionConfig): pg.PoolConfig {
   };
 }
 
+function buildPgResult(result: pg.QueryResult): QueryResult {
+  if (!result.fields || result.fields.length === 0) {
+    return {
+      rows: [],
+      columnMeta: [],
+      affectedRows: result.rowCount ?? 0,
+      insertId: null,
+    };
+  }
+  const columnMeta: ColumnMeta[] = result.fields.map(f => ({
+    name: f.name,
+    orgName: f.name,
+    table: '',
+    orgTable: '',
+    pk: false,
+    unique: false,
+    notNull: false,
+    mysqlType: 0,
+  }));
+  const columns = result.fields.map(f => f.name);
+  const serializedRows = (result.rows as Record<string, unknown>[]).map(row => {
+    const out: Record<string, unknown> = {};
+    for (const col of columns) {
+      const val = row[col];
+      if (val === null || val === undefined) {
+        out[col] = null;
+      } else if (Buffer.isBuffer(val)) {
+        out[col] = val.toString('hex');
+      } else if (val instanceof Date) {
+        out[col] = val.toISOString().replace('T', ' ').replace(/\.\d{3}Z$/, '');
+      } else {
+        out[col] = val;
+      }
+    }
+    return out;
+  });
+  return { rows: serializedRows, columnMeta };
+}
+
 export class PostgresDriver implements DbDriver {
   readonly queryMode = 'sql' as const;
   private pool: pg.Pool;
@@ -85,50 +124,36 @@ export class PostgresDriver implements DbDriver {
         pgSql = sql.replace(/\?/g, () => `$${++n}`);
       }
       const result = await client.query({ text: pgSql, values: params?.length ? params : undefined });
-
-      // Non-SELECT (INSERT, UPDATE, DELETE, DDL, etc.)
-      if (!result.fields || result.fields.length === 0) {
-        return {
-          rows: [],
-          columnMeta: [],
-          affectedRows: result.rowCount ?? 0,
-          insertId: null,
-        };
-      }
-
-      const columnMeta: ColumnMeta[] = result.fields.map(f => ({
-        name: f.name,
-        orgName: f.name,
-        table: '',
-        orgTable: '',
-        pk: false,
-        unique: false,
-        notNull: false,
-        mysqlType: 0,
-      }));
-
-      const columns = result.fields.map(f => f.name);
-      const serializedRows = (result.rows as Record<string, unknown>[]).map(row => {
-        const out: Record<string, unknown> = {};
-        for (const col of columns) {
-          const val = row[col];
-          if (val === null || val === undefined) {
-            out[col] = null;
-          } else if (Buffer.isBuffer(val)) {
-            out[col] = val.toString('hex');
-          } else if (val instanceof Date) {
-            out[col] = val.toISOString().replace('T', ' ').replace(/\.\d{3}Z$/, '');
-          } else {
-            out[col] = val;
-          }
-        }
-        return out;
-      });
-
-      return { rows: serializedRows, columnMeta };
+      // node-pg's simple query protocol returns an array of results when the SQL
+      // contains multiple statements. `query()` keeps the legacy single-result
+      // contract — `queryAll` is the multi-statement entry point — so collapse
+      // an unexpected array down to its last element.
+      const single = Array.isArray(result) ? (result as pg.QueryResult[])[result.length - 1] : result;
+      return buildPgResult(single);
     } finally {
       // pg.Pool reuses clients without resetting session state, so search_path
       // would leak to the next caller on this same client.
+      if (searchPathSet) {
+        try { await client.query('SET search_path TO DEFAULT'); } catch { /* fall through to release */ }
+      }
+      client.release();
+    }
+  }
+
+  async queryAll(sql: string, schema?: string): Promise<QueryResult[]> {
+    const client = await this.pool.connect();
+    let searchPathSet = false;
+    try {
+      if (schema) {
+        await client.query(`SET search_path TO ${this.escapeIdent(schema)}`);
+        searchPathSet = true;
+      }
+      // Always go through the simple query protocol (no values) so multi-statement
+      // SQL fans out to one result per statement.
+      const raw = await client.query(sql);
+      const results = Array.isArray(raw) ? (raw as pg.QueryResult[]) : [raw];
+      return results.map(buildPgResult);
+    } finally {
       if (searchPathSet) {
         try { await client.query('SET search_path TO DEFAULT'); } catch { /* fall through to release */ }
       }

--- a/server/src/routes/query.test.ts
+++ b/server/src/routes/query.test.ts
@@ -85,6 +85,33 @@ describe('postQuery – driver delegation (sql mode)', () => {
     expect(res.body.affectedRows).toBe(3);
   });
 
+  it('uses driver.queryAll when available and exposes every result set', async () => {
+    const mockDriver = {
+      queryMode: 'sql' as const,
+      query: vi.fn(),
+      queryAll: vi.fn().mockResolvedValue([
+        { rows: [{ a: 1 }], columnMeta: [makeMeta('a')] },
+        { rows: [{ b: 2 }], columnMeta: [makeMeta('b')] },
+      ]),
+    };
+    vi.mocked(getDriver).mockReturnValue(mockDriver as any);
+
+    const res = await request(makeApp())
+      .post('/api/query')
+      .send({ sql: 'SELECT 1 AS a; SELECT 2 AS b', schema: 'mydb' });
+
+    expect(res.status).toBe(200);
+    expect(mockDriver.queryAll).toHaveBeenCalledWith('SELECT 1 AS a; SELECT 2 AS b', 'mydb');
+    expect(mockDriver.query).not.toHaveBeenCalled();
+    // Legacy fields mirror the first statement so old clients keep working.
+    expect(res.body.columns).toEqual(['a']);
+    expect(res.body.rows).toEqual([{ a: 1 }]);
+    // The new array carries every statement's rows.
+    expect(res.body.results).toHaveLength(2);
+    expect(res.body.results[0].rows).toEqual([{ a: 1 }]);
+    expect(res.body.results[1].rows).toEqual([{ b: 2 }]);
+  });
+
   it('returns 400 when driver.query() throws', async () => {
     const mockDriver = {
       queryMode: 'sql' as const,

--- a/server/src/routes/query.ts
+++ b/server/src/routes/query.ts
@@ -43,24 +43,32 @@ export const postQuery: RequestHandler = async (req, res) => {
 
   try {
     const start = Date.now();
-    const result = await driver.query(queryText, [], schema);
+    // sql-mode drivers expose `queryAll` for multi-statement support; mql-mode
+    // payloads are always a single request and use `query`.
+    const resultList = driver.queryMode === 'sql' && driver.queryAll
+      ? await driver.queryAll(queryText, schema)
+      : [await driver.query(queryText, [], schema)];
     const executionTime = Date.now() - start;
 
-    if (result.columnMeta.length === 0) {
-      res.json({
-        columns: [],
-        rows: [],
-        affectedRows: result.affectedRows ?? 0,
-        insertId: result.insertId ?? null,
-        executionTime,
-      });
-      return;
-    }
+    const results = resultList.map(r => ({
+      columns: r.columnMeta.map(c => c.name),
+      columnMeta: r.columnMeta,
+      rows: r.rows,
+      affectedRows: r.affectedRows ?? 0,
+      insertId: r.insertId ?? null,
+    }));
 
+    // Backwards-compatible single-result envelope: every existing client field is
+    // still set from the first result, plus a new `results` array carrying every
+    // statement's rows when more than one was sent.
+    const first = results[0] ?? { columns: [], columnMeta: [], rows: [], affectedRows: 0, insertId: null };
     res.json({
-      columns: result.columnMeta.map(c => c.name),
-      columnMeta: result.columnMeta,
-      rows: result.rows,
+      columns: first.columns,
+      columnMeta: first.columnMeta,
+      rows: first.rows,
+      affectedRows: first.affectedRows,
+      insertId: first.insertId,
+      results,
       executionTime,
     });
   } catch (err) {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,6 +26,11 @@ interface Tab {
   // same table name in two different schemas gets its own tab.
   sourceTable?: { schema: string; table: string };
   results?: QueryResults | null;
+  // Every result set returned by the most recent run, in statement order.
+  // `results` mirrors the currently-selected entry so existing CRUD callbacks
+  // operate on the same rowset the user is looking at.
+  resultSets?: QueryResults[];
+  activeResultIndex?: number;
   queryError?: string | null;
   execTime?: number | null;
   isRunning?: boolean;
@@ -253,21 +258,30 @@ export default function App() {
       }
     }
 
-    updateTab(targetTab, { isRunning: true, results: null, queryError: null, execTime: null });
+    updateTab(targetTab, { isRunning: true, results: null, resultSets: undefined, activeResultIndex: 0, queryError: null, execTime: null });
 
     const started = Date.now();
     try {
       const res = queryMode === 'mql'
         ? await api.queryMql(mqlPayload, activeSchema)
         : await api.query(text, activeSchema);
+      // The route always emits the legacy fields from the first statement; `results`
+      // is the new array (one entry per statement). Old responses without it are
+      // synthesised into a single-element array so the rest of the app stays uniform.
+      const sets: QueryResults[] = res.results
+        ? res.results.map(r => ({ columns: r.columns, columnMeta: r.columnMeta, rows: r.rows as QueryResults['rows'] }))
+        : [{ columns: res.columns, columnMeta: res.columnMeta, rows: res.rows }];
       updateTab(targetTab, {
-        results: { columns: res.columns, columnMeta: res.columnMeta, rows: res.rows },
+        results: sets[0],
+        resultSets: sets,
+        activeResultIndex: 0,
         execTime: res.executionTime,
       });
       if (connectionHost) {
+        const totalRows = sets.reduce((n, s) => n + s.rows.length, 0);
         const entry = addHistoryEntry(connectionHost, {
           sql: text, schema: activeSchema, executedAt: started,
-          durationMs: res.executionTime, status: 'ok', rowCount: res.rows.length,
+          durationMs: res.executionTime, status: 'ok', rowCount: totalRows,
         });
         if (entry) setHistory(prev => [entry, ...prev].slice(0, 100));
       }
@@ -466,6 +480,13 @@ export default function App() {
           </div>
           <ResultsTable
             results={results}
+            resultSets={currentTab?.resultSets}
+            activeResultIndex={currentTab?.activeResultIndex ?? 0}
+            onSelectResultIndex={(i: number) => {
+              const sets = currentTab?.resultSets;
+              if (!sets || !sets[i]) return;
+              updateTab(activeTab, { activeResultIndex: i, results: sets[i] });
+            }}
             isRunning={isRunning}
             error={queryError}
             executionTime={execTime}

--- a/src/api.ts
+++ b/src/api.ts
@@ -92,6 +92,22 @@ async function request<T>(path: string, init?: RequestInit): Promise<T> {
 
 export type QueryMode = 'sql' | 'mql';
 
+export interface QueryResultPayload {
+  columns: string[];
+  columnMeta?: ColumnMeta[];
+  rows: Record<string, unknown>[];
+  affectedRows?: number;
+  insertId?: number | null;
+}
+
+export type QueryResponse = QueryResults & {
+  columnMeta?: ColumnMeta[];
+  executionTime: number;
+  affectedRows?: number;
+  insertId?: number;
+  results?: QueryResultPayload[];
+};
+
 export const api = {
   connect(form: ConnectFormInput) {
     return request<{ ok: boolean; connectionName: string; queryMode: QueryMode }>('/api/connect', {
@@ -129,14 +145,14 @@ export const api = {
   },
 
   query(sql: string, schema: string) {
-    return request<QueryResults & { columnMeta?: ColumnMeta[]; executionTime: number; affectedRows?: number; insertId?: number }>(
+    return request<QueryResponse>(
       '/api/query',
       { method: 'POST', body: JSON.stringify({ sql, schema }) }
     );
   },
 
   queryMql(mql: unknown, schema: string) {
-    return request<QueryResults & { columnMeta?: ColumnMeta[]; executionTime: number; affectedRows?: number; insertId?: number }>(
+    return request<QueryResponse>(
       '/api/query',
       { method: 'POST', body: JSON.stringify({ mql, schema }) }
     );

--- a/src/components/ResultsTable.tsx
+++ b/src/components/ResultsTable.tsx
@@ -68,6 +68,10 @@ function fromDatetimeLocal(v: string): string {
 
 interface ResultsTableProps {
   results: QueryResults | null;
+  /** Every result set returned by the last run; `results` mirrors the active one. */
+  resultSets?: QueryResults[];
+  activeResultIndex?: number;
+  onSelectResultIndex?: (index: number) => void;
   isRunning: boolean;
   error: string | null;
   executionTime: number | null;
@@ -308,7 +312,7 @@ function resolveDeleteTarget(row: Row, columnMeta: ColumnMeta[] | undefined): De
   };
 }
 
-export function ResultsTable({ results, isRunning, error, executionTime, activeSchema, schemaData, onDeleteRow, onUpdateCell, onInsertRow, t }: ResultsTableProps) {
+export function ResultsTable({ results, resultSets, activeResultIndex = 0, onSelectResultIndex, isRunning, error, executionTime, activeSchema, schemaData, onDeleteRow, onUpdateCell, onInsertRow, t }: ResultsTableProps) {
   const [sortCol, setSortCol] = useState<string | null>(null);
   const [sortDir, setSortDir] = useState<'asc' | 'desc'>('asc');
   const [selectedRow, setSelectedRow] = useState<number | null>(null);
@@ -622,12 +626,25 @@ export function ResultsTable({ results, isRunning, error, executionTime, activeS
   return (
     <div style={s.root}>
       <div style={s.tabBar}>
-        <div style={s.tabActive}>
-          <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-            <path d="M3 3h18v5H3zM3 8h18v5H3zM3 13h18v8H3z"/>
-          </svg>
-          Result 1
-        </div>
+        {(resultSets && resultSets.length > 1
+          ? resultSets.map((_, i) => ({ label: `Result ${i + 1}`, index: i }))
+          : [{ label: 'Result 1', index: 0 }]
+        ).map(({ label, index }) => {
+          const active = index === activeResultIndex;
+          return (
+            <div
+              key={index}
+              style={active ? s.tabActive : s.tabInactive}
+              onClick={() => { if (!active && onSelectResultIndex) onSelectResultIndex(index); }}
+              role={onSelectResultIndex ? 'button' : undefined}
+            >
+              <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M3 3h18v5H3zM3 8h18v5H3zM3 13h18v8H3z"/>
+              </svg>
+              {label}
+            </div>
+          );
+        })}
         <div style={s.tabInactive}>
           <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
             <circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/>


### PR DESCRIPTION
Closes #143.

## Summary
- MySQL pool now opts in to `multipleStatements`; `MysqlDriver.queryAll` returns one `QueryResult` per statement (mysql2's parallel-arrays response).
- `PostgresDriver.queryAll` runs the SQL through the simple query protocol and fans the resulting `Array<pg.QueryResult>` out to one entry per statement; legacy `query()` collapses to the last result for the existing single-statement callers (insertRow, updateCell, deleteRow, …).
- `/api/query` calls `queryAll` for sql-mode drivers and returns a `results: QueryResult[]` array. The pre-existing `columns` / `rows` / `affectedRows` / `insertId` envelope is preserved from the first statement so old clients keep working unchanged.
- Frontend stores all result sets per tab and renders dynamic `Result 1 … Result N` tabs in the results panel; clicking switches the rendered grid (and the target of CRUD actions). Single-statement queries still render exactly one tab — no UX change.

## Test plan
- [x] `npm test` (frontend) — 20/20 pass
- [x] `cd server && npm test` — 113/113 pass, including a new route test for the `queryAll` path and three new MysqlDriver tests covering single-result, multi-result, and error paths
- [x] Manual: connected to local MySQL test DB and ran `SELECT 1 AS a; SELECT * FROM bool_test LIMIT 2; SELECT 'three' AS msg;` — three Result tabs render and switching between them updates the grid
- [x] Manual: ran a single-statement `SELECT *` to confirm the regression case still shows just one Result tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)