### PR TITLE
chore: bump version to 1.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "helix",
-  "version": "0.0.0",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "helix",
-      "version": "0.0.0",
+      "version": "1.0.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "concurrently": "^9.1.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "helix",
   "private": true,
-  "version": "0.0.0",
+  "version": "1.0.0",
   "type": "module",
   "license": "AGPL-3.0-only",
   "main": "electron/main.cjs",

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "helix-server",
-  "version": "0.0.0",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "helix-server",
-      "version": "0.0.0",
+      "version": "1.0.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helix-server",
-  "version": "0.0.0",
+  "version": "1.0.0",
   "private": true,
   "type": "module",
   "license": "AGPL-3.0-only",


### PR DESCRIPTION
electron-builder embeds \`package.json\` version into the produced artifact
filename — \`Helix-0.0.0-arm64.dmg\` reads as unfinished. Helix has shipped
enough functionality at this point (multi-DB drivers, create/alter table,
persisted tabs, MCP, packaged Electron build) that 1.0.0 is a more honest
floor.

Bumped in both root and server packages (so the two halves of the app stay
in lockstep) plus the regenerated lockfiles. No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)