### PR TITLE
fix: handle MySQL BIT(1) as boolean and fix Update SQL preview

### DIFF
--- a/server/src/drivers/mysql.test.ts
+++ b/server/src/drivers/mysql.test.ts
@@ -181,3 +181,33 @@ describe('MysqlDriver.queryAll – multi-statement results', () => {
     expect(mockConn.release).toHaveBeenCalledTimes(1);
   });
 });
+
+describe('MysqlDriver.query – BIT column serialization', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPool.getConnection.mockResolvedValue(mockConn);
+  });
+
+  it('returns 0/1 numbers for bit(1) columns instead of hex strings', async () => {
+    // mysql2 returns BIT columns as Buffers; type code 16 is MYSQL_TYPE_BIT.
+    mockConn.query.mockResolvedValueOnce([
+      [
+        { flag: Buffer.from([0]) },
+        { flag: Buffer.from([1]) },
+      ],
+      [{ name: 'flag', columnType: 16, flags: 0 }],
+    ]);
+    const result = await makeDriver().query('SELECT flag FROM t');
+    expect(result.rows).toEqual([{ flag: 0 }, { flag: 1 }]);
+  });
+
+  it('keeps hex serialization for non-BIT Buffer columns (e.g. binary)', async () => {
+    // BLOB type code is 252; should remain hex-encoded.
+    mockConn.query.mockResolvedValueOnce([
+      [{ data: Buffer.from([0xde, 0xad]) }],
+      [{ name: 'data', columnType: 252, flags: 0 }],
+    ]);
+    const result = await makeDriver().query('SELECT data FROM t');
+    expect(result.rows).toEqual([{ data: 'dead' }]);
+  });
+});

--- a/server/src/drivers/mysql.ts
+++ b/server/src/drivers/mysql.ts
@@ -27,6 +27,7 @@ function buildMysqlPoolOptions(config: ConnectionConfig): mysql.PoolOptions {
 const MYSQL_NOT_NULL_FLAG = 1;
 const MYSQL_PRI_KEY_FLAG = 2;
 const MYSQL_UNIQUE_KEY_FLAG = 4;
+const MYSQL_TYPE_BIT = 16;
 
 function buildMysqlResult(rows: RowDataPacket[] | ResultSetHeader, fields: FieldPacket[]): QueryResult {
   if (!Array.isArray(rows)) {
@@ -37,6 +38,11 @@ function buildMysqlResult(rows: RowDataPacket[] | ResultSetHeader, fields: Field
       affectedRows: result.affectedRows ?? 0,
       insertId: result.insertId ?? null,
     };
+  }
+
+  const bitColumns = new Set<string>();
+  for (const f of fields) {
+    if ((f.columnType ?? f.type) === MYSQL_TYPE_BIT) bitColumns.add(f.name);
   }
 
   const columnMeta: ColumnMeta[] = fields.map(f => {
@@ -68,7 +74,13 @@ function buildMysqlResult(rows: RowDataPacket[] | ResultSetHeader, fields: Field
       if (val === null || val === undefined) {
         out[col] = null;
       } else if (Buffer.isBuffer(val)) {
-        out[col] = val.toString('hex');
+        if (bitColumns.has(col) && val.length <= 6) {
+          let n = 0;
+          for (const byte of val) n = n * 256 + byte;
+          out[col] = n;
+        } else {
+          out[col] = val.toString('hex');
+        }
       } else if (val instanceof Date) {
         out[col] = val.toISOString().replace('T', ' ').replace(/\.\d{3}Z$/, '');
       } else if (typeof val === 'bigint') {

--- a/src/components/ResultsTable.tsx
+++ b/src/components/ResultsTable.tsx
@@ -4,6 +4,7 @@ import type { Theme } from '../theme';
 import type { ColumnMeta, SchemaData } from '../api';
 import { InsertRowDialog } from './InsertRowDialog';
 import { rowsToCsv, rowsToJson, downloadBlob, sanitizeFilename } from '../export';
+import { formatSqlValue } from '../lib/sql';
 
 // MongoDB documents arrive with nested objects/arrays in cell values.
 // Other drivers always emit primitives. We type the row map permissively so
@@ -94,7 +95,7 @@ function isBoolColumn(schemaData: SchemaData | undefined, meta: ColumnMeta | und
   if (!schemaData || !meta?.orgTable || !meta.orgName) return false;
   const table = schemaData.tables.find(x => x.name === meta.orgTable);
   const col = table?.columns.find(c => c.name === meta.orgName);
-  return col?.type === 'tinyint(1)';
+  return col?.type === 'tinyint(1)' || col?.type === 'bit(1)';
 }
 
 function cellDisplayValue(
@@ -1287,7 +1288,7 @@ export function ResultsTable({ results, resultSets, activeResultIndex = 0, onSel
               fontFamily: '"JetBrains Mono", monospace', color: t.textPrimary,
               whiteSpace: 'pre-wrap', wordBreak: 'break-all',
             }}>
-{`UPDATE \`${confirmUpdate.target.table}\`\nSET \`${confirmUpdate.target.column}\` = ${confirmUpdate.target.value === null ? 'NULL' : JSON.stringify(confirmUpdate.target.value)}\nWHERE ${confirmUpdate.target.where.map(w => `\`${w.column}\` = ${JSON.stringify(w.value)}`).join(' AND ')}\nLIMIT 1;`}
+{`UPDATE \`${confirmUpdate.target.table}\`\nSET \`${confirmUpdate.target.column}\` = ${formatSqlValue(confirmUpdate.target.value)}\nWHERE ${confirmUpdate.target.where.map(w => `\`${w.column}\` = ${formatSqlValue(w.value)}`).join(' AND ')}\nLIMIT 1;`}
             </pre>
             {confirmUpdate.error && (
               <div style={{


### PR DESCRIPTION
Closes #147.

## Summary
- MySQL driver: BIT columns (type code 16) are now converted from `Buffer` to a number, so `bit(1)` cells round-trip as `0`/`1` instead of the hex strings `"00"`/`"01"`. Without this, editing a `bit(1)` cell sent a 2-character string back into a 1-bit column and MySQL rejected the UPDATE with "Data too long".
- `isBoolColumn` now also matches `bit(1)`, so these cells render as `true`/`false` and use the boolean toggle editor — same path that already works for `tinyint(1)`.
- The Update confirmation dialog renders SQL via the existing `formatSqlValue` helper (already used by Insert) instead of `JSON.stringify`, so the previewed SQL matches what's actually being sent and is correctly quoted.

Wider BIT columns (>6 bytes) still fall back to hex serialization to avoid silent precision loss in JS numbers.

## Test plan
- [x] `npm test` (server: 111 passed, frontend: 20 passed)
- [x] `npm run build` (typecheck + vite build clean)
- [x] New unit tests cover BIT(1) → 0/1 conversion and confirm BLOB-style buffers still hex-encode.
- [ ] Manual: open a `bit(1)` cell in Electron, toggle it, confirm dialog shows `SET ... = 0` (no quotes), and UPDATE succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)