### PR TITLE
feat: classify driver errors into client/transient/server for accurate HTTP status codes

### DIFF
--- a/server/src/drivers/interface.ts
+++ b/server/src/drivers/interface.ts
@@ -1,3 +1,14 @@
+export type DriverErrorClass = 'client' | 'transient' | 'server';
+
+export class DriverError extends Error {
+  readonly errorClass: DriverErrorClass;
+  constructor(message: string, errorClass: DriverErrorClass, options?: ErrorOptions) {
+    super(message, options);
+    this.name = 'DriverError';
+    this.errorClass = errorClass;
+  }
+}
+
 export interface ConnectionConfig {
   host: string;
   port: number;

--- a/server/src/drivers/mongodb.test.ts
+++ b/server/src/drivers/mongodb.test.ts
@@ -62,10 +62,14 @@ const { ObjectIdCtor } = vi.hoisted(() => {
 vi.mock('mongodb', () => ({
   MongoClient: vi.fn(() => mockClient),
   ObjectId: ObjectIdCtor,
+  MongoNetworkError: class MongoNetworkError extends Error { constructor(msg: string) { super(msg); this.name = 'MongoNetworkError'; } },
+  MongoServerSelectionError: class MongoServerSelectionError extends Error { constructor(msg: string) { super(msg); this.name = 'MongoServerSelectionError'; } },
+  MongoParseError: class MongoParseError extends Error { constructor(msg: string) { super(msg); this.name = 'MongoParseError'; } },
 }));
 
 import { MongoDBDriver } from './mongodb.js';
-import { MongoClient } from 'mongodb';
+import { MongoClient, MongoNetworkError, MongoServerSelectionError, MongoParseError } from 'mongodb';
+import { DriverError } from './interface.js';
 
 function makeDriver(database?: string) {
   return new MongoDBDriver({
@@ -773,5 +777,69 @@ describe('MongoDBDriver – getTableDdl', () => {
     await expect(
       makeDriver().getTableDdl('shop', 'users', 'table'),
     ).rejects.toThrow(/getCollectionInfo/);
+  });
+});
+
+describe('MongoDBDriver – error classification', () => {
+  it('classifies MongoServerSelectionError as transient', async () => {
+    mockCursor.toArray.mockRejectedValueOnce(new MongoServerSelectionError('Server selection timed out'));
+    const req = JSON.stringify({ collection: 'users', operation: 'find' });
+    await expect(makeDriver().query(req)).rejects.toMatchObject({
+      errorClass: 'transient',
+      message: 'Server selection timed out',
+    });
+  });
+
+  it('classifies MongoNetworkError as transient', async () => {
+    mockCursor.toArray.mockRejectedValueOnce(new MongoNetworkError('socket closed'));
+    const req = JSON.stringify({ collection: 'users', operation: 'find' });
+    await expect(makeDriver().query(req)).rejects.toMatchObject({
+      errorClass: 'transient',
+    });
+  });
+
+  it('classifies MongoParseError as client', async () => {
+    mockCursor.toArray.mockRejectedValueOnce(new MongoParseError('invalid query'));
+    const req = JSON.stringify({ collection: 'users', operation: 'find' });
+    await expect(makeDriver().query(req)).rejects.toMatchObject({
+      errorClass: 'client',
+    });
+  });
+
+  it('classifies an unrecognized error as server', async () => {
+    mockCursor.toArray.mockRejectedValueOnce(new Error('unexpected internal failure'));
+    const req = JSON.stringify({ collection: 'users', operation: 'find' });
+    await expect(makeDriver().query(req)).rejects.toMatchObject({
+      errorClass: 'server',
+    });
+  });
+
+  it('classifies invalid MQL JSON as a client DriverError', async () => {
+    await expect(makeDriver().query('not-json')).rejects.toMatchObject({
+      errorClass: 'client',
+    });
+  });
+
+  it('classifies missing collection field as a client DriverError', async () => {
+    await expect(makeDriver().query(JSON.stringify({ operation: 'find' }))).rejects.toMatchObject({
+      errorClass: 'client',
+    });
+  });
+
+  it('classifies unsupported operation as a client DriverError', async () => {
+    await expect(
+      makeDriver().query(JSON.stringify({ collection: 'users', operation: 'bulkWrite' })),
+    ).rejects.toMatchObject({
+      errorClass: 'client',
+      message: expect.stringContaining('Unsupported MQL operation'),
+    });
+  });
+
+  it('re-throws DriverError instances without double-wrapping', async () => {
+    const original = new DriverError('already classified', 'transient');
+    mockCursor.toArray.mockRejectedValueOnce(original);
+    const req = JSON.stringify({ collection: 'users', operation: 'find' });
+    const thrown = await makeDriver().query(req).catch(e => e);
+    expect(thrown).toBe(original);
   });
 });

--- a/server/src/drivers/mongodb.ts
+++ b/server/src/drivers/mongodb.ts
@@ -1,5 +1,6 @@
-import { MongoClient, ObjectId } from 'mongodb';
+import { MongoClient, ObjectId, MongoNetworkError, MongoServerSelectionError, MongoParseError } from 'mongodb';
 import type { Db, Document } from 'mongodb';
+import { DriverError } from './interface.js';
 import type {
   DbDriver,
   ConnectionConfig,
@@ -10,6 +11,17 @@ import type {
   TableInfo,
   CollectionInfo,
 } from './interface.js';
+
+function classifyMongoError(err: unknown): DriverError {
+  const message = err instanceof Error ? err.message : String(err);
+  if (err instanceof MongoServerSelectionError || err instanceof MongoNetworkError) {
+    return new DriverError(message, 'transient', { cause: err });
+  }
+  if (err instanceof MongoParseError) {
+    return new DriverError(message, 'client', { cause: err });
+  }
+  return new DriverError(message, 'server', { cause: err });
+}
 
 /**
  * MQL request shape carried over the wire as a JSON string in `query()`'s `sql` arg.
@@ -165,17 +177,17 @@ function parseRequest(sql: string): MqlRequest {
   try {
     parsed = JSON.parse(sql);
   } catch {
-    throw new Error('MongoDB driver expects a JSON-encoded MQL request.');
+    throw new DriverError('MongoDB driver expects a JSON-encoded MQL request.', 'client');
   }
   if (!parsed || typeof parsed !== 'object') {
-    throw new Error('MongoDB driver expects a JSON-encoded MQL request.');
+    throw new DriverError('MongoDB driver expects a JSON-encoded MQL request.', 'client');
   }
   const req = parsed as MqlRequest;
   if (!req.collection || typeof req.collection !== 'string') {
-    throw new Error('MQL request requires a "collection" field.');
+    throw new DriverError('MQL request requires a "collection" field.', 'client');
   }
   if (!req.operation) {
-    throw new Error('MQL request requires an "operation" field.');
+    throw new DriverError('MQL request requires an "operation" field.', 'client');
   }
   return req;
 }
@@ -242,91 +254,96 @@ export class MongoDBDriver implements DbDriver {
   }
 
   async query(sql: string, _params?: unknown[], schema?: string): Promise<QueryResult> {
-    await this.ensureConnected();
-    const req = parseRequest(sql);
-    const db = this.db(schema);
-    const coll = db.collection(req.collection);
+    try {
+      await this.ensureConnected();
+      const req = parseRequest(sql);
+      const db = this.db(schema);
+      const coll = db.collection(req.collection);
 
-    switch (req.operation) {
-      case 'find': {
-        let cursor = coll.find(req.filter ?? {});
-        if (req.projection) cursor = cursor.project(req.projection) as typeof cursor;
-        if (req.sort) cursor = cursor.sort(req.sort);
-        if (typeof req.skip === 'number') cursor = cursor.skip(req.skip);
-        if (typeof req.limit === 'number') cursor = cursor.limit(req.limit);
-        const docs = await cursor.toArray();
-        return this.toQueryResult(docs);
-      }
-      case 'findOne': {
-        const doc = await coll.findOne(req.filter ?? {}, {
-          projection: req.projection,
-          sort: req.sort as Document | undefined,
-        });
-        return this.toQueryResult(doc ? [doc] : []);
-      }
-      case 'aggregate': {
-        const docs = await coll.aggregate(req.pipeline ?? []).toArray();
-        return this.toQueryResult(docs);
-      }
-      case 'count': {
-        const n = await coll.countDocuments(req.filter ?? {});
-        return {
-          rows: [{ count: n }],
-          columnMeta: [
-            {
-              name: 'count', orgName: 'count', table: req.collection, orgTable: req.collection,
-              pk: false, unique: false, notNull: true, mysqlType: 0,
-            },
-          ],
-        };
-      }
-      case 'insertOne': {
-        if (!req.document) throw new Error('insertOne requires a "document" field.');
-        const result = await coll.insertOne(req.document);
-        return {
-          rows: [],
-          columnMeta: [],
-          affectedRows: result.acknowledged ? 1 : 0,
-          insertId: null,
-        };
-      }
-      case 'updateOne': {
-        if (!req.update) throw new Error('updateOne requires an "update" field.');
-        const useId = req.id !== undefined;
-        const filter = useId ? coerceIdFilter(req.id) : (req.filter ?? {});
-        let result = await coll.updateOne(filter, req.update);
-        // Graceful fallback: if we promoted a 24-hex string to ObjectId and
-        // matched nothing, retry with the raw string id.
-        if (useId && result.matchedCount === 0 && idWasCoercedToObjectId(req.id)) {
-          result = await coll.updateOne({ _id: req.id } as Document, req.update);
+      switch (req.operation) {
+        case 'find': {
+          let cursor = coll.find(req.filter ?? {});
+          if (req.projection) cursor = cursor.project(req.projection) as typeof cursor;
+          if (req.sort) cursor = cursor.sort(req.sort);
+          if (typeof req.skip === 'number') cursor = cursor.skip(req.skip);
+          if (typeof req.limit === 'number') cursor = cursor.limit(req.limit);
+          const docs = await cursor.toArray();
+          return this.toQueryResult(docs);
         }
-        // Use matchedCount, not modifiedCount: routes treat affectedRows === 0
-        // as "row not found" (404). A no-op update (matched but unchanged) must
-        // not be reported as missing.
-        return {
-          rows: [],
-          columnMeta: [],
-          affectedRows: result.matchedCount,
-          insertId: null,
-        };
-      }
-      case 'deleteOne': {
-        const useId = req.id !== undefined;
-        const filter = useId ? coerceIdFilter(req.id) : (req.filter ?? {});
-        let result = await coll.deleteOne(filter);
-        if (useId && result.deletedCount === 0 && idWasCoercedToObjectId(req.id)) {
-          result = await coll.deleteOne({ _id: req.id } as Document);
+        case 'findOne': {
+          const doc = await coll.findOne(req.filter ?? {}, {
+            projection: req.projection,
+            sort: req.sort as Document | undefined,
+          });
+          return this.toQueryResult(doc ? [doc] : []);
         }
-        return {
-          rows: [],
-          columnMeta: [],
-          affectedRows: result.deletedCount,
-          insertId: null,
-        };
+        case 'aggregate': {
+          const docs = await coll.aggregate(req.pipeline ?? []).toArray();
+          return this.toQueryResult(docs);
+        }
+        case 'count': {
+          const n = await coll.countDocuments(req.filter ?? {});
+          return {
+            rows: [{ count: n }],
+            columnMeta: [
+              {
+                name: 'count', orgName: 'count', table: req.collection, orgTable: req.collection,
+                pk: false, unique: false, notNull: true, mysqlType: 0,
+              },
+            ],
+          };
+        }
+        case 'insertOne': {
+          if (!req.document) throw new DriverError('insertOne requires a "document" field.', 'client');
+          const result = await coll.insertOne(req.document);
+          return {
+            rows: [],
+            columnMeta: [],
+            affectedRows: result.acknowledged ? 1 : 0,
+            insertId: null,
+          };
+        }
+        case 'updateOne': {
+          if (!req.update) throw new DriverError('updateOne requires an "update" field.', 'client');
+          const useId = req.id !== undefined;
+          const filter = useId ? coerceIdFilter(req.id) : (req.filter ?? {});
+          let result = await coll.updateOne(filter, req.update);
+          // Graceful fallback: if we promoted a 24-hex string to ObjectId and
+          // matched nothing, retry with the raw string id.
+          if (useId && result.matchedCount === 0 && idWasCoercedToObjectId(req.id)) {
+            result = await coll.updateOne({ _id: req.id } as Document, req.update);
+          }
+          // Use matchedCount, not modifiedCount: routes treat affectedRows === 0
+          // as "row not found" (404). A no-op update (matched but unchanged) must
+          // not be reported as missing.
+          return {
+            rows: [],
+            columnMeta: [],
+            affectedRows: result.matchedCount,
+            insertId: null,
+          };
+        }
+        case 'deleteOne': {
+          const useId = req.id !== undefined;
+          const filter = useId ? coerceIdFilter(req.id) : (req.filter ?? {});
+          let result = await coll.deleteOne(filter);
+          if (useId && result.deletedCount === 0 && idWasCoercedToObjectId(req.id)) {
+            result = await coll.deleteOne({ _id: req.id } as Document);
+          }
+          return {
+            rows: [],
+            columnMeta: [],
+            affectedRows: result.deletedCount,
+            insertId: null,
+          };
+        }
+        default: {
+          throw new DriverError(`Unsupported MQL operation: ${String(req.operation)}`, 'client');
+        }
       }
-      default: {
-        throw new Error(`Unsupported MQL operation: ${String(req.operation)}`);
-      }
+    } catch (err) {
+      if (err instanceof DriverError) throw err;
+      throw classifyMongoError(err);
     }
   }
 

--- a/server/src/drivers/postgres.test.ts
+++ b/server/src/drivers/postgres.test.ts
@@ -22,6 +22,7 @@ vi.mock('pg', () => ({
 }));
 
 import { PostgresDriver } from './postgres.js';
+import { DriverError } from './interface.js';
 
 // Snapshot module-load `setTypeParser` calls before any `vi.clearAllMocks()`
 // in later `beforeEach` blocks wipes them.
@@ -75,6 +76,62 @@ describe('PostgresDriver.query – connection release', () => {
     const calls = mockClient.query.mock.calls.map(c => (typeof c[0] === 'string' ? c[0] : c[0].text));
     expect(calls).toContain('SET search_path TO DEFAULT');
     expect(mockClient.release).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('PostgresDriver.query – error classification', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPoolInstance.connect.mockResolvedValue(mockClient);
+  });
+
+  function pgError(message: string, code: string): Error {
+    const err = new Error(message);
+    (err as Record<string, unknown>).code = code;
+    return err;
+  }
+
+  it('wraps a syntax error (42xxx) as a client DriverError', async () => {
+    mockClient.query.mockRejectedValueOnce(pgError('syntax error at or near "SELEC"', '42601'));
+    await expect(makeDriver().query('SELEC 1')).rejects.toMatchObject({
+      errorClass: 'client',
+      message: 'syntax error at or near "SELEC"',
+    });
+  });
+
+  it('wraps a connection error (08xxx) as a transient DriverError', async () => {
+    mockClient.query.mockRejectedValueOnce(pgError('connection refused', '08006'));
+    await expect(makeDriver().query('SELECT 1')).rejects.toMatchObject({
+      errorClass: 'transient',
+    });
+  });
+
+  it('wraps a resource error (53xxx) as a transient DriverError', async () => {
+    mockClient.query.mockRejectedValueOnce(pgError('too many connections', '53300'));
+    await expect(makeDriver().query('SELECT 1')).rejects.toMatchObject({
+      errorClass: 'transient',
+    });
+  });
+
+  it('wraps an operator-intervention error (57xxx) as a transient DriverError', async () => {
+    mockClient.query.mockRejectedValueOnce(pgError('canceling statement due to user request', '57014'));
+    await expect(makeDriver().query('SELECT 1')).rejects.toMatchObject({
+      errorClass: 'transient',
+    });
+  });
+
+  it('wraps an unrecognized pg error as a server DriverError', async () => {
+    mockClient.query.mockRejectedValueOnce(pgError('some internal error', 'XX000'));
+    await expect(makeDriver().query('SELECT 1')).rejects.toMatchObject({
+      errorClass: 'server',
+    });
+  });
+
+  it('re-throws DriverError instances without double-wrapping', async () => {
+    const original = new DriverError('already classified', 'client');
+    mockClient.query.mockRejectedValueOnce(original);
+    const thrown = await makeDriver().query('SELECT 1').catch(e => e);
+    expect(thrown).toBe(original);
   });
 });
 

--- a/server/src/drivers/postgres.ts
+++ b/server/src/drivers/postgres.ts
@@ -1,4 +1,5 @@
 import pg from 'pg';
+import { DriverError } from './interface.js';
 import type { DbDriver, ConnectionConfig, QueryResult, ColumnMeta, ColumnInfo, SchemaInfo, TableInfo } from './interface.js';
 
 // Return DATE / TIME / TIMESTAMP / TIMESTAMPTZ / TIMETZ as raw strings rather
@@ -17,6 +18,22 @@ const PG_TIMETZ = 1266;
 const identity = (v: string) => v;
 for (const oid of [PG_DATE, PG_TIME, PG_TIMESTAMP, PG_TIMESTAMPTZ, PG_TIMETZ]) {
   pg.types.setTypeParser(oid, identity);
+}
+
+function classifyPgError(err: unknown): DriverError {
+  const message = err instanceof Error ? err.message : String(err);
+  if (err && typeof (err as Record<string, unknown>).code === 'string') {
+    const code = (err as Record<string, unknown>).code as string;
+    // 08xxx=connection, 53xxx=insufficient resources, 57xxx=operator intervention
+    if (code.startsWith('08') || code.startsWith('53') || code.startsWith('57')) {
+      return new DriverError(message, 'transient', { cause: err });
+    }
+    // 42xxx=syntax/access errors, 28xxx=invalid authorization
+    if (code.startsWith('42') || code.startsWith('28')) {
+      return new DriverError(message, 'client', { cause: err });
+    }
+  }
+  return new DriverError(message, 'server', { cause: err });
 }
 
 function buildPgPoolConfig(config: ConnectionConfig): pg.PoolConfig {
@@ -126,56 +143,66 @@ export class PostgresDriver implements DbDriver {
   }
 
   async query(sql: string, params?: unknown[], schema?: string): Promise<QueryResult> {
-    const client = await this.pool.connect();
-    let searchPathSet = false;
     try {
-      if (schema) {
-        await client.query(`SET search_path TO ${this.escapeIdent(schema)}`);
-        searchPathSet = true;
-      }
+      const client = await this.pool.connect();
+      let searchPathSet = false;
+      try {
+        if (schema) {
+          await client.query(`SET search_path TO ${this.escapeIdent(schema)}`);
+          searchPathSet = true;
+        }
 
-      // Naive ?→$N rewrite: assumes machine-generated SQL when params is non-empty.
-      // User-authored SQL must be passed without params (the rewrite is skipped then).
-      let pgSql = sql;
-      if (params?.length) {
-        let n = 0;
-        pgSql = sql.replace(/\?/g, () => `$${++n}`);
+        // Naive ?→$N rewrite: assumes machine-generated SQL when params is non-empty.
+        // User-authored SQL must be passed without params (the rewrite is skipped then).
+        let pgSql = sql;
+        if (params?.length) {
+          let n = 0;
+          pgSql = sql.replace(/\?/g, () => `$${++n}`);
+        }
+        const result = await client.query({ text: pgSql, values: params?.length ? params : undefined });
+        // node-pg's simple query protocol returns an array of results when the SQL
+        // contains multiple statements. `query()` keeps the legacy single-result
+        // contract — `queryAll` is the multi-statement entry point — so collapse
+        // an unexpected array down to its last element.
+        const single = Array.isArray(result) ? (result as pg.QueryResult[])[result.length - 1] : result;
+        return buildPgResult(single);
+      } finally {
+        // pg.Pool reuses clients without resetting session state, so search_path
+        // would leak to the next caller on this same client.
+        if (searchPathSet) {
+          try { await client.query('SET search_path TO DEFAULT'); } catch { /* fall through to release */ }
+        }
+        client.release();
       }
-      const result = await client.query({ text: pgSql, values: params?.length ? params : undefined });
-      // node-pg's simple query protocol returns an array of results when the SQL
-      // contains multiple statements. `query()` keeps the legacy single-result
-      // contract — `queryAll` is the multi-statement entry point — so collapse
-      // an unexpected array down to its last element.
-      const single = Array.isArray(result) ? (result as pg.QueryResult[])[result.length - 1] : result;
-      return buildPgResult(single);
-    } finally {
-      // pg.Pool reuses clients without resetting session state, so search_path
-      // would leak to the next caller on this same client.
-      if (searchPathSet) {
-        try { await client.query('SET search_path TO DEFAULT'); } catch { /* fall through to release */ }
-      }
-      client.release();
+    } catch (err) {
+      if (err instanceof DriverError) throw err;
+      throw classifyPgError(err);
     }
   }
 
   async queryAll(sql: string, schema?: string): Promise<QueryResult[]> {
-    const client = await this.pool.connect();
-    let searchPathSet = false;
     try {
-      if (schema) {
-        await client.query(`SET search_path TO ${this.escapeIdent(schema)}`);
-        searchPathSet = true;
+      const client = await this.pool.connect();
+      let searchPathSet = false;
+      try {
+        if (schema) {
+          await client.query(`SET search_path TO ${this.escapeIdent(schema)}`);
+          searchPathSet = true;
+        }
+        // Always go through the simple query protocol (no values) so multi-statement
+        // SQL fans out to one result per statement.
+        const raw = await client.query(sql);
+        const results = Array.isArray(raw) ? (raw as pg.QueryResult[]) : [raw];
+        return results.map(buildPgResult);
+      } finally {
+        if (searchPathSet) {
+          try { await client.query('SET search_path TO DEFAULT'); } catch { /* fall through to release */ }
+        }
+        client.release();
       }
-      // Always go through the simple query protocol (no values) so multi-statement
-      // SQL fans out to one result per statement.
-      const raw = await client.query(sql);
-      const results = Array.isArray(raw) ? (raw as pg.QueryResult[]) : [raw];
-      return results.map(buildPgResult);
-    } finally {
-      if (searchPathSet) {
-        try { await client.query('SET search_path TO DEFAULT'); } catch { /* fall through to release */ }
-      }
-      client.release();
+    } catch (err) {
+      if (err instanceof DriverError) throw err;
+      throw classifyPgError(err);
     }
   }
 

--- a/server/src/routes/query.test.ts
+++ b/server/src/routes/query.test.ts
@@ -8,6 +8,7 @@ vi.mock('../db.js', () => ({
 
 import { getDriver } from '../db.js';
 import { postQuery } from './query.js';
+import { DriverError } from '../drivers/interface.js';
 
 function makeMeta(name: string, { pk = false, unique = false, notNull = false } = {}) {
   return { name, orgName: name, table: 't', orgTable: 't', pk, unique, notNull, mysqlType: 253 };
@@ -112,10 +113,10 @@ describe('postQuery – driver delegation (sql mode)', () => {
     expect(res.body.results[1].rows).toEqual([{ b: 2 }]);
   });
 
-  it('returns 400 when driver.query() throws', async () => {
+  it('returns 400 when driver.query() throws a client DriverError', async () => {
     const mockDriver = {
       queryMode: 'sql' as const,
-      query: vi.fn().mockRejectedValue(new Error("Table 'mydb.ghost' doesn't exist")),
+      query: vi.fn().mockRejectedValue(new DriverError("Table 'mydb.ghost' doesn't exist", 'client')),
     };
     vi.mocked(getDriver).mockReturnValue(mockDriver as any);
 
@@ -125,6 +126,51 @@ describe('postQuery – driver delegation (sql mode)', () => {
 
     expect(res.status).toBe(400);
     expect(res.body.error).toContain('ghost');
+  });
+
+  it('returns 503 when driver.query() throws a transient DriverError', async () => {
+    const mockDriver = {
+      queryMode: 'sql' as const,
+      query: vi.fn().mockRejectedValue(new DriverError('connection refused', 'transient')),
+    };
+    vi.mocked(getDriver).mockReturnValue(mockDriver as any);
+
+    const res = await request(makeApp())
+      .post('/api/query')
+      .send({ sql: 'SELECT 1' });
+
+    expect(res.status).toBe(503);
+    expect(res.body.error).toBe('connection refused');
+  });
+
+  it('returns 500 when driver.query() throws a server DriverError', async () => {
+    const mockDriver = {
+      queryMode: 'sql' as const,
+      query: vi.fn().mockRejectedValue(new DriverError('internal driver error', 'server')),
+    };
+    vi.mocked(getDriver).mockReturnValue(mockDriver as any);
+
+    const res = await request(makeApp())
+      .post('/api/query')
+      .send({ sql: 'SELECT 1' });
+
+    expect(res.status).toBe(500);
+    expect(res.body.error).toBe('internal driver error');
+  });
+
+  it('returns 500 when driver.query() throws an unclassified error', async () => {
+    const mockDriver = {
+      queryMode: 'sql' as const,
+      query: vi.fn().mockRejectedValue(new Error('something unexpected')),
+    };
+    vi.mocked(getDriver).mockReturnValue(mockDriver as any);
+
+    const res = await request(makeApp())
+      .post('/api/query')
+      .send({ sql: 'SELECT 1' });
+
+    expect(res.status).toBe(500);
+    expect(res.body.error).toBe('something unexpected');
   });
 });
 
@@ -265,10 +311,10 @@ describe('postQuery – mql mode', () => {
     expect(mockDriver.query).not.toHaveBeenCalled();
   });
 
-  it('returns 400 when driver.query() throws in mql mode', async () => {
+  it('returns 400 when driver.query() throws a client DriverError in mql mode', async () => {
     const mockDriver = {
       queryMode: 'mql' as const,
-      query: vi.fn().mockRejectedValue(new Error('Unsupported MQL operation: foo')),
+      query: vi.fn().mockRejectedValue(new DriverError('Unsupported MQL operation: foo', 'client')),
     };
     vi.mocked(getDriver).mockReturnValue(mockDriver as any);
 

--- a/server/src/routes/query.ts
+++ b/server/src/routes/query.ts
@@ -1,5 +1,6 @@
 import type { RequestHandler } from 'express';
 import { getDriver } from '../db.js';
+import { DriverError } from '../drivers/interface.js';
 
 export const postQuery: RequestHandler = async (req, res) => {
   const driver = getDriver();
@@ -72,10 +73,12 @@ export const postQuery: RequestHandler = async (req, res) => {
       executionTime,
     });
   } catch (err) {
-    // All driver errors map to 400 today — lossy for transient/infra failures
-    // (e.g. MongoServerSelectionError, MongoNetworkError, connection drops).
-    // See #122 for the proposed classification (client / transient / server).
     const message = err instanceof Error ? err.message : String(err);
-    res.status(400).json({ error: message });
+    let status = 500;
+    if (err instanceof DriverError) {
+      if (err.errorClass === 'client') status = 400;
+      else if (err.errorClass === 'transient') status = 503;
+    }
+    res.status(status).json({ error: message });
   }
 };


### PR DESCRIPTION
Implements #122: introduces DriverError with errorClass so the query route returns 400/503/500 instead of always 400.

Changes:
- interface.ts: DriverErrorClass + DriverError class
- postgres.ts: classifyPgError() maps pg error codes to classes
- mongodb.ts: explicit throws converted to DriverError, Mongo errors classified by type
- query.ts: catch block maps errorClass to HTTP status
- Tests updated and extended

Closes #122

Generated with [Claude Code](https://claude.ai/code)