### PR TITLE
feat: redesign connection manager with auto-detect single-page form

### DIFF
--- a/src/components/ConnectionManager.tsx
+++ b/src/components/ConnectionManager.tsx
@@ -1,5 +1,5 @@
-import { useState, useEffect } from 'react';
-import type { CSSProperties, ReactNode } from 'react';
+import { useState, useEffect, useMemo, useRef } from 'react';
+import type { CSSProperties } from 'react';
 import type { Theme } from '../theme';
 import { api } from '../api';
 import { listSavedConnections, deleteSavedConnection, type SavedConnection } from '../savedConnections';
@@ -20,10 +20,10 @@ export interface ConnectionForm {
   // Only meaningful in Electron — when true, the password is persisted via
   // safeStorage and reloaded the next time this connection is opened.
   savePassword: boolean;
-  // Only meaningful when type === 'mongodb' AND mongoMode === 'uri'.
+  // Only meaningful when type === 'mongodb' AND the user is editing via URI.
   connectionString?: string;
-  // UI state: which input mode the mongodb form is in. Persisted alongside
-  // the connection itself (derived on load: presence of connectionString).
+  // UI state: which input mode is active for the mongodb form. Persisted on
+  // saved connections; in this redesign it's also driven by `lastEdited`.
   mongoMode?: 'fields' | 'uri';
 }
 
@@ -34,86 +34,65 @@ interface ConnectionManagerProps {
   t: Theme;
 }
 
-interface DbTypeMeta {
-  id: DbType;
-  name: string;
-  badge: 'SQL' | 'NoSQL';
-  version: string;
-  desc: string;
-  defaultPort: string;
-  defaultUser: string;
-  icon: (color: string) => ReactNode;
+const DB_META = {
+  mysql:    { name: 'MySQL',      badge: 'SQL'   as const, defaultPort: '3306'  },
+  postgres: { name: 'PostgreSQL', badge: 'SQL'   as const, defaultPort: '5432'  },
+  mongodb:  { name: 'MongoDB',    badge: 'NoSQL' as const, defaultPort: '27017' },
+};
+
+// ─────────────────────────────────────────────────────────────
+// DB type detection — heuristic, "predicted" until the server confirms.
+// ─────────────────────────────────────────────────────────────
+function predictDbType(form: { connectionString?: string; port?: string }): DbType | null {
+  const uri = form.connectionString?.trim();
+  if (uri) {
+    if (/^mongodb(\+srv)?:\/\//i.test(uri)) return 'mongodb';
+    if (/^postgres(ql)?:\/\//i.test(uri))   return 'postgres';
+    if (/^mysql:\/\//i.test(uri))           return 'mysql';
+  }
+  const p = parseInt(form.port ?? '', 10);
+  if (p === 27017) return 'mongodb';
+  if (p === 5432)  return 'postgres';
+  if (p === 3306)  return 'mysql';
+  return null;
 }
 
-const DB_TYPES: DbTypeMeta[] = [
-  {
-    id: 'mysql',
-    name: 'MySQL',
-    badge: 'SQL',
-    version: '5.7 – 8.x',
-    desc: 'Popular open source relational database',
-    defaultPort: '3306',
-    defaultUser: 'root',
-    icon: (color) => (
-      <svg width="22" height="22" viewBox="0 0 40 40" fill="none">
-        <ellipse cx="20" cy="12" rx="14" ry="5" stroke={color} strokeWidth="2.5" fill="none"/>
-        <path d="M6 12v16c0 2.76 6.27 5 14 5s14-2.24 14-5V12" stroke={color} strokeWidth="2.5" fill="none"/>
-        <path d="M6 20c0 2.76 6.27 5 14 5s14-2.24 14-5" stroke={color} strokeWidth="1.5" fill="none" opacity="0.5"/>
-      </svg>
-    ),
-  },
-  {
-    id: 'postgres',
-    name: 'PostgreSQL',
-    badge: 'SQL',
-    version: '12 – 16',
-    desc: 'Advanced relational database with powerful extensions',
-    defaultPort: '5432',
-    defaultUser: 'postgres',
-    icon: (color) => (
-      <svg width="22" height="22" viewBox="0 0 40 40" fill="none">
-        <ellipse cx="20" cy="12" rx="14" ry="5" stroke={color} strokeWidth="2.5" fill="none"/>
-        <path d="M6 12v16c0 2.76 6.27 5 14 5s14-2.24 14-5V12" stroke={color} strokeWidth="2.5" fill="none"/>
-        <path d="M6 20c0 2.76 6.27 5 14 5s14-2.24 14-5" stroke={color} strokeWidth="1.5" fill="none" opacity="0.5"/>
-        <path d="M27 8 C32 4, 37 10, 33 16" stroke={color} strokeWidth="1.5" strokeLinecap="round" fill="none"/>
-      </svg>
-    ),
-  },
-  {
-    id: 'mongodb',
-    name: 'MongoDB',
-    badge: 'NoSQL',
-    version: '4.4 – 7.x',
-    desc: 'Flexible document database for modern applications',
-    defaultPort: '27017',
-    defaultUser: '',
-    icon: (color) => (
-      <svg width="22" height="22" viewBox="0 0 40 40" fill="none">
-        <path d="M20 4 C20 4, 28 14, 28 22 C28 30, 24 36, 20 36 C16 36, 12 30, 12 22 C12 14, 20 4, 20 4Z" stroke={color} strokeWidth="2.5" fill="none"/>
-        <line x1="20" y1="30" x2="20" y2="38" stroke={color} strokeWidth="1.5" strokeLinecap="round"/>
-      </svg>
-    ),
-  },
-];
+// ─────────────────────────────────────────────────────────────
+// URI ↔ fields sync
+// ─────────────────────────────────────────────────────────────
+function buildUri(f: { type: DbType; host: string; port: string; user: string; password: string; database: string }, maskPassword = false): string {
+  if (!f.host) return '';
+  const scheme = f.type === 'postgres' ? 'postgresql' : f.type === 'mongodb' ? 'mongodb' : 'mysql';
+  const pw = f.password ? (maskPassword ? '***' : encodeURIComponent(f.password)) : '';
+  const auth = f.user
+    ? (pw ? `${encodeURIComponent(f.user)}:${pw}@` : `${encodeURIComponent(f.user)}@`)
+    : '';
+  const port = f.port ? `:${f.port}` : '';
+  const db   = f.database ? `/${f.database}` : '';
+  return `${scheme}://${auth}${f.host}${port}${db}`;
+}
 
-const dbMeta = (type: DbType): DbTypeMeta => DB_TYPES.find(d => d.id === type) ?? DB_TYPES[0];
-const defaultPort = (type: DbType): string => dbMeta(type).defaultPort;
-
-// Mirrors `connectionLabel` in `server/src/routes/connect.ts`: rewrites
-// `mongodb+srv://` so WHATWG URL populates host/username, and prefers
-// `hostname` over `host` so we never leak an explicit port. Returns just the
-// host portion (no `user@`) for the saved-list subtitle. Falls back to a
-// neutral placeholder rather than the raw URI so a malformed entry — or one
-// we can't parse — never displays an embedded password.
-const hostFromConnectionString = (uri: string): string => {
+function parseUri(uri: string): Partial<Pick<ConnectionForm, 'host' | 'port' | 'user' | 'password' | 'database'>> {
+  if (!uri) return {};
   try {
-    const normalized = uri.replace(/^mongodb\+srv:\/\//, 'mongodb://');
-    const url = new URL(normalized);
-    return url.hostname || '<connectionString>';
-  } catch {
-    return '<connectionString>';
-  }
-};
+    // WHATWG URL doesn't recognize mysql:/postgresql:/mongodb: schemes — rewrite
+    // to http: so it'll populate hostname/port/username/password for us, then
+    // strip back out. mongodb+srv has no port (SRV records resolve it) so the
+    // port extraction yields '' which is what we want.
+    const norm = uri
+      .replace(/^mysql:\/\//i,        'http://')
+      .replace(/^postgresql?:\/\//i,  'http://')
+      .replace(/^mongodb(\+srv)?:\/\//i, 'http://');
+    const u = new URL(norm);
+    return {
+      host:     u.hostname || '',
+      port:     u.port     || '',
+      user:     u.username ? decodeURIComponent(u.username) : '',
+      password: u.password ? decodeURIComponent(u.password) : '',
+      database: (u.pathname || '').replace(/^\//, ''),
+    };
+  } catch { return {}; }
+}
 
 const formFromSaved = (entry: SavedConnection): ConnectionForm => {
   const type: DbType = entry.type ?? 'mysql';
@@ -134,30 +113,23 @@ const formFromSaved = (entry: SavedConnection): ConnectionForm => {
   };
 };
 
-const freshFormFor = (type: DbType): ConnectionForm => {
-  const d = dbMeta(type);
-  return {
-    name: `Local ${d.name}`,
-    type,
-    host: import.meta.env['VITE_DEFAULT_HOST'] ?? 'localhost',
-    port: import.meta.env['VITE_DEFAULT_PORT'] ?? d.defaultPort,
-    user: import.meta.env['VITE_DEFAULT_USER'] ?? d.defaultUser,
-    password: '',
-    database: '',
-    ssl: false,
-    sslVerify: true,
-    savePassword: false,
-    mongoMode: type === 'mongodb' ? 'fields' : undefined,
-  };
-};
+const initialForm = (): ConnectionForm => ({
+  name: '',
+  type: 'mysql',
+  host: import.meta.env['VITE_DEFAULT_HOST'] ?? '',
+  port: import.meta.env['VITE_DEFAULT_PORT'] ?? '',
+  user: import.meta.env['VITE_DEFAULT_USER'] ?? '',
+  password: '', database: '', ssl: false, sslVerify: true, savePassword: false,
+  mongoMode: 'fields',
+});
 
 export function ConnectionManager({ onConnect, isConnecting, error, t }: ConnectionManagerProps) {
   const [saved, setSaved] = useState<SavedConnection[]>(() => listSavedConnections());
-  const [step, setStep] = useState<'pick' | 'form'>('pick');
-  const [form, setForm] = useState<ConnectionForm>(() => freshFormFor('mysql'));
+  const [form, setForm] = useState<ConnectionForm>(initialForm);
+  const [lastEdited, setLastEdited] = useState<'uri' | 'fields'>('fields');
   const [appliedSaved, setAppliedSaved] = useState<string>('');
   const [testing, setTesting] = useState(false);
-  const [testResult, setTestResult] = useState<{ ok: true } | { ok: false; error: string } | null>(null);
+  const [testResult, setTestResult] = useState<{ ok: true; type: DbType } | { ok: false; error: string } | null>(null);
   const [canSavePassword, setCanSavePassword] = useState(false);
 
   useEffect(() => {
@@ -166,23 +138,88 @@ export function ConnectionManager({ onConnect, isConnecting, error, t }: Connect
     return () => { cancelled = true; };
   }, []);
 
-  const meta = dbMeta(form.type);
-  const isMongoUri = form.type === 'mongodb' && form.mongoMode === 'uri';
+  const predicted = useMemo(() => predictDbType(form), [form.connectionString, form.port]);
+  const effectiveType: DbType = predicted ?? form.type;
 
-  const buildSubmitForm = (): ConnectionForm => {
-    if (isMongoUri) return form;
-    // Strip connectionString in fields mode so it can't slip through if a stale
-    // value lingered in form state (e.g. after switching modes/types).
+  // What we send to the backend. The form's `type` is the predicted one (so
+  // the server picks the right driver). For mongo URIs we keep
+  // `connectionString` and the existing `mongoMode: 'uri'` contract; otherwise
+  // we strip it so a stale URI can't slip through with the fields payload.
+  const buildSubmit = (): ConnectionForm => {
+    const isMongoUri = effectiveType === 'mongodb' && lastEdited === 'uri' && !!form.connectionString;
+    if (isMongoUri) {
+      return { ...form, type: effectiveType, mongoMode: 'uri' };
+    }
     const { connectionString: _cs, ...rest } = form;
-    return { ...rest };
+    return { ...rest, type: effectiveType, mongoMode: effectiveType === 'mongodb' ? 'fields' : undefined };
+  };
+
+  const setField = <K extends keyof ConnectionForm>(k: K, v: ConnectionForm[K]) => {
+    setForm(p => {
+      const next = { ...p, [k]: v };
+      // Re-derive the URI when any of the URI-relevant fields change. Type
+      // pulls from the prediction (driven by port) so the scheme stays in sync.
+      if (k === 'host' || k === 'port' || k === 'user' || k === 'password' || k === 'database') {
+        const predictedType = predictDbType(next) ?? next.type;
+        next.connectionString = buildUri({ ...next, type: predictedType });
+      }
+      return next;
+    });
+    setLastEdited('fields');
+    setTestResult(null);
+  };
+
+  const setUri = (v: string) => {
+    setForm(p => {
+      const parsed = parseUri(v);
+      return { ...p, connectionString: v, ...parsed };
+    });
+    setLastEdited('uri');
+    setTestResult(null);
+  };
+
+  const setNameOnly = (v: string) => {
+    setForm(p => ({ ...p, name: v }));
+    if (appliedSaved && appliedSaved !== v) setAppliedSaved('');
+  };
+
+  const setSimple = <K extends keyof ConnectionForm>(k: K, v: ConnectionForm[K]) => {
+    setForm(p => ({ ...p, [k]: v }));
+    setTestResult(null);
+  };
+
+  const applySaved = (entry: SavedConnection) => {
+    const next = formFromSaved(entry);
+    // Reconstruct the URI so the dual-input shows what's behind this saved
+    // connection. For mongo with a stored connectionString, prefer that.
+    if (next.type !== 'mongodb' || !next.connectionString) {
+      next.connectionString = buildUri(next);
+    }
+    setForm(next);
+    setAppliedSaved(entry.name);
+    setLastEdited(entry.type === 'mongodb' && entry.connectionString ? 'uri' : 'fields');
+    setTestResult(null);
+    if (entry.savePassword && electronAPI) {
+      electronAPI.passwords.load(entry.name).then(pw => {
+        if (pw === null) return;
+        setForm(p => p.name === entry.name && p.password === '' ? { ...p, password: pw, connectionString: buildUri({ ...p, password: pw }) } : p);
+      }).catch(() => {});
+    }
+  };
+
+  const removeSaved = (name: string) => {
+    deleteSavedConnection(name);
+    electronAPI?.passwords.delete(name).catch(() => {});
+    setSaved(listSavedConnections());
+    if (appliedSaved === name) setAppliedSaved('');
   };
 
   const runTest = async () => {
     setTesting(true);
     setTestResult(null);
     try {
-      await api.testConnection(buildSubmitForm());
-      setTestResult({ ok: true });
+      await api.testConnection(buildSubmit());
+      setTestResult({ ok: true, type: effectiveType });
     } catch (err) {
       setTestResult({ ok: false, error: err instanceof Error ? err.message : String(err) });
     } finally {
@@ -190,318 +227,115 @@ export function ConnectionManager({ onConnect, isConnecting, error, t }: Connect
     }
   };
 
-  const set = <K extends keyof ConnectionForm>(k: K, v: ConnectionForm[K]) => {
-    setForm(p => ({ ...p, [k]: v }));
-    setTestResult(null);
-  };
-
-  const setMongoMode = (mode: 'fields' | 'uri') => {
-    setForm(p => ({ ...p, mongoMode: mode }));
-    setTestResult(null);
-  };
-
-  const pickFreshDb = (type: DbType) => {
-    setForm(freshFormFor(type));
-    setAppliedSaved('');
-    setTestResult(null);
-    setStep('form');
-  };
-
-  const applySaved = (entry: SavedConnection) => {
-    setForm(formFromSaved(entry));
-    setAppliedSaved(entry.name);
-    setTestResult(null);
-    if (entry.savePassword && electronAPI) {
-      electronAPI.passwords.load(entry.name).then(pw => {
-        if (pw === null) return;
-        setForm(p => p.name === entry.name && p.password === '' ? { ...p, password: pw } : p);
-      }).catch(() => {});
-    }
-    setStep('form');
-  };
-
-  const removeSaved = (name: string, e?: React.MouseEvent) => {
-    e?.stopPropagation();
-    deleteSavedConnection(name);
-    electronAPI?.passwords.delete(name).catch(() => {});
-    const next = listSavedConnections();
-    setSaved(next);
-    if (appliedSaved === name) setAppliedSaved('');
-  };
-
+  // ─────────────────────────────────────────────────────────
+  // Styles
+  // ─────────────────────────────────────────────────────────
   const s = {
-    overlay: { position: 'fixed', inset: 0, background: t.bgBase, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', zIndex: 300 } as CSSProperties,
-    modal: { width: 500, maxWidth: '92vw', background: t.bgElevated, border: `1px solid ${t.border}`, borderRadius: 12, overflow: 'hidden', boxShadow: t.shadowModal } as CSSProperties,
-    header: { padding: '18px 22px', borderBottom: `1px solid ${t.border}`, display: 'flex', alignItems: 'center', gap: 12, background: t.bgSurface } as CSSProperties,
+    overlay: { position: 'fixed', inset: 0, background: t.bgBase, display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 300 } as CSSProperties,
+    modal: { width: 500, maxWidth: '92vw', background: t.bgElevated, border: `1px solid ${t.border}`, borderRadius: 12, overflow: 'visible', boxShadow: t.shadowModal } as CSSProperties,
+    header: { padding: '16px 22px', background: t.bgSurface, borderBottom: `1px solid ${t.border}`, borderRadius: '12px 12px 0 0', display: 'flex', alignItems: 'center', gap: 12 } as CSSProperties,
     title: { fontSize: 15, fontWeight: 600, color: t.textPrimary, fontFamily: '"Space Grotesk", sans-serif' } as CSSProperties,
-    subtitle: { fontSize: 11, color: t.textMuted, marginTop: 2 } as CSSProperties,
-    body: { padding: '18px 22px', display: 'flex', flexDirection: 'column', gap: 10 } as CSSProperties,
-    label: { fontSize: 10, fontWeight: 600, letterSpacing: '0.05em', textTransform: 'uppercase', color: t.textMuted, fontFamily: '"IBM Plex Sans", sans-serif' } as CSSProperties,
-    field: { display: 'flex', flexDirection: 'column', gap: 4 } as CSSProperties,
-    input: { height: 32, background: t.bgInput, border: `1px solid ${t.border}`, borderRadius: 5, padding: '0 10px', fontSize: 13, color: t.textPrimary, outline: 'none', width: '100%', fontFamily: 'inherit', boxSizing: 'border-box' } as CSSProperties,
-    row: { display: 'flex', gap: 10 } as CSSProperties,
-    footer: { padding: '12px 22px', borderTop: `1px solid ${t.border}`, background: t.bgSurface, display: 'flex', alignItems: 'center', gap: 10 } as CSSProperties,
+    subtitle: { fontSize: 11, color: t.textMuted, marginTop: 1 } as CSSProperties,
+    body: { padding: '16px 22px', display: 'flex', flexDirection: 'column', gap: 12 } as CSSProperties,
+    label: { fontSize: 10, fontWeight: 600, letterSpacing: '0.05em', textTransform: 'uppercase', color: t.textMuted, display: 'block', marginBottom: 4 } as CSSProperties,
+    input: { height: 32, background: t.bgInput, border: `1px solid ${t.border}`, borderRadius: 5, padding: '0 10px', fontSize: 12, color: t.textPrimary, outline: 'none', width: '100%', fontFamily: 'inherit', boxSizing: 'border-box' } as CSSProperties,
+    footer: { padding: '12px 22px', borderTop: `1px solid ${t.border}`, background: t.bgSurface, borderRadius: '0 0 12px 12px', display: 'flex', gap: 8, alignItems: 'center' } as CSSProperties,
     testBtn: { height: 32, padding: '0 14px', background: 'transparent', border: `1px solid ${t.border}`, borderRadius: 5, fontSize: 12, color: t.textSecondary, cursor: 'pointer', fontFamily: 'inherit' } as CSSProperties,
-    connectBtn: { height: 32, padding: '0 18px', background: t.accent, border: 'none', borderRadius: 5, fontSize: 13, fontWeight: 600, color: t.textInverse, cursor: 'pointer', display: 'flex', alignItems: 'center', gap: 6, fontFamily: 'inherit' } as CSSProperties,
-    backBtn: { background: 'none', border: 'none', cursor: 'pointer', color: t.textMuted, display: 'flex', alignItems: 'center', padding: '2px 4px', borderRadius: 4 } as CSSProperties,
-    dbCard: { display: 'flex', alignItems: 'center', gap: 14, padding: '14px 18px', background: t.bgElevated, border: `1px solid ${t.border}`, borderRadius: 8, cursor: 'pointer', transition: 'border-color 120ms ease' } as CSSProperties,
-    dbCardIcon: { width: 40, height: 40, background: t.accentMuted, border: `1px solid ${t.borderAccent}`, borderRadius: 8, display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 } as CSSProperties,
-    badge: { fontSize: 9, fontWeight: 600, color: t.accent, background: t.accentMuted, border: `1px solid ${t.borderAccent}`, padding: '1px 6px', borderRadius: 9999, letterSpacing: '0.04em' } as CSSProperties,
-    sectionLabel: { fontSize: 10, fontWeight: 600, letterSpacing: '0.06em', textTransform: 'uppercase', color: t.textMuted, padding: '0 4px' } as CSSProperties,
+    connectBtn: { height: 32, padding: '0 18px', background: t.accent, border: 'none', borderRadius: 5, fontSize: 12, fontWeight: 600, color: t.textInverse, cursor: 'pointer', display: 'flex', alignItems: 'center', gap: 6, fontFamily: 'inherit' } as CSSProperties,
     errorBanner: { display: 'flex', alignItems: 'center', gap: 8, padding: '9px 12px', background: t.colorErrorBg, border: `1px solid ${t.colorErrorBorder}`, borderRadius: 6, fontSize: 12, color: t.colorError, fontFamily: 'monospace' } as CSSProperties,
   };
 
-  // ─────────────────────────────────────────────────────────
-  // Step 1 — Picker (saved connections + DB type cards)
-  // ─────────────────────────────────────────────────────────
-  if (step === 'pick') {
-    return (
-      <div style={s.overlay}>
-        <div style={s.modal}>
-          <div style={s.header}>
-            <svg width="20" height="20" viewBox="0 0 40 40" fill="none">
-              <path d="M6 6 C6 6, 20 2, 20 20 C20 38, 6 34, 6 34" stroke={t.accent} strokeWidth="2.5" strokeLinecap="round"/>
-              <path d="M16 6 C16 6, 30 2, 30 20 C30 38, 16 34, 16 34" stroke={t.accent} strokeWidth="2.5" strokeLinecap="round" opacity="0.5"/>
-              <circle cx="6"  cy="6"  r="2.5" fill={t.accent}/>
-              <circle cx="20" cy="20" r="2.5" fill={t.accent}/>
-              <circle cx="6"  cy="34" r="2.5" fill={t.accent}/>
-            </svg>
-            <div>
-              <div style={s.title}>Connect to a database</div>
-              <div style={s.subtitle}>
-                {saved.length > 0 ? 'Pick a saved connection or start fresh' : 'Select the database type to get started'}
-              </div>
-            </div>
-          </div>
+  const badgeStatus: 'predicted' | 'connecting' | 'confirmed' | null =
+    isConnecting || testing ? 'connecting'
+    : testResult && testResult.ok ? 'confirmed'
+    : predicted ? 'predicted'
+    : null;
+  const badgeType = testResult && testResult.ok ? testResult.type : predicted;
 
-          <div style={{ padding: '16px 22px 20px', display: 'flex', flexDirection: 'column', gap: 14, maxHeight: '70vh', overflowY: 'auto' }}>
-            {saved.length > 0 && (
-              <>
-                <div style={s.sectionLabel}>Saved connections</div>
-                <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
-                  {saved.map(entry => {
-                    const m = dbMeta(entry.type ?? 'mysql');
-                    const subtitle = (entry.user || entry.host || entry.port)
-                      ? `${entry.user}@${entry.host}:${entry.port}`
-                      : entry.connectionString
-                        ? hostFromConnectionString(entry.connectionString)
-                        : '';
-                    return (
-                      <SavedRow
-                        key={entry.name}
-                        name={entry.name}
-                        subtitle={subtitle}
-                        meta={m}
-                        ssl={!!entry.ssl}
-                        database={entry.database}
-                        onClick={() => applySaved(entry)}
-                        onForget={(e) => removeSaved(entry.name, e)}
-                        t={t}
-                      />
-                    );
-                  })}
-                </div>
-                <div style={{ ...s.sectionLabel, marginTop: 6 }}>Or start fresh</div>
-              </>
-            )}
-
-            {DB_TYPES.map(d => (
-              <DbCard key={d.id} meta={d} onClick={() => pickFreshDb(d.id)} t={t} s={s}/>
-            ))}
-          </div>
-        </div>
-      </div>
-    );
-  }
-
-  // ─────────────────────────────────────────────────────────
-  // Step 2 — Connection form
-  // ─────────────────────────────────────────────────────────
   return (
     <div style={s.overlay}>
       <div style={s.modal}>
+        {/* Header */}
         <div style={s.header}>
-          <button type="button" style={s.backBtn} onClick={() => setStep('pick')} title="Back">
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-              <polyline points="15 18 9 12 15 6"/>
-            </svg>
-          </button>
-          <div style={{ width: 32, height: 32, background: t.accentMuted, border: `1px solid ${t.borderAccent}`, borderRadius: 7, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-            {meta.icon(t.accent)}
+          <svg width="20" height="20" viewBox="0 0 40 40" fill="none">
+            <path d="M6 6 C6 6, 20 2, 20 20 C20 38, 6 34, 6 34" stroke={t.accent} strokeWidth="2.5" strokeLinecap="round"/>
+            <path d="M16 6 C16 6, 30 2, 30 20 C30 38, 16 34, 16 34" stroke={t.accent} strokeWidth="2.5" strokeLinecap="round" opacity="0.5"/>
+            <circle cx="6"  cy="6"  r="2.5" fill={t.accent}/>
+            <circle cx="20" cy="20" r="2.5" fill={t.accent}/>
+            <circle cx="6"  cy="34" r="2.5" fill={t.accent}/>
+          </svg>
+          <div style={{ flex: 1 }}>
+            <div style={s.title}>New connection</div>
+            <div style={s.subtitle}>Database type identified on connect</div>
           </div>
-          <div>
-            <div style={s.title}>{appliedSaved || `New ${meta.name} connection`}</div>
-            <div style={s.subtitle}>{meta.badge} · port {meta.defaultPort}</div>
-          </div>
+          <DetectionBadge status={badgeStatus} type={badgeType} t={t}/>
         </div>
 
         <form
           onSubmit={(e) => {
             e.preventDefault();
             if (isConnecting) return;
-            onConnect(buildSubmitForm());
+            onConnect(buildSubmit());
           }}
           autoComplete="on"
         >
           <div style={s.body}>
-            <div style={s.field}>
-              <label style={s.label}>Connection name</label>
-              <input
-                style={s.input}
-                name="connection-name"
-                autoComplete="off"
-                value={form.name}
-                onChange={e => set('name', e.target.value)}
-                placeholder="My Database"
-              />
-            </div>
+            <ConnectionNameField
+              value={form.name}
+              onChange={setNameOnly}
+              saved={saved}
+              appliedSaved={appliedSaved}
+              onSelect={applySaved}
+              onDelete={removeSaved}
+              t={t}
+            />
 
-            {form.type === 'mongodb' && (
-              <div style={s.field}>
-                <label style={s.label}>Input mode</label>
-                <div style={{ display: 'flex', gap: 6 }}>
-                  {(['fields', 'uri'] as const).map(mode => {
-                    const active = form.mongoMode === mode;
-                    return (
-                      <button
-                        key={mode}
-                        type="button"
-                        onClick={() => setMongoMode(mode)}
-                        style={{
-                          height: 30, padding: '0 14px',
-                          background: active ? t.accent : t.bgInput,
-                          border: `1px solid ${active ? t.accent : t.border}`,
-                          borderRadius: 5, fontSize: 12, fontWeight: active ? 600 : 400,
-                          color: active ? t.textInverse : t.textSecondary,
-                          cursor: 'pointer', fontFamily: 'inherit',
-                        }}
-                      >
-                        {mode === 'fields' ? 'Fields' : 'Connection string'}
-                      </button>
-                    );
-                  })}
-                </div>
-              </div>
-            )}
+            <DualInput
+              form={form}
+              effectiveType={effectiveType}
+              lastEdited={lastEdited}
+              setLastEdited={setLastEdited}
+              setField={setField}
+              setUri={setUri}
+              t={t}
+            />
 
-            {isMongoUri ? (
-              <div style={s.field}>
-                <label style={s.label}>Connection string</label>
-                <textarea
-                  style={{ ...s.input, height: 72, padding: '8px 10px', fontFamily: 'monospace', resize: 'vertical' }}
-                  name="connection-string"
-                  autoComplete="off"
-                  value={form.connectionString ?? ''}
-                  onChange={e => set('connectionString', e.target.value)}
-                  placeholder="mongodb://user:pass@host:27017/?authSource=admin"
+            {canSavePassword && (
+              <label style={{ display: 'flex', alignItems: 'center', gap: 8, cursor: 'pointer', marginTop: -2 }}>
+                <input
+                  type="checkbox"
+                  checked={form.savePassword}
+                  onChange={e => setSimple('savePassword', e.target.checked)}
+                  style={{ width: 14, height: 14, cursor: 'pointer', accentColor: t.accent }}
                 />
-              </div>
-            ) : (
-              <>
-                <div style={s.row}>
-                  <div style={{ ...s.field, flex: 1 }}>
-                    <label style={s.label}>Host</label>
-                    <input
-                      style={s.input}
-                      name="host"
-                      autoComplete="off"
-                      value={form.host}
-                      onChange={e => set('host', e.target.value)}
-                      placeholder="localhost"
-                    />
-                  </div>
-                  <div style={{ ...s.field, width: 90 }}>
-                    <label style={s.label}>Port</label>
-                    <input
-                      style={{ ...s.input, fontFamily: '"JetBrains Mono", monospace', fontSize: 12 }}
-                      name="port"
-                      autoComplete="off"
-                      value={form.port}
-                      onChange={e => set('port', e.target.value)}
-                      placeholder={meta.defaultPort}
-                    />
-                  </div>
-                </div>
-
-                <div style={s.row}>
-                  <div style={{ ...s.field, flex: 1 }}>
-                    <label style={s.label}>Username</label>
-                    <input
-                      style={s.input}
-                      name="username"
-                      autoComplete="username"
-                      value={form.user}
-                      onChange={e => set('user', e.target.value)}
-                      placeholder={meta.defaultUser || 'username'}
-                    />
-                  </div>
-                  <div style={{ ...s.field, flex: 1 }}>
-                    <label style={s.label}>Password</label>
-                    <input
-                      style={s.input}
-                      type="password"
-                      name="password"
-                      autoComplete="current-password"
-                      value={form.password}
-                      onChange={e => set('password', e.target.value)}
-                      placeholder="••••••••"
-                    />
-                  </div>
-                </div>
-
-                {canSavePassword && (
-                  <label style={{ display: 'flex', alignItems: 'center', gap: 8, cursor: 'pointer', marginTop: -2 }}>
-                    <input
-                      type="checkbox"
-                      checked={form.savePassword}
-                      onChange={e => set('savePassword', e.target.checked)}
-                      style={{ width: 14, height: 14, cursor: 'pointer', accentColor: t.accent }}
-                    />
-                    <span style={{ fontSize: 12.5, color: t.textSecondary }}>Save password</span>
-                    <span style={{ fontSize: 11, color: t.textMuted }}>(encrypted via OS keychain)</span>
-                  </label>
-                )}
-              </>
-            )}
-
-            <div style={s.field}>
-              <label style={s.label}>
-                {form.type === 'mongodb' ? 'Default database' : 'Default schema'}{' '}
-                <span style={{ color: t.textMuted, textTransform: 'none', letterSpacing: 0, fontWeight: 400 }}>(optional)</span>
+                <span style={{ fontSize: 12, color: t.textSecondary }}>Save password</span>
+                <span style={{ fontSize: 11, color: t.textMuted }}>(encrypted via OS keychain)</span>
               </label>
-              <input
-                style={s.input}
-                name="database"
-                autoComplete="off"
-                value={form.database}
-                onChange={e => set('database', e.target.value)}
-                placeholder={form.type === 'postgres' ? 'postgres' : 'my_database'}
-              />
-            </div>
+            )}
 
             <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
               <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
                 <button
                   type="button"
-                  style={{ width: 34, height: 20, borderRadius: 9999, border: 'none', cursor: 'pointer', position: 'relative', flexShrink: 0, background: form.ssl ? t.accent : t.border, transition: 'background 150ms ease' }}
-                  onClick={() => set('ssl', !form.ssl)}
+                  style={{ width: 32, height: 18, borderRadius: 9999, border: 'none', cursor: 'pointer', position: 'relative', flexShrink: 0, background: form.ssl ? t.accent : t.border, transition: 'background 150ms ease' }}
+                  onClick={() => setSimple('ssl', !form.ssl)}
                 >
-                  <div style={{ position: 'absolute', width: 14, height: 14, background: 'white', borderRadius: '50%', top: 3, left: form.ssl ? 17 : 3, transition: 'left 150ms ease' }}/>
+                  <div style={{ position: 'absolute', width: 12, height: 12, background: 'white', borderRadius: '50%', top: 3, left: form.ssl ? 17 : 3, transition: 'left 150ms ease' }}/>
                 </button>
-                <span style={{ fontSize: 13, color: t.textSecondary }}>Use SSL / TLS</span>
-                {form.ssl && <span style={{ fontSize: 10, fontWeight: 600, color: t.accent, background: t.accentMuted, border: `1px solid ${t.borderAccent}`, padding: '1px 8px', borderRadius: 9999 }}>Encrypted</span>}
+                <span style={{ fontSize: 12, color: t.textSecondary }}>Use SSL / TLS</span>
+                {form.ssl && <span style={{ fontSize: 10, fontWeight: 600, color: t.accent, background: t.accentMuted, border: `1px solid ${t.borderAccent}`, padding: '1px 7px', borderRadius: 9999 }}>Encrypted</span>}
               </div>
 
               {form.ssl && (
-                <div style={{ paddingLeft: 44, display: 'flex', flexDirection: 'column', gap: 6 }}>
+                <div style={{ paddingLeft: 42, display: 'flex', flexDirection: 'column', gap: 6 }}>
                   <label style={{ display: 'flex', alignItems: 'center', gap: 8, cursor: 'pointer' }}>
                     <input
                       type="checkbox"
                       checked={form.sslVerify}
-                      onChange={e => set('sslVerify', e.target.checked)}
+                      onChange={e => setSimple('sslVerify', e.target.checked)}
                       style={{ width: 14, height: 14, cursor: 'pointer', accentColor: t.accent }}
                     />
-                    <span style={{ fontSize: 12.5, color: t.textSecondary }}>Verify server certificate</span>
+                    <span style={{ fontSize: 12, color: t.textSecondary }}>Verify server certificate</span>
                   </label>
                   {!form.sslVerify && (
                     <div style={{ display: 'flex', alignItems: 'center', gap: 5, fontSize: 11, color: t.colorWarning }}>
@@ -526,11 +360,11 @@ export function ConnectionManager({ onConnect, isConnecting, error, t }: Connect
             )}
 
             {testResult && testResult.ok && (
-              <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '9px 12px', background: t.colorSuccessBg, border: `1px solid ${t.colorSuccess}55`, borderRadius: 6, fontSize: 12, color: t.colorSuccess }}>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '8px 12px', background: t.colorSuccessBg, border: `1px solid ${t.colorSuccess}55`, borderRadius: 6, fontSize: 12, color: t.colorSuccess }}>
                 <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke={t.colorSuccess} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
                   <polyline points="20 6 9 17 4 12"/>
                 </svg>
-                <span>Connection successful{!isMongoUri && <> — {form.user}@{form.host}:{form.port || defaultPort(form.type)}</>}</span>
+                <span>{DB_META[testResult.type].name} reachable{form.host && <> · {form.user}@{form.host}:{form.port || DB_META[testResult.type].defaultPort}</>}</span>
               </div>
             )}
             {testResult && !testResult.ok && (
@@ -553,12 +387,12 @@ export function ConnectionManager({ onConnect, isConnecting, error, t }: Connect
             <div style={{ flex: 1 }}/>
             <button
               type="submit"
-              style={{ ...s.connectBtn, opacity: isConnecting ? 0.7 : 1 }}
+              style={{ ...s.connectBtn, opacity: isConnecting ? 0.75 : 1 }}
               disabled={isConnecting}
             >
               {isConnecting
-                ? <><div style={{ width: 12, height: 12, border: `2px solid ${t.textInverse}40`, borderTop: `2px solid ${t.textInverse}`, borderRadius: '50%', animation: 'spin 0.8s linear infinite' }}/> Connecting…</>
-                : <><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M18.36 6.64a9 9 0 1 1-12.73 0"/><line x1="12" y1="2" x2="12" y2="12"/></svg> Connect</>
+                ? <><div style={{ width: 11, height: 11, border: `2px solid ${t.textInverse}40`, borderTop: `2px solid ${t.textInverse}`, borderRadius: '50%', animation: 'spin 0.8s linear infinite' }}/> Connecting…</>
+                : <><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M18.36 6.64a9 9 0 1 1-12.73 0"/><line x1="12" y1="2" x2="12" y2="12"/></svg> Connect</>
               }
             </button>
           </div>
@@ -568,83 +402,374 @@ export function ConnectionManager({ onConnect, isConnecting, error, t }: Connect
   );
 }
 
-// Picker card for one of the supported DB types.
-function DbCard({ meta, onClick, t, s }: {
-  meta: DbTypeMeta;
-  onClick: () => void;
+// ─────────────────────────────────────────────────────────────
+// DetectionBadge — predicted/connecting/confirmed pill
+// ─────────────────────────────────────────────────────────────
+function DetectionBadge({ status, type, t }: { status: 'predicted' | 'connecting' | 'confirmed' | null; type: DbType | null; t: Theme }) {
+  if (status === 'connecting') {
+    return (
+      <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6, fontSize: 10, color: t.textMuted, whiteSpace: 'nowrap' }}>
+        <div style={{ width: 10, height: 10, border: `2px solid ${t.border}`, borderTop: `2px solid ${t.accent}`, borderRadius: '50%', animation: 'spin 0.8s linear infinite', flexShrink: 0 }}/>
+        Identifying…
+      </span>
+    );
+  }
+  if (status === 'predicted' && type) {
+    return (
+      <span style={{ display: 'inline-flex', alignItems: 'center', gap: 5, fontSize: 10, fontWeight: 600,
+        color: t.colorWarning, background: t.colorWarningBg, border: `1px solid ${t.colorWarning}40`,
+        padding: '2px 9px', borderRadius: 9999, whiteSpace: 'nowrap' }}>
+        <svg width="9" height="9" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+          <circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/>
+        </svg>
+        Likely {DB_META[type].name}
+      </span>
+    );
+  }
+  if (status === 'confirmed' && type) {
+    return (
+      <span style={{ display: 'inline-flex', alignItems: 'center', gap: 5, fontSize: 10, fontWeight: 600,
+        color: t.accent, background: t.accentMuted, border: `1px solid ${t.borderAccent}`,
+        padding: '2px 9px', borderRadius: 9999, whiteSpace: 'nowrap' }}>
+        <svg width="9" height="9" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+          <polyline points="20 6 9 17 4 12"/>
+        </svg>
+        {DB_META[type].name} · {DB_META[type].badge}
+      </span>
+    );
+  }
+  return null;
+}
+
+// ─────────────────────────────────────────────────────────────
+// ConnectionNameField — name input + saved-connections dropdown
+// ─────────────────────────────────────────────────────────────
+function ConnectionNameField({ value, onChange, saved, appliedSaved, onSelect, onDelete, t }: {
+  value: string;
+  onChange: (v: string) => void;
+  saved: SavedConnection[];
+  appliedSaved: string;
+  onSelect: (entry: SavedConnection) => void;
+  onDelete: (name: string) => void;
   t: Theme;
-  s: Record<string, CSSProperties>;
 }) {
+  const [open, setOpen] = useState(false);
+  const [isTyping, setIsTyping] = useState(false);
+  const [highlight, setHighlight] = useState(-1);
+  const wrapRef = useRef<HTMLDivElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handler = (e: MouseEvent) => {
+      if (wrapRef.current && !wrapRef.current.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, []);
+
+  // While typing, filter to matching saved connections; on focus / after a
+  // selection, show the full list so the user can browse.
+  const filtered = isTyping && value.trim()
+    ? saved.filter(c => c.name.toLowerCase().includes(value.toLowerCase()))
+    : saved;
+
+  useEffect(() => { setHighlight(-1); }, [value, isTyping, open]);
+  useEffect(() => {
+    if (highlight < 0 || !listRef.current) return;
+    const row = listRef.current.children[highlight] as HTMLElement | undefined;
+    row?.scrollIntoView({ block: 'nearest' });
+  }, [highlight]);
+
+  const choose = (entry: SavedConnection) => {
+    setIsTyping(false);
+    onSelect(entry);
+    setOpen(false);
+  };
+
+  const onKey = (e: React.KeyboardEvent) => {
+    if (!open && (e.key === 'ArrowDown' || e.key === 'ArrowUp')) {
+      setOpen(true); e.preventDefault(); return;
+    }
+    if (e.key === 'ArrowDown') { e.preventDefault(); setHighlight(h => Math.min(filtered.length - 1, h + 1)); }
+    else if (e.key === 'ArrowUp') { e.preventDefault(); setHighlight(h => Math.max(0, h - 1)); }
+    else if (e.key === 'Enter' && highlight >= 0 && filtered[highlight]) {
+      e.preventDefault(); choose(filtered[highlight]);
+    }
+    else if (e.key === 'Escape') {
+      e.preventDefault();
+      e.nativeEvent.stopImmediatePropagation();
+      setOpen(false);
+    }
+  };
+
+  const showDropdown = open && saved.length > 0;
+  const subtitleFor = (c: SavedConnection): string => {
+    if (c.host) return `${c.user ? c.user + '@' : ''}${c.host}${c.port ? ':' + c.port : ''}`;
+    if (c.connectionString) {
+      try { return new URL(c.connectionString.replace(/^mongodb\+srv:\/\//, 'mongodb://')).hostname; }
+      catch { return ''; }
+    }
+    return '';
+  };
+
   return (
-    <div
-      style={s.dbCard}
-      onClick={onClick}
-      onMouseEnter={(e) => { e.currentTarget.style.borderColor = t.borderAccent; }}
-      onMouseLeave={(e) => { e.currentTarget.style.borderColor = t.border; }}
-    >
-      <div style={s.dbCardIcon}>{meta.icon(t.accent)}</div>
-      <div style={{ flex: 1, minWidth: 0 }}>
-        <div style={{ display: 'flex', alignItems: 'center', gap: 7, marginBottom: 3 }}>
-          <span style={{ fontSize: 14, fontWeight: 600, color: t.textPrimary }}>{meta.name}</span>
-          <span style={s.badge}>{meta.badge}</span>
-          <span style={{ fontSize: 11, color: t.textMuted }}>{meta.version}</span>
+    <div ref={wrapRef} style={{ position: 'relative' }}>
+      <label style={{ fontSize: 10, fontWeight: 600, letterSpacing: '0.05em', textTransform: 'uppercase', color: t.textMuted, display: 'block', marginBottom: 4 }}>
+        Connection name <span style={{ fontWeight: 400, textTransform: 'none', letterSpacing: 0, color: t.textMuted, opacity: 0.7 }}>— leave blank to not save</span>
+      </label>
+      <div style={{ position: 'relative' }}>
+        <input
+          name="connection-name"
+          autoComplete="off"
+          value={value}
+          onChange={e => { onChange(e.target.value); setIsTyping(true); setOpen(true); }}
+          onKeyDown={onKey}
+          onFocus={() => setOpen(true)}
+          onClick={() => setOpen(true)}
+          placeholder="Name this connection, or leave blank"
+          style={{
+            height: 32, width: '100%', background: t.bgInput,
+            border: `1px solid ${showDropdown ? t.borderSubtle : t.border}`,
+            borderRadius: showDropdown ? '5px 5px 0 0' : 5,
+            padding: '0 32px 0 10px', fontSize: 12, color: t.textPrimary, outline: 'none',
+            fontFamily: 'inherit', boxSizing: 'border-box',
+          }}
+        />
+        <div style={{ position: 'absolute', right: 8, top: '50%', transform: 'translateY(-50%)', pointerEvents: 'none', color: t.textMuted }}>
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <polyline points="6 9 12 15 18 9"/>
+          </svg>
         </div>
-        <span style={{ fontSize: 12, color: t.textMuted }}>{meta.desc}</span>
       </div>
-      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke={t.textMuted} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-        <polyline points="9 18 15 12 9 6"/>
-      </svg>
+
+      {showDropdown && (
+        <div style={{
+          position: 'absolute', top: '100%', left: 0, right: 0, zIndex: 100,
+          background: t.bgOverlay ?? t.bgElevated, border: `1px solid ${t.border}`, borderTop: 'none',
+          borderRadius: '0 0 6px 6px',
+          boxShadow: t.shadowLg, maxHeight: 280, overflowY: 'auto',
+        }}>
+          {filtered.length > 0
+            ? <div ref={listRef}>
+                {filtered.map((c, i) => (
+                  <SavedRow
+                    key={c.name}
+                    entry={c}
+                    subtitle={subtitleFor(c)}
+                    typeLabel={DB_META[(c.type ?? 'mysql') as DbType].name}
+                    highlighted={i === highlight}
+                    isApplied={appliedSaved === c.name}
+                    onSelect={() => choose(c)}
+                    onDelete={(e) => { e.stopPropagation(); onDelete(c.name); }}
+                    t={t}
+                  />
+                ))}
+              </div>
+            : <div style={{ padding: '8px 12px', fontSize: 11, color: t.textMuted, fontStyle: 'italic' }}>
+                No saved connections match "{value}"
+              </div>
+          }
+        </div>
+      )}
     </div>
   );
 }
 
-// Saved-connection row on the picker step. Click = restore + go to form.
-function SavedRow({ name, subtitle, meta, ssl, database, onClick, onForget, t }: {
-  name: string;
+function SavedRow({ entry, subtitle, typeLabel, highlighted, isApplied, onSelect, onDelete, t }: {
+  entry: SavedConnection;
   subtitle: string;
-  meta: DbTypeMeta;
-  ssl: boolean;
-  database?: string;
-  onClick: () => void;
-  onForget: (e: React.MouseEvent) => void;
+  typeLabel: string;
+  highlighted: boolean;
+  isApplied: boolean;
+  onSelect: () => void;
+  onDelete: (e: React.MouseEvent) => void;
   t: Theme;
 }) {
   const [hovered, setHovered] = useState(false);
+  const active = hovered || highlighted;
   return (
     <div
-      onClick={onClick}
+      onClick={onSelect}
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
       style={{
-        display: 'flex', alignItems: 'center', gap: 12,
-        padding: '10px 14px',
-        background: hovered ? t.bgHover : 'transparent',
-        border: `1px solid ${hovered ? t.borderAccent : t.borderSubtle}`,
-        borderRadius: 7, cursor: 'pointer', minWidth: 0,
+        display: 'flex', alignItems: 'center', gap: 8, padding: '7px 10px',
+        cursor: 'pointer',
+        background: active ? t.bgHover : 'transparent',
+        borderBottom: `1px solid ${t.borderSubtle}`,
+        borderLeft: `2px solid ${highlighted ? t.accent : 'transparent'}`,
       }}
     >
-      <div style={{ width: 28, height: 28, background: t.accentMuted, border: `1px solid ${t.borderAccent}`, borderRadius: 6, display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>
-        <span style={{ width: 18, height: 18, display: 'inline-flex' }}>{meta.icon(t.accent)}</span>
-      </div>
-      <div style={{ flex: 1, minWidth: 0 }}>
-        <div style={{ fontSize: 13, fontWeight: 500, color: t.textPrimary, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{name}</div>
-        <div style={{ fontSize: 11, color: t.textMuted, fontFamily: 'monospace', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-          {subtitle}
-          {database && <span> · {database}</span>}
-          {ssl && <span style={{ color: t.accent }}> · SSL</span>}
-        </div>
-      </div>
+      <div style={{ width: 6, height: 6, borderRadius: '50%', background: t.accent, flexShrink: 0, opacity: 0.7 }}/>
+      <span style={{ fontSize: 12, color: t.textPrimary, flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+        {entry.name}
+      </span>
+      <span style={{ fontSize: 9, color: t.textMuted, fontFamily: '"JetBrains Mono", monospace', flexShrink: 0 }}>{typeLabel}</span>
+      <span style={{ fontSize: 10, color: t.textMuted, flexShrink: 0, maxWidth: 130, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{subtitle}</span>
+      {isApplied && <span style={{ fontSize: 9, color: t.accent, textTransform: 'uppercase', letterSpacing: '0.05em', flexShrink: 0 }}>current</span>}
       <button
         type="button"
-        onClick={onForget}
-        title={`Forget '${name}'`}
+        onMouseDown={onDelete}
+        title={`Forget '${entry.name}'`}
         style={{
-          background: 'transparent', border: 'none', cursor: 'pointer',
-          color: t.textMuted, padding: '4px 6px', fontSize: 11, fontFamily: 'inherit',
+          background: 'none', border: 'none', cursor: 'pointer',
+          color: t.colorError, display: 'flex', alignItems: 'center', padding: 2,
+          borderRadius: 3, flexShrink: 0,
           opacity: hovered ? 1 : 0,
           transition: 'opacity 100ms ease',
         }}
-      >Forget</button>
+      >
+        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+          <line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/>
+        </svg>
+      </button>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// DualInput — connection string + fields, both visible & synced
+// ─────────────────────────────────────────────────────────────
+function DualInput({ form, effectiveType, lastEdited, setLastEdited, setField, setUri, t }: {
+  form: ConnectionForm;
+  effectiveType: DbType;
+  lastEdited: 'uri' | 'fields';
+  setLastEdited: (v: 'uri' | 'fields') => void;
+  setField: <K extends keyof ConnectionForm>(k: K, v: ConnectionForm[K]) => void;
+  setUri: (v: string) => void;
+  t: Theme;
+}) {
+  const uriActive = lastEdited === 'uri';
+  const fieldsActive = lastEdited === 'fields';
+  const accentBorder = `1px solid ${t.accent}`;
+  const subtleBorder = `1px solid ${t.borderSubtle}`;
+  const accentShadow = `0 0 0 2px ${t.accentMuted}`;
+
+  // When the user is editing fields, mask the password in the rendered URI so
+  // the actual password isn't readable in the connection string box. The form
+  // state still holds the real password — it's just hidden from view.
+  const displayUri = form.password && lastEdited === 'fields'
+    ? buildUri({ ...form, type: effectiveType }, true)
+    : form.connectionString ?? '';
+
+  const label = (text: string) => (
+    <span style={{ fontSize: 10, fontWeight: 600, letterSpacing: '0.05em', textTransform: 'uppercase', color: t.textMuted, display: 'block', marginBottom: 4 }}>{text}</span>
+  );
+  const input: CSSProperties = {
+    height: 32, background: t.bgInput, border: `1px solid ${t.border}`,
+    borderRadius: 5, padding: '0 10px', fontSize: 12, color: t.textPrimary,
+    outline: 'none', width: '100%', fontFamily: 'inherit', boxSizing: 'border-box',
+  };
+
+  const placeholderUri = effectiveType === 'postgres'
+    ? 'postgresql://user@host:5432/dbname'
+    : effectiveType === 'mongodb'
+      ? 'mongodb://host:27017/database'
+      : 'mysql://user:password@host:3306/db';
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+      {/* URI box */}
+      <div style={{
+        padding: 10, borderRadius: 7,
+        border: uriActive ? accentBorder : subtleBorder,
+        boxShadow: uriActive ? accentShadow : 'none',
+        background: t.bgSurface,
+        transition: 'border-color 150ms, box-shadow 150ms',
+      }}>
+        {label('Connection string')}
+        <input
+          name="connection-string"
+          autoComplete="off"
+          value={displayUri}
+          onChange={e => setUri(e.target.value)}
+          onFocus={() => setLastEdited('uri')}
+          placeholder={placeholderUri}
+          style={{ ...input, fontFamily: '"JetBrains Mono", monospace', fontSize: 11 }}
+        />
+      </div>
+
+      {/* "or" divider */}
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+        <div style={{ flex: 1, height: 1, background: t.borderSubtle }}/>
+        <span style={{ fontSize: 10, color: t.textMuted, fontWeight: 500 }}>or</span>
+        <div style={{ flex: 1, height: 1, background: t.borderSubtle }}/>
+      </div>
+
+      {/* Fields box */}
+      <div
+        style={{
+          padding: 10, borderRadius: 7,
+          border: fieldsActive ? accentBorder : subtleBorder,
+          boxShadow: fieldsActive ? accentShadow : 'none',
+          background: t.bgSurface,
+          transition: 'border-color 150ms, box-shadow 150ms',
+          display: 'flex', flexDirection: 'column', gap: 8,
+        }}
+        onFocusCapture={() => setLastEdited('fields')}
+      >
+        <div style={{ display: 'flex', gap: 8 }}>
+          <div style={{ flex: 1 }}>
+            {label('Host')}
+            <input
+              name="host"
+              autoComplete="off"
+              value={form.host}
+              onChange={e => setField('host', e.target.value)}
+              placeholder="localhost"
+              style={input}
+            />
+          </div>
+          <div style={{ width: 90 }}>
+            {label('Port')}
+            <input
+              name="port"
+              autoComplete="off"
+              value={form.port}
+              onChange={e => setField('port', e.target.value.replace(/\D/g, ''))}
+              placeholder={DB_META[effectiveType].defaultPort}
+              style={{ ...input, fontFamily: '"JetBrains Mono", monospace', fontSize: 11 }}
+              inputMode="numeric"
+            />
+          </div>
+        </div>
+        <div style={{ display: 'flex', gap: 8 }}>
+          <div style={{ flex: 1 }}>
+            {label('Username')}
+            <input
+              name="username"
+              autoComplete="username"
+              value={form.user}
+              onChange={e => setField('user', e.target.value)}
+              placeholder={effectiveType === 'mongodb' ? 'optional' : 'root'}
+              style={input}
+            />
+          </div>
+          <div style={{ flex: 1 }}>
+            {label('Password')}
+            <input
+              type="password"
+              name="password"
+              autoComplete="current-password"
+              value={form.password}
+              onChange={e => setField('password', e.target.value)}
+              placeholder="••••••••"
+              style={input}
+            />
+          </div>
+        </div>
+        <div>
+          {label(effectiveType === 'mongodb' ? 'Default database' : 'Database')}
+          <input
+            name="database"
+            autoComplete="off"
+            value={form.database}
+            onChange={e => setField('database', e.target.value)}
+            placeholder={effectiveType === 'postgres' ? 'postgres' : 'my_database'}
+            style={input}
+          />
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/components/ConnectionManager.tsx
+++ b/src/components/ConnectionManager.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import type { CSSProperties } from 'react';
+import type { CSSProperties, ReactNode } from 'react';
 import type { Theme } from '../theme';
 import { api } from '../api';
 import { listSavedConnections, deleteSavedConnection, type SavedConnection } from '../savedConnections';
@@ -34,22 +34,75 @@ interface ConnectionManagerProps {
   t: Theme;
 }
 
-const defaultPort = (type: DbType): string => {
-  if (type === 'postgres') return '5432';
-  if (type === 'mongodb') return '27017';
-  return '3306';
-};
+interface DbTypeMeta {
+  id: DbType;
+  name: string;
+  badge: 'SQL' | 'NoSQL';
+  version: string;
+  desc: string;
+  defaultPort: string;
+  defaultUser: string;
+  icon: (color: string) => ReactNode;
+}
 
-const dbLabel = (type: DbType): string => {
-  if (type === 'postgres') return 'PostgreSQL';
-  if (type === 'mongodb') return 'MongoDB';
-  return 'MySQL';
-};
+const DB_TYPES: DbTypeMeta[] = [
+  {
+    id: 'mysql',
+    name: 'MySQL',
+    badge: 'SQL',
+    version: '5.7 – 8.x',
+    desc: 'Popular open source relational database',
+    defaultPort: '3306',
+    defaultUser: 'root',
+    icon: (color) => (
+      <svg width="22" height="22" viewBox="0 0 40 40" fill="none">
+        <ellipse cx="20" cy="12" rx="14" ry="5" stroke={color} strokeWidth="2.5" fill="none"/>
+        <path d="M6 12v16c0 2.76 6.27 5 14 5s14-2.24 14-5V12" stroke={color} strokeWidth="2.5" fill="none"/>
+        <path d="M6 20c0 2.76 6.27 5 14 5s14-2.24 14-5" stroke={color} strokeWidth="1.5" fill="none" opacity="0.5"/>
+      </svg>
+    ),
+  },
+  {
+    id: 'postgres',
+    name: 'PostgreSQL',
+    badge: 'SQL',
+    version: '12 – 16',
+    desc: 'Advanced relational database with powerful extensions',
+    defaultPort: '5432',
+    defaultUser: 'postgres',
+    icon: (color) => (
+      <svg width="22" height="22" viewBox="0 0 40 40" fill="none">
+        <ellipse cx="20" cy="12" rx="14" ry="5" stroke={color} strokeWidth="2.5" fill="none"/>
+        <path d="M6 12v16c0 2.76 6.27 5 14 5s14-2.24 14-5V12" stroke={color} strokeWidth="2.5" fill="none"/>
+        <path d="M6 20c0 2.76 6.27 5 14 5s14-2.24 14-5" stroke={color} strokeWidth="1.5" fill="none" opacity="0.5"/>
+        <path d="M27 8 C32 4, 37 10, 33 16" stroke={color} strokeWidth="1.5" strokeLinecap="round" fill="none"/>
+      </svg>
+    ),
+  },
+  {
+    id: 'mongodb',
+    name: 'MongoDB',
+    badge: 'NoSQL',
+    version: '4.4 – 7.x',
+    desc: 'Flexible document database for modern applications',
+    defaultPort: '27017',
+    defaultUser: '',
+    icon: (color) => (
+      <svg width="22" height="22" viewBox="0 0 40 40" fill="none">
+        <path d="M20 4 C20 4, 28 14, 28 22 C28 30, 24 36, 20 36 C16 36, 12 30, 12 22 C12 14, 20 4, 20 4Z" stroke={color} strokeWidth="2.5" fill="none"/>
+        <line x1="20" y1="30" x2="20" y2="38" stroke={color} strokeWidth="1.5" strokeLinecap="round"/>
+      </svg>
+    ),
+  },
+];
+
+const dbMeta = (type: DbType): DbTypeMeta => DB_TYPES.find(d => d.id === type) ?? DB_TYPES[0];
+const defaultPort = (type: DbType): string => dbMeta(type).defaultPort;
 
 // Mirrors `connectionLabel` in `server/src/routes/connect.ts`: rewrites
 // `mongodb+srv://` so WHATWG URL populates host/username, and prefers
 // `hostname` over `host` so we never leak an explicit port. Returns just the
-// host portion (no `user@`) for the autocomplete subtitle. Falls back to a
+// host portion (no `user@`) for the saved-list subtitle. Falls back to a
 // neutral placeholder rather than the raw URI so a malformed entry — or one
 // we can't parse — never displays an embedded password.
 const hostFromConnectionString = (uri: string): string => {
@@ -81,25 +134,28 @@ const formFromSaved = (entry: SavedConnection): ConnectionForm => {
   };
 };
 
+const freshFormFor = (type: DbType): ConnectionForm => {
+  const d = dbMeta(type);
+  return {
+    name: `Local ${d.name}`,
+    type,
+    host: import.meta.env['VITE_DEFAULT_HOST'] ?? 'localhost',
+    port: import.meta.env['VITE_DEFAULT_PORT'] ?? d.defaultPort,
+    user: import.meta.env['VITE_DEFAULT_USER'] ?? d.defaultUser,
+    password: '',
+    database: '',
+    ssl: false,
+    sslVerify: true,
+    savePassword: false,
+    mongoMode: type === 'mongodb' ? 'fields' : undefined,
+  };
+};
+
 export function ConnectionManager({ onConnect, isConnecting, error, t }: ConnectionManagerProps) {
   const [saved, setSaved] = useState<SavedConnection[]>(() => listSavedConnections());
-  const [form, setForm] = useState<ConnectionForm>(() => {
-    const list = listSavedConnections();
-    if (list[0]) return formFromSaved(list[0]);
-    return {
-      name: 'Local MySQL',
-      type: 'mysql',
-      host: import.meta.env['VITE_DEFAULT_HOST'] ?? 'localhost',
-      port: import.meta.env['VITE_DEFAULT_PORT'] ?? '3306',
-      user: import.meta.env['VITE_DEFAULT_USER'] ?? 'root',
-      password: '', database: '', ssl: false, sslVerify: true, savePassword: false,
-      mongoMode: 'fields',
-    };
-  });
-  // Track the saved entry currently reflected in the form, so we only auto-populate once per match.
-  const [appliedSaved, setAppliedSaved] = useState<string>(saved[0]?.name ?? '');
-  const [suggestOpen, setSuggestOpen] = useState(false);
-  const [highlightIdx, setHighlightIdx] = useState(-1);
+  const [step, setStep] = useState<'pick' | 'form'>('pick');
+  const [form, setForm] = useState<ConnectionForm>(() => freshFormFor('mysql'));
+  const [appliedSaved, setAppliedSaved] = useState<string>('');
   const [testing, setTesting] = useState(false);
   const [testResult, setTestResult] = useState<{ ok: true } | { ok: false; error: string } | null>(null);
   const [canSavePassword, setCanSavePassword] = useState(false);
@@ -110,21 +166,7 @@ export function ConnectionManager({ onConnect, isConnecting, error, t }: Connect
     return () => { cancelled = true; };
   }, []);
 
-  // If the initial saved entry has a stored password, load it on mount.
-  useEffect(() => {
-    const first = saved[0];
-    if (!first?.savePassword || !electronAPI) return;
-    let cancelled = false;
-    electronAPI.passwords.load(first.name).then(pw => {
-      if (cancelled || pw === null) return;
-      setForm(p => p.name === first.name && p.password === '' ? { ...p, password: pw } : p);
-    }).catch(() => {});
-    return () => { cancelled = true; };
-  // Intentional empty deps — we only want to load the password for the connection
-  // that was active when the modal opened, not on every re-render.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
+  const meta = dbMeta(form.type);
   const isMongoUri = form.type === 'mongodb' && form.mongoMode === 'uri';
 
   const buildSubmitForm = (): ConnectionForm => {
@@ -153,46 +195,33 @@ export function ConnectionManager({ onConnect, isConnecting, error, t }: Connect
     setTestResult(null);
   };
 
-  const setDbType = (next: DbType) => {
-    setForm(p => {
-      const prevDefault = defaultPort(p.type);
-      const portIsPrevDefault = p.port === '' || p.port === prevDefault;
-      const nextMongoMode = next === 'mongodb' ? (p.mongoMode ?? 'fields') : 'fields';
-      return {
-        ...p,
-        type: next,
-        port: portIsPrevDefault ? defaultPort(next) : p.port,
-        mongoMode: nextMongoMode,
-        connectionString: next === 'mongodb' ? p.connectionString : undefined,
-      };
-    });
-    setTestResult(null);
-  };
-
   const setMongoMode = (mode: 'fields' | 'uri') => {
     setForm(p => ({ ...p, mongoMode: mode }));
     setTestResult(null);
   };
 
+  const pickFreshDb = (type: DbType) => {
+    setForm(freshFormFor(type));
+    setAppliedSaved('');
+    setTestResult(null);
+    setStep('form');
+  };
+
   const applySaved = (entry: SavedConnection) => {
     setForm(formFromSaved(entry));
     setAppliedSaved(entry.name);
-    setSuggestOpen(false);
+    setTestResult(null);
     if (entry.savePassword && electronAPI) {
       electronAPI.passwords.load(entry.name).then(pw => {
         if (pw === null) return;
         setForm(p => p.name === entry.name && p.password === '' ? { ...p, password: pw } : p);
       }).catch(() => {});
     }
+    setStep('form');
   };
 
-  const onNameChange = (value: string) => {
-    setForm(p => ({ ...p, name: value }));
-    if (appliedSaved && appliedSaved !== value) setAppliedSaved('');
-    setHighlightIdx(-1);
-  };
-
-  const removeSaved = (name: string) => {
+  const removeSaved = (name: string, e?: React.MouseEvent) => {
+    e?.stopPropagation();
     deleteSavedConnection(name);
     electronAPI?.passwords.delete(name).catch(() => {});
     const next = listSavedConnections();
@@ -200,58 +229,109 @@ export function ConnectionManager({ onConnect, isConnecting, error, t }: Connect
     if (appliedSaved === name) setAppliedSaved('');
   };
 
-  const filteredSaved = (() => {
-    const q = form.name.trim().toLowerCase();
-    if (!q) return saved;
-    const starts = saved.filter(c => c.name.toLowerCase().startsWith(q));
-    const includes = saved.filter(c => !c.name.toLowerCase().startsWith(q) && c.name.toLowerCase().includes(q));
-    return [...starts, ...includes];
-  })();
-
   const s = {
-    overlay: { position: 'fixed', inset: 0, background: t.bgBase + 'EE', display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 300 } as CSSProperties,
-    modal: { width: 460, background: t.bgElevated, border: `1px solid ${t.border}`, borderRadius: 12, overflow: 'hidden', boxShadow: t.shadowModal } as CSSProperties,
-    header: { padding: '20px 24px', borderBottom: `1px solid ${t.border}`, display: 'flex', alignItems: 'center', gap: 14, background: t.bgSurface } as CSSProperties,
-    title: { fontSize: 16, fontWeight: 600, color: t.textPrimary, fontFamily: '"Space Grotesk", sans-serif' } as CSSProperties,
-    subtitle: { fontSize: 12, color: t.textMuted, marginTop: 2 } as CSSProperties,
-    body: { padding: 20, display: 'flex', flexDirection: 'column', gap: 14 } as CSSProperties,
-    row: { display: 'flex', gap: 10 } as CSSProperties,
-    field: { display: 'flex', flexDirection: 'column', gap: 5 } as CSSProperties,
+    overlay: { position: 'fixed', inset: 0, background: t.bgBase, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', zIndex: 300 } as CSSProperties,
+    modal: { width: 500, maxWidth: '92vw', background: t.bgElevated, border: `1px solid ${t.border}`, borderRadius: 12, overflow: 'hidden', boxShadow: t.shadowModal } as CSSProperties,
+    header: { padding: '18px 22px', borderBottom: `1px solid ${t.border}`, display: 'flex', alignItems: 'center', gap: 12, background: t.bgSurface } as CSSProperties,
+    title: { fontSize: 15, fontWeight: 600, color: t.textPrimary, fontFamily: '"Space Grotesk", sans-serif' } as CSSProperties,
+    subtitle: { fontSize: 11, color: t.textMuted, marginTop: 2 } as CSSProperties,
+    body: { padding: '18px 22px', display: 'flex', flexDirection: 'column', gap: 10 } as CSSProperties,
     label: { fontSize: 10, fontWeight: 600, letterSpacing: '0.05em', textTransform: 'uppercase', color: t.textMuted, fontFamily: '"IBM Plex Sans", sans-serif' } as CSSProperties,
-    input: { height: 32, background: t.bgInput, border: `1px solid ${t.border}`, borderRadius: 5, padding: '0 10px', fontFamily: '"IBM Plex Sans", sans-serif', fontSize: 13, color: t.textPrimary, outline: 'none', width: '100%' } as CSSProperties,
-    toggleRow: { display: 'flex', alignItems: 'center', gap: 10 } as CSSProperties,
-    toggleLabel: { fontSize: 13, color: t.textSecondary } as CSSProperties,
-    sslBadge: { fontSize: 10, fontWeight: 600, color: t.accent, background: t.accentMuted, border: `1px solid ${t.borderAccent}`, padding: '2px 8px', borderRadius: 9999 } as CSSProperties,
-    errorBanner: { display: 'flex', alignItems: 'center', gap: 8, padding: '10px 12px', background: t.colorErrorBg, border: `1px solid ${t.colorErrorBorder}`, borderRadius: 6, fontSize: 12, color: t.colorError, fontFamily: 'monospace' } as CSSProperties,
-    footer: { padding: '14px 20px', borderTop: `1px solid ${t.border}`, display: 'flex', alignItems: 'center', gap: 10, background: t.bgSurface } as CSSProperties,
-    testBtn: { height: 32, padding: '0 14px', background: 'transparent', border: `1px solid ${t.border}`, borderRadius: 5, fontSize: 12, color: t.textSecondary, cursor: 'pointer', fontFamily: '"IBM Plex Sans", sans-serif' } as CSSProperties,
-    connectBtn: { height: 32, padding: '0 18px', background: t.accent, border: 'none', borderRadius: 5, fontSize: 13, fontWeight: 600, color: t.textInverse, cursor: 'pointer', display: 'flex', alignItems: 'center', gap: 6, fontFamily: '"IBM Plex Sans", sans-serif' } as CSSProperties,
+    field: { display: 'flex', flexDirection: 'column', gap: 4 } as CSSProperties,
+    input: { height: 32, background: t.bgInput, border: `1px solid ${t.border}`, borderRadius: 5, padding: '0 10px', fontSize: 13, color: t.textPrimary, outline: 'none', width: '100%', fontFamily: 'inherit', boxSizing: 'border-box' } as CSSProperties,
+    row: { display: 'flex', gap: 10 } as CSSProperties,
+    footer: { padding: '12px 22px', borderTop: `1px solid ${t.border}`, background: t.bgSurface, display: 'flex', alignItems: 'center', gap: 10 } as CSSProperties,
+    testBtn: { height: 32, padding: '0 14px', background: 'transparent', border: `1px solid ${t.border}`, borderRadius: 5, fontSize: 12, color: t.textSecondary, cursor: 'pointer', fontFamily: 'inherit' } as CSSProperties,
+    connectBtn: { height: 32, padding: '0 18px', background: t.accent, border: 'none', borderRadius: 5, fontSize: 13, fontWeight: 600, color: t.textInverse, cursor: 'pointer', display: 'flex', alignItems: 'center', gap: 6, fontFamily: 'inherit' } as CSSProperties,
+    backBtn: { background: 'none', border: 'none', cursor: 'pointer', color: t.textMuted, display: 'flex', alignItems: 'center', padding: '2px 4px', borderRadius: 4 } as CSSProperties,
+    dbCard: { display: 'flex', alignItems: 'center', gap: 14, padding: '14px 18px', background: t.bgElevated, border: `1px solid ${t.border}`, borderRadius: 8, cursor: 'pointer', transition: 'border-color 120ms ease' } as CSSProperties,
+    dbCardIcon: { width: 40, height: 40, background: t.accentMuted, border: `1px solid ${t.borderAccent}`, borderRadius: 8, display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 } as CSSProperties,
+    badge: { fontSize: 9, fontWeight: 600, color: t.accent, background: t.accentMuted, border: `1px solid ${t.borderAccent}`, padding: '1px 6px', borderRadius: 9999, letterSpacing: '0.04em' } as CSSProperties,
+    sectionLabel: { fontSize: 10, fontWeight: 600, letterSpacing: '0.06em', textTransform: 'uppercase', color: t.textMuted, padding: '0 4px' } as CSSProperties,
+    errorBanner: { display: 'flex', alignItems: 'center', gap: 8, padding: '9px 12px', background: t.colorErrorBg, border: `1px solid ${t.colorErrorBorder}`, borderRadius: 6, fontSize: 12, color: t.colorError, fontFamily: 'monospace' } as CSSProperties,
   };
 
-  const dbTypeBtnStyle = (active: boolean): CSSProperties => ({
-    height: 30, padding: '0 14px',
-    background: active ? t.accent : t.bgInput,
-    border: `1px solid ${active ? t.accent : t.border}`,
-    borderRadius: 5, fontSize: 12, fontWeight: active ? 600 : 400,
-    color: active ? t.textInverse : t.textSecondary,
-    cursor: 'pointer', fontFamily: '"IBM Plex Sans", sans-serif',
-    transition: 'background 120ms, color 120ms, border-color 120ms',
-  });
+  // ─────────────────────────────────────────────────────────
+  // Step 1 — Picker (saved connections + DB type cards)
+  // ─────────────────────────────────────────────────────────
+  if (step === 'pick') {
+    return (
+      <div style={s.overlay}>
+        <div style={s.modal}>
+          <div style={s.header}>
+            <svg width="20" height="20" viewBox="0 0 40 40" fill="none">
+              <path d="M6 6 C6 6, 20 2, 20 20 C20 38, 6 34, 6 34" stroke={t.accent} strokeWidth="2.5" strokeLinecap="round"/>
+              <path d="M16 6 C16 6, 30 2, 30 20 C30 38, 16 34, 16 34" stroke={t.accent} strokeWidth="2.5" strokeLinecap="round" opacity="0.5"/>
+              <circle cx="6"  cy="6"  r="2.5" fill={t.accent}/>
+              <circle cx="20" cy="20" r="2.5" fill={t.accent}/>
+              <circle cx="6"  cy="34" r="2.5" fill={t.accent}/>
+            </svg>
+            <div>
+              <div style={s.title}>Connect to a database</div>
+              <div style={s.subtitle}>
+                {saved.length > 0 ? 'Pick a saved connection or start fresh' : 'Select the database type to get started'}
+              </div>
+            </div>
+          </div>
 
+          <div style={{ padding: '16px 22px 20px', display: 'flex', flexDirection: 'column', gap: 14, maxHeight: '70vh', overflowY: 'auto' }}>
+            {saved.length > 0 && (
+              <>
+                <div style={s.sectionLabel}>Saved connections</div>
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+                  {saved.map(entry => {
+                    const m = dbMeta(entry.type ?? 'mysql');
+                    const subtitle = (entry.user || entry.host || entry.port)
+                      ? `${entry.user}@${entry.host}:${entry.port}`
+                      : entry.connectionString
+                        ? hostFromConnectionString(entry.connectionString)
+                        : '';
+                    return (
+                      <SavedRow
+                        key={entry.name}
+                        name={entry.name}
+                        subtitle={subtitle}
+                        meta={m}
+                        ssl={!!entry.ssl}
+                        database={entry.database}
+                        onClick={() => applySaved(entry)}
+                        onForget={(e) => removeSaved(entry.name, e)}
+                        t={t}
+                      />
+                    );
+                  })}
+                </div>
+                <div style={{ ...s.sectionLabel, marginTop: 6 }}>Or start fresh</div>
+              </>
+            )}
+
+            {DB_TYPES.map(d => (
+              <DbCard key={d.id} meta={d} onClick={() => pickFreshDb(d.id)} t={t} s={s}/>
+            ))}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // ─────────────────────────────────────────────────────────
+  // Step 2 — Connection form
+  // ─────────────────────────────────────────────────────────
   return (
     <div style={s.overlay}>
       <div style={s.modal}>
         <div style={s.header}>
-          <svg width="20" height="20" viewBox="0 0 40 40" fill="none">
-            <path d="M6 6 C6 6, 20 2, 20 20 C20 38, 6 34, 6 34" stroke={t.accent} strokeWidth="2.5" strokeLinecap="round"/>
-            <path d="M16 6 C16 6, 30 2, 30 20 C30 38, 16 34, 16 34" stroke={t.accent} strokeWidth="2.5" strokeLinecap="round" opacity="0.5"/>
-            <circle cx="6" cy="6" r="2.5" fill={t.accent}/>
-            <circle cx="20" cy="20" r="2.5" fill={t.accent}/>
-            <circle cx="6" cy="34" r="2.5" fill={t.accent}/>
-          </svg>
+          <button type="button" style={s.backBtn} onClick={() => setStep('pick')} title="Back">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <polyline points="15 18 9 12 15 6"/>
+            </svg>
+          </button>
+          <div style={{ width: 32, height: 32, background: t.accentMuted, border: `1px solid ${t.borderAccent}`, borderRadius: 7, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+            {meta.icon(t.accent)}
+          </div>
           <div>
-            <div style={s.title}>New connection</div>
-            <div style={s.subtitle}>Connect to a {dbLabel(form.type)} server</div>
+            <div style={s.title}>{appliedSaved || `New ${meta.name} connection`}</div>
+            <div style={s.subtitle}>{meta.badge} · port {meta.defaultPort}</div>
           </div>
         </div>
 
@@ -265,122 +345,44 @@ export function ConnectionManager({ onConnect, isConnecting, error, t }: Connect
         >
           <div style={s.body}>
             <div style={s.field}>
-              <label style={s.label}>Database type</label>
-              <div style={{ display: 'flex', gap: 6 }}>
-                {(['mysql', 'postgres', 'mongodb'] as const).map(dbType => (
-                  <button
-                    key={dbType}
-                    type="button"
-                    onClick={() => setDbType(dbType)}
-                    style={dbTypeBtnStyle(form.type === dbType)}
-                  >
-                    {dbLabel(dbType)}
-                  </button>
-                ))}
-              </div>
+              <label style={s.label}>Connection name</label>
+              <input
+                style={s.input}
+                name="connection-name"
+                autoComplete="off"
+                value={form.name}
+                onChange={e => set('name', e.target.value)}
+                placeholder="My Database"
+              />
             </div>
 
             {form.type === 'mongodb' && (
               <div style={s.field}>
                 <label style={s.label}>Input mode</label>
                 <div style={{ display: 'flex', gap: 6 }}>
-                  {(['fields', 'uri'] as const).map(mode => (
-                    <button
-                      key={mode}
-                      type="button"
-                      onClick={() => setMongoMode(mode)}
-                      style={dbTypeBtnStyle(form.mongoMode === mode)}
-                    >
-                      {mode === 'fields' ? 'Fields' : 'Connection string'}
-                    </button>
-                  ))}
+                  {(['fields', 'uri'] as const).map(mode => {
+                    const active = form.mongoMode === mode;
+                    return (
+                      <button
+                        key={mode}
+                        type="button"
+                        onClick={() => setMongoMode(mode)}
+                        style={{
+                          height: 30, padding: '0 14px',
+                          background: active ? t.accent : t.bgInput,
+                          border: `1px solid ${active ? t.accent : t.border}`,
+                          borderRadius: 5, fontSize: 12, fontWeight: active ? 600 : 400,
+                          color: active ? t.textInverse : t.textSecondary,
+                          cursor: 'pointer', fontFamily: 'inherit',
+                        }}
+                      >
+                        {mode === 'fields' ? 'Fields' : 'Connection string'}
+                      </button>
+                    );
+                  })}
                 </div>
               </div>
             )}
-
-            <div style={s.field}>
-              <label style={s.label}>
-                Connection name
-                {saved.length > 0 && (
-                  <span style={{ color: t.textMuted, textTransform: 'none', letterSpacing: 0, fontWeight: 400, marginLeft: 6 }}>
-                    — start typing to see saved connections
-                  </span>
-                )}
-              </label>
-              <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
-                <div style={{ position: 'relative', flex: 1 }}>
-                  <input
-                    style={s.input}
-                    name="connection-name"
-                    autoComplete="off"
-                    value={form.name}
-                    onChange={e => onNameChange(e.target.value)}
-                    onFocus={() => { if (saved.length > 0) { setSuggestOpen(true); setHighlightIdx(-1); } }}
-                    onBlur={() => setTimeout(() => setSuggestOpen(false), 120)}
-                    onKeyDown={(e) => {
-                      if (!suggestOpen || filteredSaved.length === 0) return;
-                      if (e.key === 'ArrowDown') { e.preventDefault(); setHighlightIdx(i => Math.min(i + 1, filteredSaved.length - 1)); }
-                      else if (e.key === 'ArrowUp') { e.preventDefault(); setHighlightIdx(i => Math.max(i - 1, 0)); }
-                      else if (e.key === 'Enter' && highlightIdx >= 0) { e.preventDefault(); applySaved(filteredSaved[highlightIdx]); }
-                      else if (e.key === 'Escape') { e.preventDefault(); e.nativeEvent.stopImmediatePropagation(); setSuggestOpen(false); }
-                    }}
-                    placeholder="My Database"
-                  />
-                  {suggestOpen && filteredSaved.length > 0 && (
-                    <div
-                      role="listbox"
-                      style={{
-                        position: 'absolute', top: 'calc(100% + 4px)', left: 0, right: 0, zIndex: 10,
-                        background: t.bgElevated, border: `1px solid ${t.border}`, borderRadius: 6,
-                        boxShadow: t.shadowLg, maxHeight: 240, overflowY: 'auto', padding: 4,
-                      }}
-                    >
-                      {filteredSaved.map((c, i) => {
-                        const highlighted = i === highlightIdx;
-                        return (
-                          <div
-                            key={c.name}
-                            role="option"
-                            aria-selected={highlighted}
-                            onMouseEnter={() => setHighlightIdx(i)}
-                            onMouseDown={(e) => { e.preventDefault(); applySaved(c); }}
-                            style={{
-                              display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 10,
-                              padding: '8px 10px', borderRadius: 4, cursor: 'pointer',
-                              background: highlighted ? t.bgHover : 'transparent',
-                            }}
-                          >
-                            <div style={{ minWidth: 0 }}>
-                              <div style={{ fontSize: 12, color: t.textPrimary, fontWeight: 500, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{c.name}</div>
-                              <div style={{ fontSize: 11, color: t.textMuted, fontFamily: 'monospace', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                                {(c.user || c.host || c.port)
-                                  ? <>{c.user}@{c.host}:{c.port}</>
-                                  : c.connectionString
-                                    ? <>{hostFromConnectionString(c.connectionString)}</>
-                                    : null}
-                                {c.database && <span style={{ marginLeft: 6 }}>· {c.database}</span>}
-                                {c.ssl && <span style={{ marginLeft: 6, color: t.accent }}>· SSL</span>}
-                              </div>
-                            </div>
-                            {appliedSaved === c.name && (
-                              <span style={{ fontSize: 10, color: t.accent, textTransform: 'uppercase', letterSpacing: '0.05em' }}>current</span>
-                            )}
-                          </div>
-                        );
-                      })}
-                    </div>
-                  )}
-                </div>
-                {appliedSaved && (
-                  <button
-                    type="button"
-                    onClick={() => removeSaved(appliedSaved)}
-                    title={`Forget '${appliedSaved}'`}
-                    style={{ height: 32, padding: '0 10px', background: 'transparent', border: `1px solid ${t.border}`, borderRadius: 5, color: t.textMuted, cursor: 'pointer', fontSize: 12, fontFamily: 'inherit' }}
-                  >Forget</button>
-                )}
-              </div>
-            </div>
 
             {isMongoUri ? (
               <div style={s.field}>
@@ -411,12 +413,12 @@ export function ConnectionManager({ onConnect, isConnecting, error, t }: Connect
                   <div style={{ ...s.field, width: 90 }}>
                     <label style={s.label}>Port</label>
                     <input
-                      style={{ ...s.input, fontFamily: 'monospace' }}
+                      style={{ ...s.input, fontFamily: '"JetBrains Mono", monospace', fontSize: 12 }}
                       name="port"
                       autoComplete="off"
                       value={form.port}
                       onChange={e => set('port', e.target.value)}
-                      placeholder={defaultPort(form.type)}
+                      placeholder={meta.defaultPort}
                     />
                   </div>
                 </div>
@@ -430,7 +432,7 @@ export function ConnectionManager({ onConnect, isConnecting, error, t }: Connect
                       autoComplete="username"
                       value={form.user}
                       onChange={e => set('user', e.target.value)}
-                      placeholder="root"
+                      placeholder={meta.defaultUser || 'username'}
                     />
                   </div>
                   <div style={{ ...s.field, flex: 1 }}>
@@ -448,7 +450,7 @@ export function ConnectionManager({ onConnect, isConnecting, error, t }: Connect
                 </div>
 
                 {canSavePassword && (
-                  <label style={{ display: 'flex', alignItems: 'center', gap: 8, cursor: 'pointer', marginTop: -4 }}>
+                  <label style={{ display: 'flex', alignItems: 'center', gap: 8, cursor: 'pointer', marginTop: -2 }}>
                     <input
                       type="checkbox"
                       checked={form.savePassword}
@@ -473,21 +475,21 @@ export function ConnectionManager({ onConnect, isConnecting, error, t }: Connect
                 autoComplete="off"
                 value={form.database}
                 onChange={e => set('database', e.target.value)}
-                placeholder="my_database"
+                placeholder={form.type === 'postgres' ? 'postgres' : 'my_database'}
               />
             </div>
 
             <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
-              <div style={s.toggleRow}>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
                 <button
                   type="button"
-                  style={{ width: 34, height: 20, borderRadius: 9999, border: 'none', cursor: 'pointer', position: 'relative', flexShrink: 0, transition: 'background 150ms ease', background: form.ssl ? t.accent : t.border }}
+                  style={{ width: 34, height: 20, borderRadius: 9999, border: 'none', cursor: 'pointer', position: 'relative', flexShrink: 0, background: form.ssl ? t.accent : t.border, transition: 'background 150ms ease' }}
                   onClick={() => set('ssl', !form.ssl)}
                 >
                   <div style={{ position: 'absolute', width: 14, height: 14, background: 'white', borderRadius: '50%', top: 3, left: form.ssl ? 17 : 3, transition: 'left 150ms ease' }}/>
                 </button>
-                <span style={s.toggleLabel}>Use SSL / TLS</span>
-                {form.ssl && <span style={s.sslBadge}>Encrypted</span>}
+                <span style={{ fontSize: 13, color: t.textSecondary }}>Use SSL / TLS</span>
+                {form.ssl && <span style={{ fontSize: 10, fontWeight: 600, color: t.accent, background: t.accentMuted, border: `1px solid ${t.borderAccent}`, padding: '1px 8px', borderRadius: 9999 }}>Encrypted</span>}
               </div>
 
               {form.ssl && (
@@ -524,7 +526,7 @@ export function ConnectionManager({ onConnect, isConnecting, error, t }: Connect
             )}
 
             {testResult && testResult.ok && (
-              <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '10px 12px', background: t.colorSuccessBg, border: `1px solid ${t.colorSuccess}55`, borderRadius: 6, fontSize: 12, color: t.colorSuccess }}>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '9px 12px', background: t.colorSuccessBg, border: `1px solid ${t.colorSuccess}55`, borderRadius: 6, fontSize: 12, color: t.colorSuccess }}>
                 <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke={t.colorSuccess} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
                   <polyline points="20 6 9 17 4 12"/>
                 </svg>
@@ -562,6 +564,87 @@ export function ConnectionManager({ onConnect, isConnecting, error, t }: Connect
           </div>
         </form>
       </div>
+    </div>
+  );
+}
+
+// Picker card for one of the supported DB types.
+function DbCard({ meta, onClick, t, s }: {
+  meta: DbTypeMeta;
+  onClick: () => void;
+  t: Theme;
+  s: Record<string, CSSProperties>;
+}) {
+  return (
+    <div
+      style={s.dbCard}
+      onClick={onClick}
+      onMouseEnter={(e) => { e.currentTarget.style.borderColor = t.borderAccent; }}
+      onMouseLeave={(e) => { e.currentTarget.style.borderColor = t.border; }}
+    >
+      <div style={s.dbCardIcon}>{meta.icon(t.accent)}</div>
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 7, marginBottom: 3 }}>
+          <span style={{ fontSize: 14, fontWeight: 600, color: t.textPrimary }}>{meta.name}</span>
+          <span style={s.badge}>{meta.badge}</span>
+          <span style={{ fontSize: 11, color: t.textMuted }}>{meta.version}</span>
+        </div>
+        <span style={{ fontSize: 12, color: t.textMuted }}>{meta.desc}</span>
+      </div>
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke={t.textMuted} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <polyline points="9 18 15 12 9 6"/>
+      </svg>
+    </div>
+  );
+}
+
+// Saved-connection row on the picker step. Click = restore + go to form.
+function SavedRow({ name, subtitle, meta, ssl, database, onClick, onForget, t }: {
+  name: string;
+  subtitle: string;
+  meta: DbTypeMeta;
+  ssl: boolean;
+  database?: string;
+  onClick: () => void;
+  onForget: (e: React.MouseEvent) => void;
+  t: Theme;
+}) {
+  const [hovered, setHovered] = useState(false);
+  return (
+    <div
+      onClick={onClick}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+      style={{
+        display: 'flex', alignItems: 'center', gap: 12,
+        padding: '10px 14px',
+        background: hovered ? t.bgHover : 'transparent',
+        border: `1px solid ${hovered ? t.borderAccent : t.borderSubtle}`,
+        borderRadius: 7, cursor: 'pointer', minWidth: 0,
+      }}
+    >
+      <div style={{ width: 28, height: 28, background: t.accentMuted, border: `1px solid ${t.borderAccent}`, borderRadius: 6, display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>
+        <span style={{ width: 18, height: 18, display: 'inline-flex' }}>{meta.icon(t.accent)}</span>
+      </div>
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{ fontSize: 13, fontWeight: 500, color: t.textPrimary, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{name}</div>
+        <div style={{ fontSize: 11, color: t.textMuted, fontFamily: 'monospace', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+          {subtitle}
+          {database && <span> · {database}</span>}
+          {ssl && <span style={{ color: t.accent }}> · SSL</span>}
+        </div>
+      </div>
+      <button
+        type="button"
+        onClick={onForget}
+        title={`Forget '${name}'`}
+        style={{
+          background: 'transparent', border: 'none', cursor: 'pointer',
+          color: t.textMuted, padding: '4px 6px', fontSize: 11, fontFamily: 'inherit',
+          opacity: hovered ? 1 : 0,
+          transition: 'opacity 100ms ease',
+        }}
+      >Forget</button>
     </div>
   );
 }

--- a/src/components/ConnectionManager.tsx
+++ b/src/components/ConnectionManager.tsx
@@ -497,7 +497,10 @@ function ConnectionNameField({ value, onChange, saved, appliedSaved, onSelect, o
     else if (e.key === 'Enter' && highlight >= 0 && filtered[highlight]) {
       e.preventDefault(); choose(filtered[highlight]);
     }
-    else if (e.key === 'Escape') {
+    else if (e.key === 'Escape' && open) {
+      // Only intercept Escape when there's actually a dropdown to close —
+      // otherwise we'd swallow the key and break any parent-level handler
+      // (e.g. modal-dismiss-on-Escape) that's added later.
       e.preventDefault();
       e.nativeEvent.stopImmediatePropagation();
       setOpen(false);

--- a/src/components/ConnectionManager.tsx
+++ b/src/components/ConnectionManager.tsx
@@ -157,10 +157,12 @@ export function ConnectionManager({ onConnect, isConnecting, error, t }: Connect
   const setField = <K extends keyof ConnectionForm>(k: K, v: ConnectionForm[K]) => {
     setForm(p => {
       const next = { ...p, [k]: v };
-      // Re-derive the URI when any of the URI-relevant fields change. Type
-      // pulls from the prediction (driven by port) so the scheme stays in sync.
+      // Re-derive the URI when any of the URI-relevant fields change. Predict
+      // from the new port only — the existing URI is stale and about to be
+      // overwritten, so deferring to its scheme would lock in the old type
+      // (e.g. postgresql:// staying put after the user types port 27017).
       if (k === 'host' || k === 'port' || k === 'user' || k === 'password' || k === 'database') {
-        const predictedType = predictDbType(next) ?? next.type;
+        const predictedType = predictDbType({ port: next.port }) ?? next.type;
         next.connectionString = buildUri({ ...next, type: predictedType });
       }
       return next;


### PR DESCRIPTION
Updates the connection manager to match the design from the [Helix design system handoff bundle](https://api.anthropic.com/v1/design/h/n7jg62UCiunR3I_EtZsatQ) (claude.ai/design).

(First push of this branch shipped a 2-step picker; that was the wrong variation. Force-pushed to the auto-detect single-page form.)

## What you see now
- **Header** — title + DetectionBadge pill that shows _Likely MySQL_ (warning, predicted from URI scheme or port) → _Identifying…_ (spinner during connect) → _MySQL · SQL_ (accent, after a successful Test).
- **Connection name** — input with a chevron dropdown listing saved connections. Focus shows all; typing filters. Click loads the connection (and pulls the keychain password on Electron).
- **Dual input** — Connection string box AND Host/Port/User/Password/Database box, both visible. The last-edited side gets the accent border + glow. Edits on either side sync to the other; the URI scheme follows the predicted type so it auto-switches to \`postgresql://\` or \`mongodb://\` as the port changes.
- **Password masking** — when the user is editing fields, the rendered URI shows \`***\` instead of the real password so it's never visible in the connection-string box.
- **SSL toggle** — plus the existing "Verify server certificate" sub-option with the unverified warning.

## What's preserved
- Save-password keychain integration on Electron.
- Test-connection button + success/error banners.
- MongoDB URI mode (now just "type into the connection-string box"; \`mongoMode\` stays in the form contract for backwards compat with saved entries).
- The \`ConnectionForm\` shape — \`App.tsx\` and the backend contract didn't change.

## What's out of scope
- The animated URI ticker placeholder from the prototype (cute but non-essential — used a static placeholder string instead).
- The "Open in Helix" confirmed-state CTA — the existing app advances the user past the modal as soon as Connect succeeds, so the confirmed state only appears after Test.
- Restyled \`TopBar\`, \`SchemaBrowser\`, \`QueryEditor\`, \`ResultsTable\`, multi-DB schema browser — separate redesigns; this PR only touches the connection manager.

## Test plan
- [x] \`npm test\` (frontend: 41, server: 133) — all green.
- [x] \`npm run build\` clean.
- [ ] Manual in Electron: confirm modal layout matches mock; confirm name dropdown shows saved entries; confirm typing in the URI populates host/port/user/password/db; confirm typing in fields rebuilds the URI; confirm SSL verify sub-option still surfaces the warning; confirm keychain password loads on saved-connection click.

🤖 Generated with [Claude Code](https://claude.com/claude-code)