### PR TITLE
fix: return DATE/DATETIME/TIMESTAMP as raw strings to avoid local-TZ shift

### DIFF
--- a/server/src/drivers/mysql.test.ts
+++ b/server/src/drivers/mysql.test.ts
@@ -140,6 +140,14 @@ describe('MysqlDriver.recyclePool', () => {
     expect(opts.enableKeepAlive).toBe(true);
     expect(opts.keepAliveInitialDelay).toBe(10_000);
   });
+
+  it('enables dateStrings so DATE/DATETIME/TIMESTAMP avoid the local-TZ JS Date roundtrip', async () => {
+    const cp = await getCreatePoolMock();
+    cp.mockClear();
+    makeDriver();
+    const opts = cp.mock.calls[0][0];
+    expect(opts.dateStrings).toBe(true);
+  });
 });
 
 describe('MysqlDriver.queryAll – multi-statement results', () => {

--- a/server/src/drivers/mysql.ts
+++ b/server/src/drivers/mysql.ts
@@ -16,6 +16,13 @@ function buildMysqlPoolOptions(config: ConnectionConfig): mysql.PoolOptions {
     connectionLimit: 5,
     connectTimeout: 10_000,
     multipleStatements: true,
+    // Return DATE / DATETIME / TIMESTAMP as raw strings rather than JS Dates.
+    // mysql2's default coerces them through `new Date(...)`, which interprets
+    // the value in the Node process's local timezone and then loses TZ on the
+    // way out — a row written as "2026-05-07 10:00:00" comes back several hours
+    // skewed in any process whose TZ differs from where it was written.
+    // Helix is a DB browser; surface the literal value, don't reinterpret.
+    dateStrings: true,
     // OS-level TCP keepalive — without this, dead sockets after macOS sleep
     // are only surfaced by the kernel's default ~2-hour timer, which causes
     // the first post-resume query to hang. See #145.

--- a/server/src/drivers/postgres.test.ts
+++ b/server/src/drivers/postgres.test.ts
@@ -12,11 +12,20 @@ class MockPool {
 }
 const mockPoolInstance = new MockPool();
 
+const { setTypeParser } = vi.hoisted(() => ({ setTypeParser: vi.fn() }));
+
 vi.mock('pg', () => ({
-  default: { Pool: vi.fn(() => mockPoolInstance) },
+  default: {
+    Pool: vi.fn(() => mockPoolInstance),
+    types: { setTypeParser },
+  },
 }));
 
 import { PostgresDriver } from './postgres.js';
+
+// Snapshot module-load `setTypeParser` calls before any `vi.clearAllMocks()`
+// in later `beforeEach` blocks wipes them.
+const initialTypeParserCalls = setTypeParser.mock.calls.map(c => [c[0], c[1]] as const);
 
 function makeDriver() {
   return new PostgresDriver({
@@ -150,5 +159,18 @@ describe('PostgresDriver.recyclePool', () => {
     const cfg = Pool.mock.calls[0][0];
     expect(cfg.keepAlive).toBe(true);
     expect(cfg.keepAliveInitialDelayMillis).toBe(10_000);
+  });
+});
+
+describe('PostgresDriver – date/time type parsers', () => {
+  it('overrides DATE/TIME/TIMESTAMP/TIMESTAMPTZ/TIMETZ parsers to return raw strings', () => {
+    const oids = initialTypeParserCalls.map(([oid]) => oid);
+    // 1082=DATE, 1083=TIME, 1114=TIMESTAMP, 1184=TIMESTAMPTZ, 1266=TIMETZ
+    expect(oids).toEqual(expect.arrayContaining([1082, 1083, 1114, 1184, 1266]));
+
+    // Each parser should be the identity for the wire string — no Date conversion.
+    for (const [, parser] of initialTypeParserCalls) {
+      expect((parser as (v: string) => string)('2026-05-07 10:00:00')).toBe('2026-05-07 10:00:00');
+    }
   });
 });

--- a/server/src/drivers/postgres.ts
+++ b/server/src/drivers/postgres.ts
@@ -1,6 +1,24 @@
 import pg from 'pg';
 import type { DbDriver, ConnectionConfig, QueryResult, ColumnMeta, ColumnInfo, SchemaInfo, TableInfo } from './interface.js';
 
+// Return DATE / TIME / TIMESTAMP / TIMESTAMPTZ / TIMETZ as raw strings rather
+// than JS Dates. pg's default parsers route through `new Date(...)`, which
+// (a) loses sub-millisecond precision and (b) re-renders the value in whatever
+// timezone the consumer happens to call `toISOString()` from — a row written
+// as "2026-05-07 10:00:00" comes back skewed by hours in any process whose TZ
+// differs from where it was written. Helix is a DB browser; show the literal
+// value the server hands us. setTypeParser mutates pg's global registry, but
+// pg is only used by this driver in this app.
+const PG_DATE = 1082;
+const PG_TIME = 1083;
+const PG_TIMESTAMP = 1114;
+const PG_TIMESTAMPTZ = 1184;
+const PG_TIMETZ = 1266;
+const identity = (v: string) => v;
+for (const oid of [PG_DATE, PG_TIME, PG_TIMESTAMP, PG_TIMESTAMPTZ, PG_TIMETZ]) {
+  pg.types.setTypeParser(oid, identity);
+}
+
 function buildPgPoolConfig(config: ConnectionConfig): pg.PoolConfig {
   return {
     host: config.host,


### PR DESCRIPTION
Closes #149.

## Summary
Date and datetime cells were being shifted by the local-TZ offset on read. A row written as \`2026-05-07 10:00:00\` from a Toronto client came back as \`2026-05-07 14:00:00\` because mysql2/pg coerce date columns into JS \`Date\` objects (interpreted in the Node process's local TZ) and our serializer renders them via \`toISOString()\`, which always emits UTC.

## Fix
Skip the JS \`Date\` round-trip entirely:
- **MySQL** — set \`dateStrings: true\` on the pool. mysql2 then returns \`DATE\`/\`DATETIME\`/\`TIMESTAMP\` as raw strings.
- **Postgres** — override \`pg.types.setTypeParser\` for OIDs 1082 (DATE), 1083 (TIME), 1114 (TIMESTAMP), 1184 (TIMESTAMPTZ), 1266 (TIMETZ) to return the wire string verbatim.

\`val instanceof Date\` branches in both serializers stay as defensive fallbacks; they should no longer be reachable for date columns.

## Verification
Reproduced and confirmed end-to-end with \`TZ=America/Toronto\` against live MySQL 8 + Postgres 16:

\`\`\`
--- MySQL DEFAULT (reproduces user's bug) ---
{ id: 1, dt: 2026-05-07T14:00:00.000Z, ts: 2026-05-07T14:00:00.000Z, d: 2026-05-07T04:00:00.000Z }

--- MySQL with dateStrings: true ---
{ id: 1, dt: '2026-05-07 10:00:00', ts: '2026-05-07 10:00:00', d: '2026-05-07' }

--- Postgres with parser overrides ---
{ id: 1, dt: '2026-05-07 10:00:00', tstz: '2026-05-07 14:00:00+00', d: '2026-05-07', t: '10:00:00' }
\`\`\`

(Postgres TIMESTAMPTZ normalizes to UTC + offset on the wire; that's how Postgres stores it. Honest representation of the actual stored value.)

## Test plan
- [x] \`npm test\` (server: 127 passed) — added unit tests asserting \`dateStrings: true\` on the MySQL pool and that pg's setTypeParser is invoked with the right OIDs returning identity for strings.
- [x] \`npm run build\` (typecheck + vite build clean).
- [x] Live verification with \`TZ=America/Toronto\` against MySQL and Postgres.
- [ ] Manual: reproduce in Electron — open a DATETIME cell that was just written, confirm it matches the source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)