### PR TITLE
fix: preserve saved mongo URI on keychain password load

### DIFF
--- a/src/components/ConnectionManager.tsx
+++ b/src/components/ConnectionManager.tsx
@@ -204,7 +204,16 @@ export function ConnectionManager({ onConnect, isConnecting, error, t }: Connect
     if (entry.savePassword && electronAPI) {
       electronAPI.passwords.load(entry.name).then(pw => {
         if (pw === null) return;
-        setForm(p => p.name === entry.name && p.password === '' ? { ...p, password: pw, connectionString: buildUri({ ...p, password: pw }) } : p);
+        // Inject the keychain password into the form, but DON'T rebuild
+        // `connectionString` here. For mongo URI-mode connections that's
+        // load-bearing: the saved URI may have `mongodb+srv://` and a query
+        // string (e.g. `?retryWrites=true&w=majority`), and `buildUri` would
+        // strip both — leaving Atlas connections unable to resolve their SRV
+        // records. The dual-input's `displayUri` already re-renders
+        // dynamically from `form.password` when fields-mode is active, so
+        // we don't need to mirror it into `connectionString` to keep the
+        // URI box in sync.
+        setForm(p => p.name === entry.name && p.password === '' ? { ...p, password: pw } : p);
       }).catch(() => {});
     }
   };


### PR DESCRIPTION
## Bug
A saved MongoDB Atlas connection — stored correctly in localStorage with the original
\`mongodb+srv://...?retryWrites=true&w=majority\` URI — comes back as
\`mongodb://...\` (no \`+srv\`, no query string) after the keychain password
loads. The user then can't reach Atlas because SRV resolution is required.

Reproduced from the user's report and confirmed by inspecting localStorage:
the saved \`connectionString\` is the original (correct) URI; the corruption
happens at load time.

## Root cause
In \`applySaved\`'s keychain callback:
\`\`\`ts
setForm(p => ({ ...p, password: pw, connectionString: buildUri({ ...p, password: pw }) }))
\`\`\`
\`buildUri\` always emits \`mongodb://\` (no \`+srv\`) and ignores query strings,
so the saved Atlas URI gets clobbered.

The rebuild was meant to keep the URI box in sync once the keychain
password loaded. But the dual-input's \`displayUri\` already re-renders
dynamically from \`form.password\` when fields-mode is active, and in
URI-mode the saved \`connectionString\` already contains the password
baked in — so mirroring it into \`connectionString\` is both unnecessary
and destructive.

## Fix
One-line change: only set \`password\` in the keychain callback, leave
\`connectionString\` alone.

## Test plan
- [x] \`npm test\` (53 frontend tests pass).
- [x] \`npm run build\` clean.
- [ ] **Manual (must be in Electron — keychain is null in plain browser)**:
  1. Save a mongo Atlas connection via \`mongodb+srv://...?retryWrites=true&w=majority\`
     with **Save password** enabled.
  2. Disconnect, reopen modal, pick the saved entry from the dropdown.
  3. URI box should now still show \`mongodb+srv://...?retryWrites=...\`
     after the keychain password loads.
  4. Connect should succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)