### PR TITLE
feat: sort default table query by single auto-inc PK descending

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ import { saveConnection } from './savedConnections';
 import { electronAPI } from './electronAPI';
 import { addHistoryEntry, listHistory, deleteHistoryEntry, clearHistory, type HistoryEntry } from './queryHistory';
 import { listSavedQueries, saveQuery, deleteSavedQuery, renameSavedQuery, type SavedQuery } from './savedQueries';
+import { buildDefaultTableQuery } from './lib/sql';
 
 interface Tab {
   id: string;
@@ -369,7 +370,14 @@ export default function App() {
       const body = JSON.stringify({ collection: name, operation: 'find', filter: {}, limit: 100 }, null, 2);
       addTab(`${name}.json`, body, source);
     } else {
-      addTab(`${name}.sql`, `SELECT *\nFROM \`${name}\`\nLIMIT 100;`, source);
+      // Sort by the PK descending only when it's a single auto-incrementing
+      // column, so the user lands on the most-recent rows for the common case.
+      // UUID/string/composite PKs get the unsorted template — descending order
+      // would be meaningless or surprising there.
+      const tableInfo = schemaData.tables.find(t => t.name === name);
+      const pkCols = tableInfo?.columns.filter(c => c.pk) ?? [];
+      const autoIncPk = pkCols.length === 1 && pkCols[0].autoIncrement ? pkCols[0].name : null;
+      addTab(`${name}.sql`, buildDefaultTableQuery(name, autoIncPk), source);
     }
   };
 

--- a/src/lib/sql.test.ts
+++ b/src/lib/sql.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { formatSqlValue, buildInsertSql, parseEnumValues } from './sql';
+import { formatSqlValue, buildInsertSql, parseEnumValues, buildDefaultTableQuery } from './sql';
 
 describe('parseEnumValues', () => {
   it('parses a standard enum type', () => {
@@ -90,5 +90,23 @@ describe('buildInsertSql', () => {
   it('backtick-escapes table name', () => {
     const sql = buildInsertSql('my table', { col: 1 });
     expect(sql).toContain('`my table`');
+  });
+});
+
+describe('buildDefaultTableQuery', () => {
+  it('returns the unsorted template when there is no auto-inc PK', () => {
+    expect(buildDefaultTableQuery('users', null)).toBe('SELECT *\nFROM `users`\nLIMIT 100;');
+  });
+
+  it('appends ORDER BY <pk> DESC when an auto-inc PK is provided', () => {
+    expect(buildDefaultTableQuery('orders', 'id')).toBe(
+      'SELECT *\nFROM `orders`\nORDER BY `id` DESC\nLIMIT 100;',
+    );
+  });
+
+  it('backtick-escapes both the table name and the PK column', () => {
+    const sql = buildDefaultTableQuery('my table', 'order id');
+    expect(sql).toContain('`my table`');
+    expect(sql).toContain('`order id`');
   });
 });

--- a/src/lib/sql.ts
+++ b/src/lib/sql.ts
@@ -18,6 +18,17 @@ export function formatSqlValue(v: CellValue): string {
   return String(v);
 }
 
+/**
+ * Default query template used when the user clicks a table in the sidebar.
+ * Sorts by `pkColumn DESC` when provided so the most recent rows appear first
+ * — caller passes null for tables without a single auto-incrementing PK,
+ * since descending order is meaningless on UUID/string/composite keys.
+ */
+export function buildDefaultTableQuery(table: string, pkColumn: string | null): string {
+  const orderBy = pkColumn ? `\nORDER BY \`${pkColumn}\` DESC` : '';
+  return `SELECT *\nFROM \`${table}\`${orderBy}\nLIMIT 100;`;
+}
+
 export function buildInsertSql(table: string, values: Record<string, CellValue>): string {
   const cols = Object.keys(values);
   if (cols.length === 0) return `INSERT INTO \`${table}\` () VALUES ();`;


### PR DESCRIPTION
Closes #151.

## Summary
When clicking a table in the schema browser, append \`ORDER BY \\\`<pk>\\\` DESC\` to the default query — but only for tables where the PK is a single auto-incrementing column. UUID, string, and composite PKs continue to get the unsorted \`SELECT * FROM t LIMIT 100;\` template, since descending order is meaningless on them.

## Behavior
| Table shape | Default query |
|---|---|
| \`users (id INT AUTO_INCREMENT PK)\` | \`SELECT * FROM \\\`users\\\` ORDER BY \\\`id\\\` DESC LIMIT 100;\` |
| \`sessions (token UUID PK)\` | \`SELECT * FROM \\\`sessions\\\` LIMIT 100;\` |
| \`order_items (order_id, line_no PK)\` | \`SELECT * FROM \\\`order_items\\\` LIMIT 100;\` |
| Postgres \`accounts (id BIGSERIAL PK)\` | \`SELECT * FROM \\\`accounts\\\` ORDER BY \\\`id\\\` DESC LIMIT 100;\` |

\`ColumnInfo.autoIncrement\` is already populated by both drivers (MySQL: \`extra LIKE '%auto_increment%'\`; Postgres: \`column_default LIKE 'nextval(%' OR is_identity = 'YES'\`), so no schema-loading changes are needed.

## Implementation
- New helper \`buildDefaultTableQuery(table, pkColumn | null)\` in \`src/lib/sql.ts\` — pure, easy to unit-test, mirrors the existing \`buildInsertSql\` style.
- \`handleTableSelect\` in \`App.tsx\` looks up the table's columns from \`schemaData\`, filters PK columns, and passes the column name only when there's exactly one and it's auto-incrementing.

## Test plan
- [x] Unit tests for \`buildDefaultTableQuery\` (unsorted fallback, sorted variant, identifier escaping).
- [x] \`npm test\` (23 frontend tests pass).
- [x] \`npm run build\` (typecheck + vite build clean).
- [ ] Manual: click a table with auto-inc PK, confirm \`ORDER BY\` is added; click a UUID-PK table, confirm it isn't.

🤖 Generated with [Claude Code](https://claude.com/claude-code)