### PR TITLE
feat: persist editor tabs per connection across app restarts

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ import { electronAPI } from './electronAPI';
 import { addHistoryEntry, listHistory, deleteHistoryEntry, clearHistory, type HistoryEntry } from './queryHistory';
 import { listSavedQueries, saveQuery, deleteSavedQuery, renameSavedQuery, type SavedQuery } from './savedQueries';
 import { buildDefaultTableQuery } from './lib/sql';
+import { loadTabs, saveTabs } from './tabPersistence';
 
 interface Tab {
   id: string;
@@ -128,6 +129,24 @@ export default function App() {
       setSavedQueries(listSavedQueries(res.connectionName));
       setSchemas(list);
       setActiveSchema(initial);
+
+      // Restore the user's previous tabs for this connection. We deliberately
+      // don't persist result data (privacy + size); the user re-runs to get
+      // fresh rows. Seed tabCounter from the highest restored id so new tabs
+      // can't collide with restored ones.
+      const persistedTabs = loadTabs(res.connectionName);
+      if (persistedTabs) {
+        setTabs(persistedTabs.tabs);
+        const restoredActive = persistedTabs.tabs.find(t => t.id === persistedTabs.activeTabId)
+          ? persistedTabs.activeTabId
+          : persistedTabs.tabs[0].id;
+        setActiveTab(restoredActive);
+        tabCounter.current = persistedTabs.tabs.reduce(
+          (max, t) => Math.max(max, parseInt(t.id, 10) || 0),
+          0,
+        );
+      }
+
       setConnected(true);
       setShowConnectionModal(false);
 
@@ -402,6 +421,17 @@ export default function App() {
   useEffect(() => {
     if (connected && activeSchema) loadSchema(activeSchema);
   }, [activeSchema, connected, loadSchema]);
+
+  // Persist the editor tabs (name + query + sourceTable only) per connection.
+  // Skips when not connected so disconnect's reset-to-default doesn't wipe the
+  // saved set — reconnecting the same database picks them back up.
+  useEffect(() => {
+    if (!connected || !connectionHost) return;
+    saveTabs(connectionHost, {
+      tabs: tabs.map(({ id, name, query, sourceTable }) => ({ id, name, query, sourceTable })),
+      activeTabId: activeTab,
+    });
+  }, [connected, connectionHost, tabs, activeTab]);
 
   // Sync MCP status on mount and whenever connection state changes (covers page refresh).
   useEffect(() => {

--- a/src/tabPersistence.test.ts
+++ b/src/tabPersistence.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { loadTabs, saveTabs, clearTabs, type PersistedTabState } from './tabPersistence';
+
+class MemoryStorage {
+  store = new Map<string, string>();
+  getItem(k: string) { return this.store.get(k) ?? null; }
+  setItem(k: string, v: string) { this.store.set(k, v); }
+  removeItem(k: string) { this.store.delete(k); }
+  clear() { this.store.clear(); }
+  get length() { return this.store.size; }
+  key(i: number) { return Array.from(this.store.keys())[i] ?? null; }
+}
+
+beforeEach(() => {
+  // Vitest's default node env doesn't ship a localStorage; substitute one.
+  // (The tabPersistence module reads the global lazily, so we can swap freely.)
+  (globalThis as unknown as { localStorage: MemoryStorage }).localStorage = new MemoryStorage();
+});
+
+const sample: PersistedTabState = {
+  tabs: [
+    { id: '1', name: 'query_1.sql', query: 'SELECT 1' },
+    { id: '2', name: 'users.sql', query: 'SELECT * FROM users', sourceTable: { schema: 'public', table: 'users' } },
+  ],
+  activeTabId: '2',
+};
+
+describe('tabPersistence', () => {
+  it('round-trips a tab state through save and load', () => {
+    saveTabs('conn-A', sample);
+    expect(loadTabs('conn-A')).toEqual(sample);
+  });
+
+  it('returns null when nothing has been saved for the connection', () => {
+    expect(loadTabs('never-saved')).toBeNull();
+  });
+
+  it('scopes state per connection — saving under one key does not leak into another', () => {
+    saveTabs('conn-A', sample);
+    expect(loadTabs('conn-B')).toBeNull();
+  });
+
+  it('returns null and skips persistence for an empty connection identifier', () => {
+    saveTabs('', sample);
+    expect(loadTabs('')).toBeNull();
+  });
+
+  it('returns null on malformed JSON without throwing', () => {
+    localStorage.setItem('helix.tabs.broken', '{not json');
+    expect(loadTabs('broken')).toBeNull();
+  });
+
+  it('returns null when the persisted shape is wrong (missing fields)', () => {
+    localStorage.setItem('helix.tabs.bad', JSON.stringify({ tabs: 'oops', activeTabId: 1 }));
+    expect(loadTabs('bad')).toBeNull();
+  });
+
+  it('drops malformed tab entries while keeping the well-formed ones', () => {
+    localStorage.setItem('helix.tabs.mixed', JSON.stringify({
+      tabs: [
+        { id: '1', name: 'ok.sql', query: 'SELECT 1' },
+        { id: 2, name: 'bad-id.sql', query: 'SELECT 2' }, // id wrong type
+        { id: '3', query: 'SELECT 3' },                   // missing name
+        null,
+      ],
+      activeTabId: '1',
+    }));
+    const restored = loadTabs('mixed');
+    expect(restored?.tabs).toEqual([{ id: '1', name: 'ok.sql', query: 'SELECT 1' }]);
+  });
+
+  it('returns null when every tab entry is malformed (no usable state)', () => {
+    localStorage.setItem('helix.tabs.empty', JSON.stringify({ tabs: [null, null], activeTabId: '1' }));
+    expect(loadTabs('empty')).toBeNull();
+  });
+
+  it('clears persisted state for the connection', () => {
+    saveTabs('conn-A', sample);
+    clearTabs('conn-A');
+    expect(loadTabs('conn-A')).toBeNull();
+  });
+});

--- a/src/tabPersistence.ts
+++ b/src/tabPersistence.ts
@@ -1,0 +1,57 @@
+// Tab state is persisted per connection so a returning user lands back on
+// the same set of editor tabs they had open. Result data is intentionally
+// not persisted — rerunning is fast and stale rows on disk are a privacy
+// + UX hazard. See #153.
+
+export interface PersistedTab {
+  id: string;
+  name: string;
+  query: string;
+  sourceTable?: { schema: string; table: string };
+}
+
+export interface PersistedTabState {
+  tabs: PersistedTab[];
+  activeTabId: string;
+}
+
+function keyFor(conn: string): string {
+  return `helix.tabs.${conn}`;
+}
+
+export function loadTabs(conn: string): PersistedTabState | null {
+  if (!conn) return null;
+  try {
+    const raw = localStorage.getItem(keyFor(conn));
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as unknown;
+    if (
+      !parsed ||
+      typeof parsed !== 'object' ||
+      !Array.isArray((parsed as PersistedTabState).tabs) ||
+      typeof (parsed as PersistedTabState).activeTabId !== 'string'
+    ) return null;
+    const state = parsed as PersistedTabState;
+    // Drop entries that don't match the expected shape — defensively skip
+    // anything malformed rather than blowing up restoration entirely.
+    const tabs = state.tabs.filter(
+      t => t && typeof t.id === 'string' && typeof t.name === 'string' && typeof t.query === 'string',
+    );
+    if (tabs.length === 0) return null;
+    return { tabs, activeTabId: state.activeTabId };
+  } catch {
+    return null;
+  }
+}
+
+export function saveTabs(conn: string, state: PersistedTabState): void {
+  if (!conn) return;
+  try {
+    localStorage.setItem(keyFor(conn), JSON.stringify(state));
+  } catch { /* quota or disabled storage — ignore */ }
+}
+
+export function clearTabs(conn: string): void {
+  if (!conn) return;
+  try { localStorage.removeItem(keyFor(conn)); } catch { /* ignore */ }
+}


### PR DESCRIPTION
Closes #153.

## Summary
Reconnecting to the same database now restores the user's previous editor tabs (name, query, sourceTable) and active selection. Tabs are scoped per connection in \`localStorage\` under \`helix.tabs.<connectionName>\`, mirroring the \`queryHistory\` / \`savedQueries\` pattern.

Result data is **not** persisted — caching MB-scale rowsets on disk has privacy, storage-quota, and stale-data UX costs that aren't worth it given how fast re-running is.

## Implementation
- \`src/tabPersistence.ts\` — \`loadTabs\` / \`saveTabs\` / \`clearTabs\` with defensive parsing (malformed JSON returns null; per-entry type-check skips bad tabs while keeping good ones).
- \`App.tsx\`:
  - On connect, after schema setup but before flipping \`connected: true\`, call \`loadTabs(res.connectionName)\` and seed \`tabs\` / \`activeTab\` / \`tabCounter\` from it. The counter seeds from \`max(restoredId)\` so newly-created tabs can't collide with restored ones.
  - A new \`useEffect\` on \`[connected, connectionHost, tabs, activeTab]\` writes the tab snapshot back. Guarded by \`connected && connectionHost\` so disconnect's reset-to-default doesn't wipe the saved set — reconnecting picks them back up.

## Test plan
- [x] Unit tests for \`tabPersistence\` (round-trip, scoping per connection, malformed JSON, partial-entry skipping, empty-connection guard, clear).
- [x] \`npm test\` (32 frontend tests pass).
- [x] \`npm run build\` (typecheck + vite build clean).
- [ ] Manual in Electron: open several tabs (mix of table-clicks and ad-hoc queries), restart, reconnect — confirm the tab list and active tab come back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)