### PR TITLE
feat: show a loading indicator while the schema fetches

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -82,6 +82,7 @@ export default function App() {
   const [schemas, setSchemas] = useState<string[]>([]);
   const [activeSchema, setActiveSchema] = useState('');
   const [schemaData, setSchemaData] = useState<SchemaData>(EMPTY_SCHEMA);
+  const [loadingSchema, setLoadingSchema] = useState(false);
 
   const [tabs, setTabs] = useState<Tab[]>([
     { id: '1', name: 'query_1.sql', query: '' },
@@ -104,11 +105,14 @@ export default function App() {
   }, []);
 
   const loadSchema = useCallback(async (schema: string) => {
+    setLoadingSchema(true);
     try {
       const data = await api.schema(schema);
       setSchemaData(data);
     } catch {
       setSchemaData(EMPTY_SCHEMA);
+    } finally {
+      setLoadingSchema(false);
     }
   }, []);
 
@@ -520,6 +524,7 @@ export default function App() {
           onSchemaChange={handleSchemaChange}
           schemas={schemas}
           activeSchema={activeSchema}
+          loading={loadingSchema}
           onDropTable={handleDropTable}
           onCreateTable={queryMode === 'sql' ? () => setShowCreateTable(true) : undefined}
           onAlterTable={queryMode === 'sql' ? handleOpenAlterTable : undefined}

--- a/src/components/SchemaBrowser.tsx
+++ b/src/components/SchemaBrowser.tsx
@@ -15,6 +15,7 @@ interface SchemaBrowserProps {
   onDropTable?: (schema: string, table: string) => Promise<void>;
   onCreateTable?: () => void;
   onAlterTable?: (schema: string, table: string) => void;
+  loading?: boolean;
   t: Theme;
 }
 
@@ -84,7 +85,7 @@ function readStoredWidth(): number {
   }
 }
 
-export function SchemaBrowser({ schema, activeTable, onTableSelect, onSchemaChange, schemas, activeSchema, onDropTable, onCreateTable, onAlterTable, t }: SchemaBrowserProps) {
+export function SchemaBrowser({ schema, activeTable, onTableSelect, onSchemaChange, schemas, activeSchema, loading, onDropTable, onCreateTable, onAlterTable, t }: SchemaBrowserProps) {
   const [expanded, setExpanded] = useState({ tables: true, views: false, procedures: false, triggers: false });
   const [expandedTables, setExpandedTables] = useState<Record<string, boolean>>({});
   const [filter, setFilter] = useState('');
@@ -218,7 +219,16 @@ export function SchemaBrowser({ schema, activeTable, onTableSelect, onSchemaChan
       </div>
 
       <div style={s.tree}>
-        {groups.map(g => (
+        {loading && (
+          // Replace the tree entirely (rather than overlay) so the user can't
+          // race-click into a stale empty list while inference is in flight —
+          // MongoDB collection-field sampling can take several seconds.
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '10px 14px', fontSize: 11, color: t.textMuted }}>
+            <div style={{ width: 11, height: 11, border: `2px solid ${t.borderSubtle}`, borderTop: `2px solid ${t.accent}`, borderRadius: '50%', animation: 'spin 0.8s linear infinite', flexShrink: 0 }}/>
+            <span>Loading schema…</span>
+          </div>
+        )}
+        {!loading && groups.map(g => (
           <div key={g.key}>
             <div style={s.groupRow} onClick={() => toggle(g.key)}>
               <Chevron open={expanded[g.key]} color={t.textMuted}/>


### PR DESCRIPTION
## What
Adds a spinner + "Loading schema…" line in the schema-browser sidebar
while \`api.schema()\` is in flight, replacing the empty tree state that
previously looked identical to "this schema has no objects".

## Why
For MongoDB the schema fetch is slow — the server samples documents from
every collection to infer fields, and on a real workload that can take
many seconds. With no feedback, users were left wondering whether the
app was broken or just empty.

## What changed
- \`App.tsx\` flips a new \`loadingSchema\` boolean around the
  \`api.schema()\` call inside \`loadSchema\`, and passes it to
  \`SchemaBrowser\`.
- \`SchemaBrowser\` renders the spinner row in place of the groups when
  \`loading\` is true. The "+ New table" affordance is naturally hidden
  during load since it lives inside the tree render.

~17 lines across two files.

## Test plan
- [x] \`npm test\` (53 frontend tests pass).
- [x] \`npm run build\` clean.
- [ ] Manual in Electron — connect to a MongoDB with several collections,
  confirm the spinner appears before the collection list does. Switch
  schemas via the dropdown and confirm the same.

🤖 Generated with [Claude Code](https://claude.com/claude-code)