### PR TITLE
chore: bump version to 1.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "helix",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "helix",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "concurrently": "^9.1.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "helix",
   "private": true,
-  "version": "1.0.0",
+  "version": "1.0.1",
   "type": "module",
   "license": "AGPL-3.0-only",
   "main": "electron/main.cjs",

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "helix-server",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "helix-server",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helix-server",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "type": "module",
   "license": "AGPL-3.0-only",


### PR DESCRIPTION
## Summary
- Patch release covering bug fixes and dependency security updates merged since v1.0.0.
- Bumped in both root and server packages plus regenerated lockfiles so the two halves of the app stay in lockstep.

Changes since v1.0.0:
- fix: make overflowing tabs scrollable so newest tab stays visible (#164, fixes #163)
- fix: pick free server port and surface startup failures in packaged app (#161)
- chore(deps): bump hono from 4.12.15 to 4.12.22 in /server (#166)
- chore(deps): bump fast-uri from 3.1.0 to 3.1.2 in /server (#165)
- Add Claude Code GitHub Workflow (#162)

## Test plan
- [ ] CI passes.
- [ ] After merge, tag v1.0.1 and produce the electron release artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)