### PR TITLE
fix: keep query path alive across macOS sleep/resume

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -1,6 +1,6 @@
 'use strict';
 
-const { app, BrowserWindow, Tray, Menu, nativeImage, utilityProcess, dialog, ipcMain, safeStorage } = require('electron');
+const { app, BrowserWindow, Tray, Menu, nativeImage, utilityProcess, dialog, ipcMain, safeStorage, powerMonitor } = require('electron');
 const path = require('path');
 const http = require('http');
 const fs = require('fs');
@@ -205,6 +205,15 @@ app.whenReady().then(async () => {
   }
   createWindow();
   createTray();
+
+  // Sleep kills idle TCP sockets in the pool — the OS still reports them as
+  // open, so the first post-resume query hangs on a dead socket. Notify the
+  // bundled server so it drops and rebuilds its pool. See #145. Dev mode runs
+  // its own server outside this process, so the message has no recipient and
+  // is silently dropped.
+  powerMonitor.on('resume', () => {
+    serverProc?.postMessage({ type: 'host-resumed' });
+  });
 
   app.on('activate', () => {
     if (win) win.show();

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -53,6 +53,18 @@ export function isConnected(): boolean {
   return driver !== null;
 }
 
+/**
+ * Drop and rebuild the active driver's connection pool. Idempotent — no-op when
+ * not connected or when the driver doesn't pool. Used by the resume-from-sleep
+ * path so the next query opens a fresh socket; the user-facing connection state
+ * is preserved (no UI logout).
+ */
+export async function recycleActivePool(): Promise<void> {
+  if (driver?.recyclePool) {
+    await driver.recyclePool();
+  }
+}
+
 export async function testConnection(config: ConnectionConfig): Promise<void> {
   const d = makeDriver(config);
   try {

--- a/server/src/drivers/interface.ts
+++ b/server/src/drivers/interface.ts
@@ -91,7 +91,8 @@ export interface DbDriver {
    * Drop and rebuild any underlying connection pool. Called after the host
    * machine resumes from sleep so the next query opens a fresh socket instead
    * of using a dead one the OS still thinks is open. Drivers that don't pool
-   * (or self-heal) may omit this.
+   * (or self-heal) may omit this — e.g. MongoDB's SDAM monitor heartbeats every
+   * `heartbeatFrequencyMS` and re-establishes dead servers on its own.
    */
   recyclePool?(): Promise<void>;
   end(): Promise<void>;

--- a/server/src/drivers/interface.ts
+++ b/server/src/drivers/interface.ts
@@ -87,5 +87,12 @@ export interface DbDriver {
   /** " LIMIT N" for dialects that support it in DML; "" for those that don't (e.g. Postgres). */
   rowLimitClause(n: number): string;
   ping(): Promise<void>;
+  /**
+   * Drop and rebuild any underlying connection pool. Called after the host
+   * machine resumes from sleep so the next query opens a fresh socket instead
+   * of using a dead one the OS still thinks is open. Drivers that don't pool
+   * (or self-heal) may omit this.
+   */
+  recyclePool?(): Promise<void>;
   end(): Promise<void>;
 }

--- a/server/src/drivers/mysql.test.ts
+++ b/server/src/drivers/mysql.test.ts
@@ -52,17 +52,32 @@ describe('MysqlDriver.recyclePool', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockPool.getConnection.mockResolvedValue(mockConn);
+    // recyclePool fire-and-forgets `old.end()` via `.catch()`, so the mock has
+    // to return a real promise; bare vi.fn() returns undefined.
+    mockPool.end.mockResolvedValue(undefined);
   });
 
-  it('replaces the pool and ends the old one', async () => {
-    const mysqlMod = (await import('mysql2/promise')).default as unknown as { createPool: ReturnType<typeof vi.fn> };
+  async function getCreatePoolMock() {
+    const mod = (await import('mysql2/promise')).default as unknown as { createPool: ReturnType<typeof vi.fn> };
+    return mod.createPool;
+  }
+
+  // Hand each createPool call a distinct pool instance so a test can assert
+  // that operations after recycle target the *new* pool, not the old one.
+  async function stubPoolsPerCreate(...pools: typeof mockPool[]) {
+    const cp = await getCreatePoolMock();
+    let i = 0;
+    cp.mockImplementation(() => pools[Math.min(i++, pools.length - 1)]);
+  }
+
+  it('builds a fresh pool and ends the old one', async () => {
+    const cp = await getCreatePoolMock();
     const driver = makeDriver();
-    expect(mysqlMod.createPool).toHaveBeenCalledTimes(1);
+    expect(cp).toHaveBeenCalledTimes(1);
 
     mockPool.end.mockResolvedValueOnce(undefined);
     await driver.recyclePool();
-    // One createPool call for the constructor, one for the recycle.
-    expect(mysqlMod.createPool).toHaveBeenCalledTimes(2);
+    expect(cp).toHaveBeenCalledTimes(2);
     expect(mockPool.end).toHaveBeenCalledTimes(1);
   });
 
@@ -72,12 +87,56 @@ describe('MysqlDriver.recyclePool', () => {
     await expect(driver.recyclePool()).resolves.toBeUndefined();
   });
 
+  it('routes operations after recycle to the new pool, not the old one', async () => {
+    const oldPool = { ...mockPool, getConnection: vi.fn(), query: vi.fn(), end: vi.fn().mockResolvedValue(undefined) };
+    const newPool = { ...mockPool, getConnection: vi.fn().mockResolvedValue(mockConn), query: vi.fn(), end: vi.fn() };
+    await stubPoolsPerCreate(oldPool, newPool);
+
+    const driver = makeDriver();
+    await driver.recyclePool();
+
+    // recyclePool's pre-warm itself takes one connection on the new pool.
+    const beforeQuery = newPool.getConnection.mock.calls.length;
+    mockConn.query.mockResolvedValueOnce([[{ ok: 1 }], [{ name: 'ok' }]]);
+    await driver.query('SELECT 1');
+
+    expect(newPool.getConnection.mock.calls.length).toBeGreaterThan(beforeQuery);
+    expect(oldPool.getConnection).not.toHaveBeenCalled();
+  });
+
+  it('pre-warms the new pool so the next user query skips the connect cost', async () => {
+    const cp = await getCreatePoolMock();
+    const newPool = { ...mockPool, getConnection: vi.fn().mockResolvedValue(mockConn), query: vi.fn(), end: vi.fn() };
+    cp.mockImplementationOnce(() => mockPool).mockImplementationOnce(() => newPool);
+
+    const driver = makeDriver();
+    await driver.recyclePool();
+
+    expect(newPool.getConnection).toHaveBeenCalledTimes(1);
+    expect(mockConn.release).toHaveBeenCalled();
+  });
+
+  it('coalesces concurrent recycle calls so a duplicate event does not orphan a pool', async () => {
+    const cp = await getCreatePoolMock();
+    cp.mockImplementation(() => mockPool);
+    mockPool.end.mockResolvedValue(undefined);
+    const driver = makeDriver();
+    cp.mockClear();
+
+    // Two host-resumed events fire before the first recycle settles.
+    const a = driver.recyclePool();
+    const b = driver.recyclePool();
+    expect(a).toBe(b); // same in-flight promise — no second pool built
+    await Promise.all([a, b]);
+    expect(cp).toHaveBeenCalledTimes(1);
+  });
+
   it('configures TCP keepalive on the pool so post-resume sockets are detected', async () => {
-    const mysqlMod = (await import('mysql2/promise')).default as unknown as { createPool: ReturnType<typeof vi.fn> };
-    mysqlMod.createPool.mockClear();
+    const cp = await getCreatePoolMock();
+    cp.mockClear();
     makeDriver();
-    expect(mysqlMod.createPool).toHaveBeenCalledTimes(1);
-    const opts = mysqlMod.createPool.mock.calls[0][0];
+    expect(cp).toHaveBeenCalledTimes(1);
+    const opts = cp.mock.calls[0][0];
     expect(opts.enableKeepAlive).toBe(true);
     expect(opts.keepAliveInitialDelay).toBe(10_000);
   });

--- a/server/src/drivers/mysql.test.ts
+++ b/server/src/drivers/mysql.test.ts
@@ -47,3 +47,38 @@ describe('MysqlDriver.query – connection release', () => {
     expect(mockConn.release).toHaveBeenCalledTimes(1);
   });
 });
+
+describe('MysqlDriver.recyclePool', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPool.getConnection.mockResolvedValue(mockConn);
+  });
+
+  it('replaces the pool and ends the old one', async () => {
+    const mysqlMod = (await import('mysql2/promise')).default as unknown as { createPool: ReturnType<typeof vi.fn> };
+    const driver = makeDriver();
+    expect(mysqlMod.createPool).toHaveBeenCalledTimes(1);
+
+    mockPool.end.mockResolvedValueOnce(undefined);
+    await driver.recyclePool();
+    // One createPool call for the constructor, one for the recycle.
+    expect(mysqlMod.createPool).toHaveBeenCalledTimes(2);
+    expect(mockPool.end).toHaveBeenCalledTimes(1);
+  });
+
+  it('swallows errors from the old pool — its sockets may already be dead', async () => {
+    const driver = makeDriver();
+    mockPool.end.mockRejectedValueOnce(new Error('socket closed'));
+    await expect(driver.recyclePool()).resolves.toBeUndefined();
+  });
+
+  it('configures TCP keepalive on the pool so post-resume sockets are detected', async () => {
+    const mysqlMod = (await import('mysql2/promise')).default as unknown as { createPool: ReturnType<typeof vi.fn> };
+    mysqlMod.createPool.mockClear();
+    makeDriver();
+    expect(mysqlMod.createPool).toHaveBeenCalledTimes(1);
+    const opts = mysqlMod.createPool.mock.calls[0][0];
+    expect(opts.enableKeepAlive).toBe(true);
+    expect(opts.keepAliveInitialDelay).toBe(10_000);
+  });
+});

--- a/server/src/drivers/mysql.ts
+++ b/server/src/drivers/mysql.ts
@@ -26,8 +26,8 @@ function buildMysqlPoolOptions(config: ConnectionConfig): mysql.PoolOptions {
 export class MysqlDriver implements DbDriver {
   readonly queryMode = 'sql' as const;
   private pool: mysql.Pool;
-
   private config: ConnectionConfig;
+  private recycling: Promise<void> | null = null;
 
   constructor(config: ConnectionConfig) {
     this.config = config;
@@ -38,11 +38,28 @@ export class MysqlDriver implements DbDriver {
    * Drop the current pool and rebuild it from the saved config. Used after the
    * machine resumes from sleep — every pre-existing socket is dead but the
    * pool would happily hand it back to the next query, hanging the request.
+   *
+   * Bursty resume events (sleep → brief wake → sleep) can fire `host-resumed`
+   * twice in quick succession; the in-flight guard makes the call idempotent
+   * so we don't orphan a freshly-built pool.
    */
-  async recyclePool(): Promise<void> {
+  recyclePool(): Promise<void> {
+    if (this.recycling) return this.recycling;
     const old = this.pool;
     this.pool = mysql.createPool(buildMysqlPoolOptions(this.config));
-    try { await old.end(); } catch { /* old pool sockets are likely dead — swallow */ }
+    // Fire-and-forget the old pool: its sockets are likely dead, and mysql2's
+    // `end()` waits for the socket close to be acknowledged — awaiting here
+    // would reintroduce the very hang we're trying to fix.
+    void old.end().catch(() => { /* dead sockets — nothing to do */ });
+    // Pre-warm so the user's next query doesn't pay TCP+auth on top of the
+    // resume itself. Also fire-and-forget — failure here is benign because
+    // the next query will retry the connect.
+    this.recycling = this.pool
+      .getConnection()
+      .then(c => c.release())
+      .catch(() => { /* will surface on the user's next query */ })
+      .finally(() => { this.recycling = null; });
+    return this.recycling;
   }
 
   escapeIdent(s: string): string {

--- a/server/src/drivers/mysql.ts
+++ b/server/src/drivers/mysql.ts
@@ -2,24 +2,47 @@ import mysql from 'mysql2/promise';
 import type { RowDataPacket, FieldPacket, ResultSetHeader } from 'mysql2/promise';
 import type { DbDriver, ConnectionConfig, QueryResult, ColumnMeta, ColumnInfo, SchemaInfo, TableInfo } from './interface.js';
 
+function buildMysqlPoolOptions(config: ConnectionConfig): mysql.PoolOptions {
+  return {
+    host: config.host,
+    port: config.port,
+    user: config.user,
+    password: config.password,
+    database: config.database || undefined,
+    ssl: config.ssl === 'verify-full' ? { rejectUnauthorized: true }
+       : config.ssl === 'require'     ? { rejectUnauthorized: false }
+       : undefined,
+    waitForConnections: true,
+    connectionLimit: 5,
+    connectTimeout: 10_000,
+    // OS-level TCP keepalive — without this, dead sockets after macOS sleep
+    // are only surfaced by the kernel's default ~2-hour timer, which causes
+    // the first post-resume query to hang. See #145.
+    enableKeepAlive: true,
+    keepAliveInitialDelay: 10_000,
+  };
+}
+
 export class MysqlDriver implements DbDriver {
   readonly queryMode = 'sql' as const;
   private pool: mysql.Pool;
 
+  private config: ConnectionConfig;
+
   constructor(config: ConnectionConfig) {
-    this.pool = mysql.createPool({
-      host: config.host,
-      port: config.port,
-      user: config.user,
-      password: config.password,
-      database: config.database || undefined,
-      ssl: config.ssl === 'verify-full' ? { rejectUnauthorized: true }
-         : config.ssl === 'require'     ? { rejectUnauthorized: false }
-         : undefined,
-      waitForConnections: true,
-      connectionLimit: 5,
-      connectTimeout: 10_000,
-    });
+    this.config = config;
+    this.pool = mysql.createPool(buildMysqlPoolOptions(config));
+  }
+
+  /**
+   * Drop the current pool and rebuild it from the saved config. Used after the
+   * machine resumes from sleep — every pre-existing socket is dead but the
+   * pool would happily hand it back to the next query, hanging the request.
+   */
+  async recyclePool(): Promise<void> {
+    const old = this.pool;
+    this.pool = mysql.createPool(buildMysqlPoolOptions(this.config));
+    try { await old.end(); } catch { /* old pool sockets are likely dead — swallow */ }
   }
 
   escapeIdent(s: string): string {

--- a/server/src/drivers/postgres.test.ts
+++ b/server/src/drivers/postgres.test.ts
@@ -68,3 +68,36 @@ describe('PostgresDriver.query – connection release', () => {
     expect(mockClient.release).toHaveBeenCalledTimes(1);
   });
 });
+
+describe('PostgresDriver.recyclePool', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('replaces the pool and ends the old one', async () => {
+    const pgMod = (await import('pg')).default as unknown as { Pool: ReturnType<typeof vi.fn> };
+    const driver = makeDriver();
+    expect(pgMod.Pool).toHaveBeenCalledTimes(1);
+
+    mockPoolInstance.end.mockResolvedValueOnce(undefined);
+    await driver.recyclePool();
+    expect(pgMod.Pool).toHaveBeenCalledTimes(2);
+    expect(mockPoolInstance.end).toHaveBeenCalledTimes(1);
+  });
+
+  it('swallows errors from the old pool — its clients may already be dead', async () => {
+    const driver = makeDriver();
+    mockPoolInstance.end.mockRejectedValueOnce(new Error('client closed'));
+    await expect(driver.recyclePool()).resolves.toBeUndefined();
+  });
+
+  it('configures TCP keepalive on the pool', async () => {
+    const pgMod = (await import('pg')).default as unknown as { Pool: ReturnType<typeof vi.fn> };
+    pgMod.Pool.mockClear();
+    makeDriver();
+    expect(pgMod.Pool).toHaveBeenCalledTimes(1);
+    const cfg = pgMod.Pool.mock.calls[0][0];
+    expect(cfg.keepAlive).toBe(true);
+    expect(cfg.keepAliveInitialDelayMillis).toBe(10_000);
+  });
+});

--- a/server/src/drivers/postgres.test.ts
+++ b/server/src/drivers/postgres.test.ts
@@ -72,16 +72,24 @@ describe('PostgresDriver.query – connection release', () => {
 describe('PostgresDriver.recyclePool', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // recyclePool fire-and-forgets `old.end()` via `.catch()`, so the mock has
+    // to return a real promise; bare vi.fn() returns undefined.
+    mockPoolInstance.end.mockResolvedValue(undefined);
   });
 
-  it('replaces the pool and ends the old one', async () => {
-    const pgMod = (await import('pg')).default as unknown as { Pool: ReturnType<typeof vi.fn> };
+  async function getPoolCtor() {
+    const mod = (await import('pg')).default as unknown as { Pool: ReturnType<typeof vi.fn> };
+    return mod.Pool;
+  }
+
+  it('builds a fresh pool and ends the old one', async () => {
+    const Pool = await getPoolCtor();
     const driver = makeDriver();
-    expect(pgMod.Pool).toHaveBeenCalledTimes(1);
+    expect(Pool).toHaveBeenCalledTimes(1);
 
     mockPoolInstance.end.mockResolvedValueOnce(undefined);
     await driver.recyclePool();
-    expect(pgMod.Pool).toHaveBeenCalledTimes(2);
+    expect(Pool).toHaveBeenCalledTimes(2);
     expect(mockPoolInstance.end).toHaveBeenCalledTimes(1);
   });
 
@@ -91,12 +99,55 @@ describe('PostgresDriver.recyclePool', () => {
     await expect(driver.recyclePool()).resolves.toBeUndefined();
   });
 
+  it('routes operations after recycle to the new pool, not the old one', async () => {
+    const Pool = await getPoolCtor();
+    const oldPool = { connect: vi.fn(), query: vi.fn(), end: vi.fn().mockResolvedValue(undefined) };
+    const newPool = { connect: vi.fn().mockResolvedValue(mockClient), query: vi.fn(), end: vi.fn() };
+    Pool.mockImplementationOnce(() => oldPool).mockImplementationOnce(() => newPool);
+
+    const driver = makeDriver();
+    await driver.recyclePool();
+
+    const beforeQuery = newPool.connect.mock.calls.length;
+    mockClient.query.mockResolvedValueOnce({ rows: [{ id: 1 }], fields: [{ name: 'id' }], rowCount: 1 });
+    await driver.query('SELECT 1');
+
+    expect(newPool.connect.mock.calls.length).toBeGreaterThan(beforeQuery);
+    expect(oldPool.connect).not.toHaveBeenCalled();
+  });
+
+  it('pre-warms the new pool so the next user query skips the connect cost', async () => {
+    const Pool = await getPoolCtor();
+    const newPool = { connect: vi.fn().mockResolvedValue(mockClient), query: vi.fn(), end: vi.fn() };
+    Pool.mockImplementationOnce(() => mockPoolInstance).mockImplementationOnce(() => newPool);
+
+    const driver = makeDriver();
+    await driver.recyclePool();
+
+    expect(newPool.connect).toHaveBeenCalledTimes(1);
+    expect(mockClient.release).toHaveBeenCalled();
+  });
+
+  it('coalesces concurrent recycle calls so a duplicate event does not orphan a pool', async () => {
+    const Pool = await getPoolCtor();
+    Pool.mockImplementation(() => mockPoolInstance);
+    mockPoolInstance.end.mockResolvedValue(undefined);
+    const driver = makeDriver();
+    Pool.mockClear();
+
+    const a = driver.recyclePool();
+    const b = driver.recyclePool();
+    expect(a).toBe(b);
+    await Promise.all([a, b]);
+    expect(Pool).toHaveBeenCalledTimes(1);
+  });
+
   it('configures TCP keepalive on the pool', async () => {
-    const pgMod = (await import('pg')).default as unknown as { Pool: ReturnType<typeof vi.fn> };
-    pgMod.Pool.mockClear();
+    const Pool = await getPoolCtor();
+    Pool.mockClear();
     makeDriver();
-    expect(pgMod.Pool).toHaveBeenCalledTimes(1);
-    const cfg = pgMod.Pool.mock.calls[0][0];
+    expect(Pool).toHaveBeenCalledTimes(1);
+    const cfg = Pool.mock.calls[0][0];
     expect(cfg.keepAlive).toBe(true);
     expect(cfg.keepAliveInitialDelayMillis).toBe(10_000);
   });

--- a/server/src/drivers/postgres.ts
+++ b/server/src/drivers/postgres.ts
@@ -24,19 +24,27 @@ export class PostgresDriver implements DbDriver {
   readonly queryMode = 'sql' as const;
   private pool: pg.Pool;
   private config: ConnectionConfig;
+  private recycling: Promise<void> | null = null;
 
   constructor(config: ConnectionConfig) {
     this.config = config;
     this.pool = new pg.Pool(buildPgPoolConfig(config));
   }
 
-  /**
-   * Drop the current pool and rebuild it from the saved config. See `MysqlDriver.recyclePool`.
-   */
-  async recyclePool(): Promise<void> {
+  /** See `MysqlDriver.recyclePool`. pg's `pool.end()` is stricter than mysql2's
+   * (waits for every checked-out client to be released), which makes the
+   * fire-and-forget on `old.end()` even more important here. */
+  recyclePool(): Promise<void> {
+    if (this.recycling) return this.recycling;
     const old = this.pool;
     this.pool = new pg.Pool(buildPgPoolConfig(this.config));
-    try { await old.end(); } catch { /* old clients may already be dead — swallow */ }
+    void old.end().catch(() => { /* dead clients — nothing to do */ });
+    this.recycling = this.pool
+      .connect()
+      .then(c => c.release())
+      .catch(() => { /* will surface on the user's next query */ })
+      .finally(() => { this.recycling = null; });
+    return this.recycling;
   }
 
   escapeIdent(s: string): string {

--- a/server/src/drivers/postgres.ts
+++ b/server/src/drivers/postgres.ts
@@ -1,23 +1,42 @@
 import pg from 'pg';
 import type { DbDriver, ConnectionConfig, QueryResult, ColumnMeta, ColumnInfo, SchemaInfo, TableInfo } from './interface.js';
 
+function buildPgPoolConfig(config: ConnectionConfig): pg.PoolConfig {
+  return {
+    host: config.host,
+    port: config.port,
+    user: config.user,
+    password: config.password,
+    database: config.database || undefined,
+    ssl: config.ssl === 'verify-full' ? { rejectUnauthorized: true }
+       : config.ssl === 'require'     ? { rejectUnauthorized: false }
+       : undefined,
+    max: 5,
+    connectionTimeoutMillis: 10_000,
+    // OS-level TCP keepalive so dead sockets after macOS sleep are surfaced
+    // in seconds rather than the kernel's default ~2 hours. See #145.
+    keepAlive: true,
+    keepAliveInitialDelayMillis: 10_000,
+  };
+}
+
 export class PostgresDriver implements DbDriver {
   readonly queryMode = 'sql' as const;
   private pool: pg.Pool;
+  private config: ConnectionConfig;
 
   constructor(config: ConnectionConfig) {
-    this.pool = new pg.Pool({
-      host: config.host,
-      port: config.port,
-      user: config.user,
-      password: config.password,
-      database: config.database || undefined,
-      ssl: config.ssl === 'verify-full' ? { rejectUnauthorized: true }
-         : config.ssl === 'require'     ? { rejectUnauthorized: false }
-         : undefined,
-      max: 5,
-      connectionTimeoutMillis: 10_000,
-    });
+    this.config = config;
+    this.pool = new pg.Pool(buildPgPoolConfig(config));
+  }
+
+  /**
+   * Drop the current pool and rebuild it from the saved config. See `MysqlDriver.recyclePool`.
+   */
+  async recyclePool(): Promise<void> {
+    const old = this.pool;
+    this.pool = new pg.Pool(buildPgPoolConfig(this.config));
+    try { await old.end(); } catch { /* old clients may already be dead — swallow */ }
   }
 
   escapeIdent(s: string): string {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -11,6 +11,7 @@ import { getTableDdl } from './routes/tableDdl.js';
 import { postDropTable } from './routes/dropTable.js';
 import { getMcpStatus, postMcpWrites } from './routes/mcpSettings.js';
 import { mcpHandler } from './mcp.js';
+import { recycleActivePool } from './db.js';
 
 const app = express();
 const PORT = process.env['PORT'] ?? 3001;
@@ -56,3 +57,18 @@ app.listen(PORT, () => {
   console.log(`Helix server running at http://localhost:${PORT}`);
   console.log(`MCP endpoint:        http://localhost:${PORT}/mcp`);
 });
+
+// When forked as an Electron utilityProcess, listen for the host process's
+// power events. After resume the active pool's sockets are dead — recycle so
+// the next query opens fresh ones. Standalone runs have no parentPort, so this
+// is a no-op outside Electron.
+const parentPort = (process as unknown as { parentPort?: { on(ev: 'message', fn: (msg: unknown) => void): void } }).parentPort;
+if (parentPort) {
+  parentPort.on('message', (msg: unknown) => {
+    if (msg && typeof msg === 'object' && (msg as { type?: string }).type === 'host-resumed') {
+      recycleActivePool().catch(err => {
+        console.error('[helix] recycleActivePool failed:', err);
+      });
+    }
+  });
+}


### PR DESCRIPTION
Closes #145.

## Summary
- Enable TCP keepalive on the MySQL and Postgres pools (\`enableKeepAlive\` / \`keepAlive\`, 10 s initial delay) so dead sockets after sleep are detected in seconds instead of the OS default ~2 hours.
- New optional \`recyclePool()\` on \`DbDriver\` (implemented for MySQL and Postgres) that closes the active pool and rebuilds it from the saved config — the user-visible connection state is preserved.
- The bundled server listens for a \`host-resumed\` message on its utility-process \`parentPort\`. \`electron/main.cjs\` posts that message from \`powerMonitor.on('resume')\`, so the very first post-resume query opens a fresh socket. Standalone runs without a parent port silently no-op.

## Test plan
- [x] \`cd server && npm test\` — 115/115 pass, including new coverage for both \`recyclePool\` paths and the keepalive options
- [x] \`npm test\` (frontend) — 20/20 pass
- [ ] Manual: connect via Electron to a remote MySQL, sleep the laptop for ≥30 s, resume, run a query — expect it to succeed without a Reconnect detour

🤖 Generated with [Claude Code](https://claude.com/claude-code)