### PR TITLE
fix: pick free server port and surface startup failures in packaged app

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -3,14 +3,20 @@
 const { app, BrowserWindow, Tray, Menu, nativeImage, utilityProcess, dialog, ipcMain, safeStorage, powerMonitor } = require('electron');
 const path = require('path');
 const http = require('http');
+const net = require('net');
 const fs = require('fs');
 
 const isDev = !app.isPackaged;
-const PORT = 3001;
+// In dev the server is started by `npm run dev:server` outside this process,
+// and is hardcoded to 3001. In production we pick a free port at startup so
+// a leftover dev server (or any other listener) can't shadow us — the prior
+// behaviour silently failed to bind, leaving the BrowserWindow to load
+// whatever happened to be answering on 3001 (often "Cannot GET /").
+let PORT = 3001;
+let APP_URL = `http://localhost:${PORT}`;
 
 app.setName('Helix');
 const VITE_URL = 'http://localhost:5173';
-const APP_URL = `http://localhost:${PORT}`;
 const ERR_CONNECTION_REFUSED = -102;
 
 // 1×1 transparent PNG — tray fallback when no icon file is present
@@ -23,7 +29,29 @@ let serverProc = null;
 
 // ── Server ────────────────────────────────────────────────────────────────────
 
-function startServer() {
+// Ask the OS for a port nobody's listening on. There's a small race window
+// between close-and-fork where another process could grab it, but in practice
+// it's many orders of magnitude better than hardcoding 3001 and silently
+// losing to a leftover listener.
+function findFreePort() {
+  return new Promise((resolve, reject) => {
+    const srv = net.createServer();
+    srv.unref();
+    srv.on('error', reject);
+    srv.listen(0, '127.0.0.1', () => {
+      const { port } = srv.address();
+      srv.close(() => resolve(port));
+    });
+  });
+}
+
+// Fork the bundled server, wait until it answers, and reject loudly if it
+// dies on the way up. Captures stderr so the error dialog can surface the
+// real cause instead of a generic timeout.
+async function startServer() {
+  PORT = await findFreePort();
+  APP_URL = `http://localhost:${PORT}`;
+
   const serverScript = path.join(__dirname, 'server.cjs');
   const staticPath = path.join(process.resourcesPath, 'dist');
 
@@ -32,21 +60,34 @@ function startServer() {
     stdio: 'pipe',
   });
 
+  let stderrBuf = '';
+  let exited = false;
   serverProc.stdout?.on('data', (d) => console.log('[server]', String(d).trim()));
-  serverProc.stderr?.on('data', (d) => console.error('[server]', String(d).trim()));
-}
+  serverProc.stderr?.on('data', (d) => {
+    const s = String(d);
+    stderrBuf += s;
+    console.error('[server]', s.trim());
+  });
 
-function waitForServer(maxAttempts = 50) {
   return new Promise((resolve, reject) => {
+    serverProc.on('exit', (code) => {
+      exited = true;
+      // A clean exit before we've finished readiness probing is still a
+      // failure — there's no surviving server for the renderer to talk to.
+      reject(new Error(stderrBuf.trim() || `Server exited with code ${code}`));
+    });
+
+    const maxAttempts = 50;
     let attempts = 0;
     const attempt = () => {
+      if (exited) return;
       if (attempts >= maxAttempts) {
-        reject(new Error(`Server did not start after ${maxAttempts} attempts`));
+        reject(new Error(stderrBuf.trim() || `Server did not respond after ${maxAttempts} attempts`));
         return;
       }
       attempts++;
       http
-        .get(`${APP_URL}/api/connect/status`, resolve)
+        .get(`${APP_URL}/api/connect/status`, () => resolve())
         .on('error', () => setTimeout(attempt, 300));
     };
     attempt();
@@ -195,13 +236,20 @@ app.whenReady().then(async () => {
   }
 
   if (!isDev) {
-    startServer();
-    const started = await waitForServer().catch((err) => {
-      dialog.showErrorBox('Helix failed to start', err.message);
+    try {
+      await startServer();
+    } catch (err) {
+      // Show the underlying cause (captured stderr) so a user installing the
+      // DMG can tell whether it's e.g. EADDRINUSE from a leftover dev server
+      // vs. some other crash. Without this they'd see a blank "Cannot GET /"
+      // page with no context.
+      dialog.showErrorBox(
+        "Helix can't start",
+        `The bundled server failed to launch.\n\n${err.message || err}`,
+      );
       app.quit();
-      return false;
-    });
-    if (started === false) return;
+      return;
+    }
   }
   createWindow();
   createTray();

--- a/src/components/InsertRowDialog.tsx
+++ b/src/components/InsertRowDialog.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useMemo } from 'react';
 import type { CSSProperties } from 'react';
 import type { Theme } from '../theme';
 import type { SchemaColumn } from '../api';
-import { parseEnumValues } from '../lib/sql';
+import { buildInsertSql, parseEnumValues } from '../lib/sql';
 
 type CellValue = string | number | boolean | null;
 type EditKind = 'boolean' | 'number' | 'date' | 'datetime' | 'time' | 'text';
@@ -56,6 +56,7 @@ export function InsertRowDialog({ table, columns, onSubmit, onClose, t }: Insert
   }, [editable]);
 
   const [drafts, setDrafts] = useState<Record<string, string>>(initialDrafts);
+  const [view, setView] = useState<'form' | 'confirm'>('form');
   const [error, setError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
 
@@ -89,18 +90,28 @@ export function InsertRowDialog({ table, columns, onSubmit, onClose, t }: Insert
     return { values, missing };
   };
 
-  const submit = async () => {
-    const { values, missing } = buildPayload();
+  const { values: pendingValues, missing: missingRequired } = view === 'confirm'
+    ? buildPayload()
+    : { values: {} as Record<string, CellValue>, missing: [] as string[] };
+
+  const goToConfirm = () => {
+    const { missing } = buildPayload();
     if (missing.length > 0) {
       setError(`Required column${missing.length > 1 ? 's' : ''}: ${missing.join(', ')}`);
       return;
     }
+    setError(null);
+    setView('confirm');
+  };
+
+  const submit = async () => {
     setSaving(true);
     setError(null);
     try {
-      await onSubmit(values);
+      await onSubmit(pendingValues);
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
+      setView('form');
     } finally {
       setSaving(false);
     }
@@ -120,9 +131,12 @@ export function InsertRowDialog({ table, columns, onSubmit, onClose, t }: Insert
     helper: { fontSize: 10, color: t.textMuted, marginTop: 3, lineHeight: 1.35 } as CSSProperties,
     footer: { padding: '12px 16px', borderTop: `1px solid ${t.borderSubtle}`, display: 'flex', justifyContent: 'flex-end', gap: 8, alignItems: 'center' } as CSSProperties,
     errorBanner: { padding: '8px 10px', background: t.colorErrorBg, border: `1px solid ${t.colorErrorBorder}`, borderRadius: 4, fontSize: 11, color: t.colorError, fontFamily: 'monospace', margin: '0 16px' } as CSSProperties,
+    pre: { margin: '0 16px', padding: '10px 12px', background: t.bgBase, border: `1px solid ${t.borderSubtle}`, borderRadius: 4, fontSize: 11, fontFamily: '"JetBrains Mono", monospace', color: t.textPrimary, whiteSpace: 'pre-wrap', wordBreak: 'break-all' } as CSSProperties,
     btnPrimary: { padding: '6px 14px', fontSize: 12, fontFamily: 'inherit', background: t.accent, color: '#fff', border: 'none', borderRadius: 4, cursor: saving ? 'wait' : 'pointer', opacity: saving ? 0.7 : 1 } as CSSProperties,
     btnSecondary: { padding: '6px 14px', fontSize: 12, fontFamily: 'inherit', background: 'transparent', color: t.textSecondary, border: `1px solid ${t.border}`, borderRadius: 4, cursor: saving ? 'not-allowed' : 'pointer' } as CSSProperties,
   };
+
+  const previewSql = (): string => buildInsertSql(table, pendingValues);
 
   return (
     <div style={s.overlay} onClick={() => !saving && onClose()}>
@@ -132,89 +146,109 @@ export function InsertRowDialog({ table, columns, onSubmit, onClose, t }: Insert
           <span style={s.subtitle}>{table}</span>
         </div>
 
-        <div style={s.body}>
-          {editable.length === 0 && (
-            <div style={{ fontSize: 12, color: t.textMuted }}>
-              This table has no user-editable columns (all auto-generated).
-            </div>
-          )}
-          {editable.map(col => {
-            const kind = editKindForColumn(col);
-            const enumValues = col.dataType === 'enum' ? parseEnumValues(col.type) : null;
-            const inputType = kind === 'number' ? 'number'
-              : kind === 'date' ? 'date'
-              : kind === 'datetime' ? 'datetime-local'
-              : kind === 'time' ? 'time'
-              : 'text';
-            const required = !col.nullable && col.default === null;
-            const hasBlankOption = col.default !== null || col.nullable;
-            const blankLabel = col.default !== null ? `default: ${col.default}`
-              : col.nullable ? 'NULL'
-              : '';
-            return (
-              <div key={col.name} style={s.row}>
-                <div>
-                  <div style={s.label} title={col.comment || undefined}>
-                    {col.name}
-                    {required && <span style={{ color: t.colorError, marginLeft: 3 }}>*</span>}
-                  </div>
-                  <div style={s.labelMuted}>{col.type}{col.pk ? ' · PK' : ''}</div>
+        {view === 'form' && (
+          <>
+            <div style={s.body}>
+              {editable.length === 0 && (
+                <div style={{ fontSize: 12, color: t.textMuted }}>
+                  This table has no user-editable columns (all auto-generated).
                 </div>
-                <div>
-                  {kind === 'boolean' ? (
-                    <select
-                      value={drafts[col.name] ?? ''}
-                      onChange={(e) => setDrafts(p => ({ ...p, [col.name]: e.target.value }))}
-                      style={s.input}
-                    >
-                      {hasBlankOption && (
-                        <option value="">{blankLabel}</option>
-                      )}
-                      <option value="true">true</option>
-                      <option value="false">false</option>
-                    </select>
-                  ) : enumValues ? (
-                    <select
-                      value={drafts[col.name] ?? ''}
-                      onChange={(e) => setDrafts(p => ({ ...p, [col.name]: e.target.value }))}
-                      style={s.input}
-                    >
-                      {hasBlankOption ? (
-                        <option value="">{blankLabel}</option>
+              )}
+              {editable.map(col => {
+                const kind = editKindForColumn(col);
+                const enumValues = col.dataType === 'enum' ? parseEnumValues(col.type) : null;
+                const inputType = kind === 'number' ? 'number'
+                  : kind === 'date' ? 'date'
+                  : kind === 'datetime' ? 'datetime-local'
+                  : kind === 'time' ? 'time'
+                  : 'text';
+                const required = !col.nullable && col.default === null;
+                const hasBlankOption = col.default !== null || col.nullable;
+                const blankLabel = col.default !== null ? `default: ${col.default}`
+                  : col.nullable ? 'NULL'
+                  : '';
+                return (
+                  <div key={col.name} style={s.row}>
+                    <div>
+                      <div style={s.label} title={col.comment || undefined}>
+                        {col.name}
+                        {required && <span style={{ color: t.colorError, marginLeft: 3 }}>*</span>}
+                      </div>
+                      <div style={s.labelMuted}>{col.type}{col.pk ? ' · PK' : ''}</div>
+                    </div>
+                    <div>
+                      {kind === 'boolean' ? (
+                        <select
+                          value={drafts[col.name] ?? ''}
+                          onChange={(e) => setDrafts(p => ({ ...p, [col.name]: e.target.value }))}
+                          style={s.input}
+                        >
+                          {hasBlankOption && (
+                            <option value="">{blankLabel}</option>
+                          )}
+                          <option value="true">true</option>
+                          <option value="false">false</option>
+                        </select>
+                      ) : enumValues ? (
+                        <select
+                          value={drafts[col.name] ?? ''}
+                          onChange={(e) => setDrafts(p => ({ ...p, [col.name]: e.target.value }))}
+                          style={s.input}
+                        >
+                          {hasBlankOption ? (
+                            <option value="">{blankLabel}</option>
+                          ) : (
+                            // Disabled placeholder keeps the visible state aligned with the
+                            // empty draft, so the browser doesn't silently surface the first
+                            // enum value while still routing through the "Required column"
+                            // validator if the user hits Review SQL without picking.
+                            <option value="" disabled>— select —</option>
+                          )}
+                          {enumValues.map(v => <option key={v} value={v}>{v}</option>)}
+                        </select>
                       ) : (
-                        // Disabled placeholder keeps the visible state aligned with the
-                        // empty draft, so the browser doesn't silently surface the first
-                        // enum value while still routing through the "Required column"
-                        // validator if the user hits Insert without picking.
-                        <option value="" disabled>— select —</option>
+                        <input
+                          type={inputType}
+                          value={drafts[col.name] ?? ''}
+                          step={kind === 'number' ? 'any' : undefined}
+                          onChange={(e) => setDrafts(p => ({ ...p, [col.name]: e.target.value }))}
+                          placeholder={blankLabel}
+                          style={s.input}
+                        />
                       )}
-                      {enumValues.map(v => <option key={v} value={v}>{v}</option>)}
-                    </select>
-                  ) : (
-                    <input
-                      type={inputType}
-                      value={drafts[col.name] ?? ''}
-                      step={kind === 'number' ? 'any' : undefined}
-                      onChange={(e) => setDrafts(p => ({ ...p, [col.name]: e.target.value }))}
-                      placeholder={blankLabel}
-                      style={s.input}
-                    />
-                  )}
-                  {col.comment && <div style={s.helper}>{col.comment}</div>}
-                </div>
-              </div>
-            );
-          })}
-        </div>
+                      {col.comment && <div style={s.helper}>{col.comment}</div>}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
 
-        {error && <div style={s.errorBanner}>{error}</div>}
+            {error && <div style={s.errorBanner}>{error}</div>}
 
-        <div style={s.footer}>
-          <button onClick={onClose} style={s.btnSecondary} disabled={saving}>Cancel</button>
-          <button onClick={submit} style={s.btnPrimary} disabled={editable.length === 0 || saving}>
-            {saving ? 'Inserting…' : 'Insert'}
-          </button>
-        </div>
+            <div style={s.footer}>
+              <button onClick={onClose} style={s.btnSecondary}>Cancel</button>
+              <button onClick={goToConfirm} style={s.btnPrimary} disabled={editable.length === 0}>Review SQL</button>
+            </div>
+          </>
+        )}
+
+        {view === 'confirm' && (
+          <>
+            <div style={{ padding: '12px 16px 4px', fontSize: 12, color: t.textSecondary }}>This will run:</div>
+            <pre style={s.pre}>{previewSql()}</pre>
+            {missingRequired.length > 0 && (
+              <div style={s.errorBanner}>Required columns missing: {missingRequired.join(', ')}</div>
+            )}
+            {error && <div style={s.errorBanner}>{error}</div>}
+
+            <div style={s.footer}>
+              <button onClick={() => { setView('form'); setError(null); }} style={s.btnSecondary} disabled={saving}>Back</button>
+              <button onClick={submit} style={s.btnPrimary} disabled={saving || missingRequired.length > 0}>
+                {saving ? 'Inserting…' : 'Insert'}
+              </button>
+            </div>
+          </>
+        )}
       </div>
     </div>
   );

--- a/src/components/InsertRowDialog.tsx
+++ b/src/components/InsertRowDialog.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useMemo } from 'react';
 import type { CSSProperties } from 'react';
 import type { Theme } from '../theme';
 import type { SchemaColumn } from '../api';
-import { buildInsertSql, parseEnumValues } from '../lib/sql';
+import { parseEnumValues } from '../lib/sql';
 
 type CellValue = string | number | boolean | null;
 type EditKind = 'boolean' | 'number' | 'date' | 'datetime' | 'time' | 'text';
@@ -56,7 +56,6 @@ export function InsertRowDialog({ table, columns, onSubmit, onClose, t }: Insert
   }, [editable]);
 
   const [drafts, setDrafts] = useState<Record<string, string>>(initialDrafts);
-  const [view, setView] = useState<'form' | 'confirm'>('form');
   const [error, setError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
 
@@ -90,28 +89,18 @@ export function InsertRowDialog({ table, columns, onSubmit, onClose, t }: Insert
     return { values, missing };
   };
 
-  const { values: pendingValues, missing: missingRequired } = view === 'confirm'
-    ? buildPayload()
-    : { values: {} as Record<string, CellValue>, missing: [] as string[] };
-
-  const goToConfirm = () => {
-    const { missing } = buildPayload();
+  const submit = async () => {
+    const { values, missing } = buildPayload();
     if (missing.length > 0) {
       setError(`Required column${missing.length > 1 ? 's' : ''}: ${missing.join(', ')}`);
       return;
     }
-    setError(null);
-    setView('confirm');
-  };
-
-  const submit = async () => {
     setSaving(true);
     setError(null);
     try {
-      await onSubmit(pendingValues);
+      await onSubmit(values);
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
-      setView('form');
     } finally {
       setSaving(false);
     }
@@ -131,12 +120,9 @@ export function InsertRowDialog({ table, columns, onSubmit, onClose, t }: Insert
     helper: { fontSize: 10, color: t.textMuted, marginTop: 3, lineHeight: 1.35 } as CSSProperties,
     footer: { padding: '12px 16px', borderTop: `1px solid ${t.borderSubtle}`, display: 'flex', justifyContent: 'flex-end', gap: 8, alignItems: 'center' } as CSSProperties,
     errorBanner: { padding: '8px 10px', background: t.colorErrorBg, border: `1px solid ${t.colorErrorBorder}`, borderRadius: 4, fontSize: 11, color: t.colorError, fontFamily: 'monospace', margin: '0 16px' } as CSSProperties,
-    pre: { margin: '0 16px', padding: '10px 12px', background: t.bgBase, border: `1px solid ${t.borderSubtle}`, borderRadius: 4, fontSize: 11, fontFamily: '"JetBrains Mono", monospace', color: t.textPrimary, whiteSpace: 'pre-wrap', wordBreak: 'break-all' } as CSSProperties,
     btnPrimary: { padding: '6px 14px', fontSize: 12, fontFamily: 'inherit', background: t.accent, color: '#fff', border: 'none', borderRadius: 4, cursor: saving ? 'wait' : 'pointer', opacity: saving ? 0.7 : 1 } as CSSProperties,
     btnSecondary: { padding: '6px 14px', fontSize: 12, fontFamily: 'inherit', background: 'transparent', color: t.textSecondary, border: `1px solid ${t.border}`, borderRadius: 4, cursor: saving ? 'not-allowed' : 'pointer' } as CSSProperties,
   };
-
-  const previewSql = (): string => buildInsertSql(table, pendingValues);
 
   return (
     <div style={s.overlay} onClick={() => !saving && onClose()}>
@@ -146,109 +132,89 @@ export function InsertRowDialog({ table, columns, onSubmit, onClose, t }: Insert
           <span style={s.subtitle}>{table}</span>
         </div>
 
-        {view === 'form' && (
-          <>
-            <div style={s.body}>
-              {editable.length === 0 && (
-                <div style={{ fontSize: 12, color: t.textMuted }}>
-                  This table has no user-editable columns (all auto-generated).
-                </div>
-              )}
-              {editable.map(col => {
-                const kind = editKindForColumn(col);
-                const enumValues = col.dataType === 'enum' ? parseEnumValues(col.type) : null;
-                const inputType = kind === 'number' ? 'number'
-                  : kind === 'date' ? 'date'
-                  : kind === 'datetime' ? 'datetime-local'
-                  : kind === 'time' ? 'time'
-                  : 'text';
-                const required = !col.nullable && col.default === null;
-                const hasBlankOption = col.default !== null || col.nullable;
-                const blankLabel = col.default !== null ? `default: ${col.default}`
-                  : col.nullable ? 'NULL'
-                  : '';
-                return (
-                  <div key={col.name} style={s.row}>
-                    <div>
-                      <div style={s.label} title={col.comment || undefined}>
-                        {col.name}
-                        {required && <span style={{ color: t.colorError, marginLeft: 3 }}>*</span>}
-                      </div>
-                      <div style={s.labelMuted}>{col.type}{col.pk ? ' · PK' : ''}</div>
-                    </div>
-                    <div>
-                      {kind === 'boolean' ? (
-                        <select
-                          value={drafts[col.name] ?? ''}
-                          onChange={(e) => setDrafts(p => ({ ...p, [col.name]: e.target.value }))}
-                          style={s.input}
-                        >
-                          {hasBlankOption && (
-                            <option value="">{blankLabel}</option>
-                          )}
-                          <option value="true">true</option>
-                          <option value="false">false</option>
-                        </select>
-                      ) : enumValues ? (
-                        <select
-                          value={drafts[col.name] ?? ''}
-                          onChange={(e) => setDrafts(p => ({ ...p, [col.name]: e.target.value }))}
-                          style={s.input}
-                        >
-                          {hasBlankOption ? (
-                            <option value="">{blankLabel}</option>
-                          ) : (
-                            // Disabled placeholder keeps the visible state aligned with the
-                            // empty draft, so the browser doesn't silently surface the first
-                            // enum value while still routing through the "Required column"
-                            // validator if the user hits Review SQL without picking.
-                            <option value="" disabled>— select —</option>
-                          )}
-                          {enumValues.map(v => <option key={v} value={v}>{v}</option>)}
-                        </select>
-                      ) : (
-                        <input
-                          type={inputType}
-                          value={drafts[col.name] ?? ''}
-                          step={kind === 'number' ? 'any' : undefined}
-                          onChange={(e) => setDrafts(p => ({ ...p, [col.name]: e.target.value }))}
-                          placeholder={blankLabel}
-                          style={s.input}
-                        />
-                      )}
-                      {col.comment && <div style={s.helper}>{col.comment}</div>}
-                    </div>
+        <div style={s.body}>
+          {editable.length === 0 && (
+            <div style={{ fontSize: 12, color: t.textMuted }}>
+              This table has no user-editable columns (all auto-generated).
+            </div>
+          )}
+          {editable.map(col => {
+            const kind = editKindForColumn(col);
+            const enumValues = col.dataType === 'enum' ? parseEnumValues(col.type) : null;
+            const inputType = kind === 'number' ? 'number'
+              : kind === 'date' ? 'date'
+              : kind === 'datetime' ? 'datetime-local'
+              : kind === 'time' ? 'time'
+              : 'text';
+            const required = !col.nullable && col.default === null;
+            const hasBlankOption = col.default !== null || col.nullable;
+            const blankLabel = col.default !== null ? `default: ${col.default}`
+              : col.nullable ? 'NULL'
+              : '';
+            return (
+              <div key={col.name} style={s.row}>
+                <div>
+                  <div style={s.label} title={col.comment || undefined}>
+                    {col.name}
+                    {required && <span style={{ color: t.colorError, marginLeft: 3 }}>*</span>}
                   </div>
-                );
-              })}
-            </div>
+                  <div style={s.labelMuted}>{col.type}{col.pk ? ' · PK' : ''}</div>
+                </div>
+                <div>
+                  {kind === 'boolean' ? (
+                    <select
+                      value={drafts[col.name] ?? ''}
+                      onChange={(e) => setDrafts(p => ({ ...p, [col.name]: e.target.value }))}
+                      style={s.input}
+                    >
+                      {hasBlankOption && (
+                        <option value="">{blankLabel}</option>
+                      )}
+                      <option value="true">true</option>
+                      <option value="false">false</option>
+                    </select>
+                  ) : enumValues ? (
+                    <select
+                      value={drafts[col.name] ?? ''}
+                      onChange={(e) => setDrafts(p => ({ ...p, [col.name]: e.target.value }))}
+                      style={s.input}
+                    >
+                      {hasBlankOption ? (
+                        <option value="">{blankLabel}</option>
+                      ) : (
+                        // Disabled placeholder keeps the visible state aligned with the
+                        // empty draft, so the browser doesn't silently surface the first
+                        // enum value while still routing through the "Required column"
+                        // validator if the user hits Insert without picking.
+                        <option value="" disabled>— select —</option>
+                      )}
+                      {enumValues.map(v => <option key={v} value={v}>{v}</option>)}
+                    </select>
+                  ) : (
+                    <input
+                      type={inputType}
+                      value={drafts[col.name] ?? ''}
+                      step={kind === 'number' ? 'any' : undefined}
+                      onChange={(e) => setDrafts(p => ({ ...p, [col.name]: e.target.value }))}
+                      placeholder={blankLabel}
+                      style={s.input}
+                    />
+                  )}
+                  {col.comment && <div style={s.helper}>{col.comment}</div>}
+                </div>
+              </div>
+            );
+          })}
+        </div>
 
-            {error && <div style={s.errorBanner}>{error}</div>}
+        {error && <div style={s.errorBanner}>{error}</div>}
 
-            <div style={s.footer}>
-              <button onClick={onClose} style={s.btnSecondary}>Cancel</button>
-              <button onClick={goToConfirm} style={s.btnPrimary} disabled={editable.length === 0}>Review SQL</button>
-            </div>
-          </>
-        )}
-
-        {view === 'confirm' && (
-          <>
-            <div style={{ padding: '12px 16px 4px', fontSize: 12, color: t.textSecondary }}>This will run:</div>
-            <pre style={s.pre}>{previewSql()}</pre>
-            {missingRequired.length > 0 && (
-              <div style={s.errorBanner}>Required columns missing: {missingRequired.join(', ')}</div>
-            )}
-            {error && <div style={s.errorBanner}>{error}</div>}
-
-            <div style={s.footer}>
-              <button onClick={() => { setView('form'); setError(null); }} style={s.btnSecondary} disabled={saving}>Back</button>
-              <button onClick={submit} style={s.btnPrimary} disabled={saving || missingRequired.length > 0}>
-                {saving ? 'Inserting…' : 'Insert'}
-              </button>
-            </div>
-          </>
-        )}
+        <div style={s.footer}>
+          <button onClick={onClose} style={s.btnSecondary} disabled={saving}>Cancel</button>
+          <button onClick={submit} style={s.btnPrimary} disabled={editable.length === 0 || saving}>
+            {saving ? 'Inserting…' : 'Insert'}
+          </button>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Symptom
A user installing Helix from the DMG and launching it saw a blank window
with **"Cannot GET /"** — Express's default 404 — instead of the app.

## Root cause (two issues compounding)
**1. Hardcoded port + no conflict handling.** \`electron/main.cjs\` told
the bundled server to bind \`:3001\`. If anything else was already
listening — most commonly a leftover dev \`tsx watch\` from a prior
debugging session — \`app.listen\` failed with \`EADDRINUSE\` and the
utilityProcess child crashed. But the BrowserWindow then loaded
\`http://localhost:3001/\` against whatever **else** happened to be on
3001. That other listener typically has no \`STATIC_PATH\` (only the
bundled server sets it via env) so it has no SPA fallback route → "Cannot
GET /".

**2. Silent startup failure.** \`waitForServer\` only resolved on
success; the prior \`startServer\` had no \`serverProc.on('exit')\`
hook. A child that died during startup was indistinguishable from "still
booting" until the 50-attempt timeout, and even then the user got a
generic timeout message with no captured stderr.

## Fix
- **\`findFreePort()\`** — uses \`net.createServer().listen(0)\` to ask
  the OS for an unused port, closes it, returns the number. A small race
  window remains (something could grab it between close and fork) but
  in practice this is many orders of magnitude better than colliding
  with a known stale listener.
- **\`startServer\` is now async** — captures the child's stderr into a
  buffer, registers \`on('exit')\`, and rejects with the captured stderr
  (or a fallback message) if the child dies before readiness probing
  succeeds.
- **\`app.whenReady\` catches the rejection** and surfaces a
  \`dialog.showErrorBox\` with the underlying cause, then quits. No more
  silent fallthrough into a BrowserWindow loading nothing.
- \`PORT\` / \`APP_URL\` are now \`let\` so the dynamic port reaches
  \`win.loadURL\` via closure.

Dev mode is untouched: the dev server is started outside this process by
\`concurrently\`, and the BrowserWindow loads the Vite URL.

## Test plan
- [x] Packaged \`Helix.app\` boots, picks a free port (verified
  \`http://localhost:62349/\` returned HTTP 200 with the bundled
  \`index.html\`).
- [x] No regression in dev mode (no code paths in dev branch changed).
- [x] Error-handling wiring reviewed by inspection — \`on('exit')\`
  rejects, the outer \`await\` shows the dialog, app quits.
- [ ] Manual: install fresh DMG (after merge + rebuild) on a clean Mac,
  verify no "Cannot GET /" regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)