### PR TITLE
feat: autocomplete column / table / keyword names in the SQL editor

### DIFF
--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -5,6 +5,9 @@ import type { Theme } from '../theme';
 import type { SchemaData } from '../api';
 import type { HistoryEntry } from '../queryHistory';
 import type { SavedQuery } from '../savedQueries';
+import { SuggestionPopup, type Suggestion } from './SuggestionPopup';
+import { extractTableRefs, contextAtCaret, expectedSlot, KEYWORD_GROUPS } from '../lib/sqlContext';
+import { getCaretCoordinates } from '../lib/caretPosition';
 
 const LARGE_ROW_THRESHOLD = 5_000;
 
@@ -254,6 +257,177 @@ export function QueryEditor({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [runtimeError]);
 
+  // ─── Field-name autocomplete ──────────────────────────────────────────────
+  // Tracks an open suggestion popup anchored to the caret. Suggestions are
+  // re-computed on every value/selection change in `refreshSuggestions`.
+  interface SuggestionState {
+    items: Suggestion[];
+    selectedIndex: number;
+    position: { left: number; top: number };
+    /** Source range to overwrite when an item is accepted (start..caret). */
+    replaceStart: number;
+    replaceEnd: number;
+  }
+  const [suggestions, setSuggestions] = useState<SuggestionState | null>(null);
+
+  // Resolve the qualifier (`u` in `u.name`) to an actual table info row.
+  // Falls back to the bare table name when no alias was set. Returns null
+  // when nothing matches.
+  const resolveQualifier = (qualifier: string, schema: SchemaData | undefined, refs: { table: string; alias: string }[]) => {
+    if (!schema) return null;
+    const ql = qualifier.toLowerCase();
+    // Prefer an explicit alias match (closer to what the user wrote).
+    const aliasHit = refs.find(r => r.alias.toLowerCase() === ql);
+    if (aliasHit) {
+      const table = schema.tables.find(x => x.name.toLowerCase() === aliasHit.table.toLowerCase());
+      if (table) return table;
+    }
+    // Fall back to a direct table-name match — common when the user qualifies
+    // with the table name even though they could have used the alias.
+    return schema.tables.find(x => x.name.toLowerCase() === ql) ?? null;
+  };
+
+  const refreshSuggestions = (text: string, caret: number) => {
+    if (isMql) { setSuggestions(null); return; }
+    const ctx = contextAtCaret(text, caret);
+    if (!ctx) { setSuggestions(null); return; }
+
+    // Mask the prefix-being-typed before extracting table refs. Without this,
+    // the partial identifier directly after `FROM <table>` gets parsed as an
+    // alias — so typing `wh` on a line after `FROM users` makes the parser
+    // think `wh` is the alias of `users`, polluting the suggestion list.
+    const maskedText = text.slice(0, ctx.start) + ' '.repeat(caret - ctx.start) + text.slice(caret);
+    const refs = extractTableRefs(maskedText);
+    const slot = expectedSlot(text, ctx.start, ctx.qualifier);
+    const prefixLower = ctx.prefix.toLowerCase();
+    let items: Suggestion[] = [];
+
+    if (ctx.qualifier) {
+      // Qualified prefix is always column-only — bypass slot inspection.
+      const table = resolveQualifier(ctx.qualifier, schemaData, refs);
+      if (!table) { setSuggestions(null); return; }
+      items = table.columns.map(c => ({
+        kind: 'column' as const,
+        insert: c.name,
+        label: c.name,
+        detail: c.type,
+      }));
+    } else {
+      // Keywords first when the slot expects them. Statement-starter slots
+      // get *only* keywords so the user isn't shown a column list while typing
+      // `SELE`. Expression slots mix keywords with columns (NULL/AND/OR sit
+      // happily next to column names).
+      const pushKeywords = (words: readonly string[]) => {
+        for (const w of words) {
+          items.push({ kind: 'keyword', insert: w, label: w });
+        }
+      };
+      if (slot.keywords === 'statement') {
+        pushKeywords(KEYWORD_GROUPS.statement);
+      } else if (slot.keywords === 'expr') {
+        pushKeywords(KEYWORD_GROUPS.expr);
+      } else if (slot.keywords === 'by') {
+        pushKeywords(KEYWORD_GROUPS.by);
+      } else if (slot.keywords === 'any') {
+        // Permissive fallback — show clause keywords (WHERE, GROUP BY, etc.)
+        // since that's where the parser most often lands "after FROM".
+        pushKeywords(KEYWORD_GROUPS.clauses);
+      }
+
+      if (slot.columns && schemaData && refs.length > 0) {
+        const seenCol = new Set<string>();
+        for (const ref of refs) {
+          const tinfo = schemaData.tables.find(x => x.name.toLowerCase() === ref.table.toLowerCase());
+          if (!tinfo) continue;
+          for (const c of tinfo.columns) {
+            const k = `${tinfo.name}.${c.name}`.toLowerCase();
+            if (seenCol.has(k)) continue;
+            seenCol.add(k);
+            items.push({
+              kind: 'column',
+              insert: c.name,
+              label: c.name,
+              detail: `${tinfo.name} · ${c.type}`,
+            });
+          }
+        }
+        // Aliases — only when an alias exists (alias != table name).
+        for (const ref of refs) {
+          if (ref.alias.toLowerCase() === ref.table.toLowerCase()) continue;
+          items.push({
+            kind: 'alias',
+            insert: ref.alias,
+            label: ref.alias,
+            detail: ref.table,
+          });
+        }
+      }
+      if (slot.tables && schemaData) {
+        for (const t of schemaData.tables) {
+          items.push({
+            kind: 'table',
+            insert: t.name,
+            label: t.name,
+            detail: `${t.columns.length} cols`,
+          });
+        }
+      }
+    }
+
+    if (items.length === 0) { setSuggestions(null); return; }
+
+    // Filter by prefix: case-insensitive startsWith first, then includes.
+    // When prefix is empty (user just typed `.`), keep the full list.
+    if (prefixLower) {
+      const starts: Suggestion[] = [];
+      const contains: Suggestion[] = [];
+      for (const it of items) {
+        const il = it.label.toLowerCase();
+        if (il.startsWith(prefixLower)) starts.push(it);
+        else if (il.includes(prefixLower)) contains.push(it);
+      }
+      items = [...starts, ...contains];
+    }
+
+    if (items.length === 0) { setSuggestions(null); return; }
+
+    // Cap the list. The popup scrolls but a giant render is wasteful and rare
+    // matches at the bottom are noise more than help.
+    items = items.slice(0, 50);
+
+    const el = textareaRef.current;
+    if (!el) { setSuggestions(null); return; }
+    // Anchor at the start of the prefix so the popup grows down-and-right from
+    // the partial word the user is editing (cursor itself is one char ahead).
+    const coords = getCaretCoordinates(el, ctx.start);
+    // Subtract the textarea's scroll so the popup tracks the visible caret,
+    // not the absolute caret position inside a scrolled textarea.
+    const left = coords.left - el.scrollLeft;
+    const top = coords.top - el.scrollTop + coords.height + 2;
+
+    setSuggestions({
+      items,
+      selectedIndex: 0,
+      position: { left, top },
+      replaceStart: ctx.start,
+      replaceEnd: caret,
+    });
+  };
+
+  const acceptSuggestion = (item: Suggestion) => {
+    const el = textareaRef.current;
+    if (!el || !suggestions) return;
+    const next = value.slice(0, suggestions.replaceStart) + item.insert + value.slice(suggestions.replaceEnd);
+    onChange(next);
+    const caretAt = suggestions.replaceStart + item.insert.length;
+    // Restore caret post-React-update so it lands after the inserted text.
+    requestAnimationFrame(() => {
+      el.selectionStart = el.selectionEnd = caretAt;
+      el.focus();
+    });
+    setSuggestions(null);
+  };
+
   const handleRunClick = () => {
     if (isMql && value.trim()) {
       try {
@@ -268,6 +442,31 @@ export function QueryEditor({
   };
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    // Suggestion-popup keys take precedence over everything else (Run shortcut,
+    // Format, plain Tab/Enter) so the user can drive the popup without losing
+    // these keys to the editor.
+    if (suggestions) {
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        setSuggestions(s => s ? { ...s, selectedIndex: (s.selectedIndex + 1) % s.items.length } : s);
+        return;
+      }
+      if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        setSuggestions(s => s ? { ...s, selectedIndex: (s.selectedIndex - 1 + s.items.length) % s.items.length } : s);
+        return;
+      }
+      if (e.key === 'Enter' || e.key === 'Tab') {
+        e.preventDefault();
+        acceptSuggestion(suggestions.items[suggestions.selectedIndex]);
+        return;
+      }
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        setSuggestions(null);
+        return;
+      }
+    }
     if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
       e.preventDefault();
       handleRunClick();
@@ -686,7 +885,7 @@ export function QueryEditor({
           )}
         </div>
       )}
-      <div style={s.editorWrap}>
+      <div style={{ ...s.editorWrap, position: 'relative' }}>
         <div style={s.lineNums} aria-hidden="true">
           {value.split('\n').map((_, i) => (
             <div key={i} style={s.lineNum}>{i + 1}</div>
@@ -698,12 +897,39 @@ export function QueryEditor({
           onChange={e => {
             if (editorError) setEditorError(null);
             onChange(e.target.value);
+            // Recompute suggestions for the new value; the React selection
+            // updates synchronously here so `selectionStart` is the caret
+            // position right after the edit.
+            refreshSuggestions(e.target.value, e.target.selectionStart);
+          }}
+          onKeyUp={e => {
+            // Arrow / Home / End move the caret without firing onChange. Drop
+            // the popup in that case so it doesn't drift off a stale word.
+            if (['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown', 'Home', 'End'].includes(e.key)) {
+              if (suggestions) setSuggestions(null);
+            }
+          }}
+          onMouseDown={() => { if (suggestions) setSuggestions(null); }}
+          onBlur={() => {
+            // Defer so a click on the popup row (which calls acceptSuggestion)
+            // gets a chance to run before we tear the popup down on blur.
+            setTimeout(() => setSuggestions(null), 100);
           }}
           onKeyDown={handleKeyDown}
           style={s.textarea}
           spellCheck={false}
           autoComplete="off"
         />
+        {suggestions && (
+          <SuggestionPopup
+            items={suggestions.items}
+            selectedIndex={suggestions.selectedIndex}
+            onHover={(i) => setSuggestions(s => s ? { ...s, selectedIndex: i } : s)}
+            onAccept={(item) => acceptSuggestion(item)}
+            position={suggestions.position}
+            t={t}
+          />
+        )}
       </div>
     </div>
   );

--- a/src/components/SuggestionPopup.tsx
+++ b/src/components/SuggestionPopup.tsx
@@ -1,0 +1,127 @@
+import { useEffect, useRef } from 'react';
+import type { CSSProperties } from 'react';
+import type { Theme } from '../theme';
+
+export type SuggestionKind = 'column' | 'table' | 'alias' | 'keyword';
+
+export interface Suggestion {
+  /** Identifier inserted into the editor when accepted. */
+  insert: string;
+  /** Text shown as the primary line in the list. */
+  label: string;
+  /** Secondary line (e.g. table name for a column, or column type). */
+  detail?: string;
+  kind: SuggestionKind;
+}
+
+interface SuggestionPopupProps {
+  items: Suggestion[];
+  selectedIndex: number;
+  onHover: (index: number) => void;
+  onAccept: (item: Suggestion) => void;
+  /** Position relative to the popup's positioned ancestor. */
+  position: { left: number; top: number };
+  t: Theme;
+}
+
+const MAX_VISIBLE = 8;
+const ITEM_HEIGHT = 32;
+
+export function SuggestionPopup({ items, selectedIndex, onHover, onAccept, position, t }: SuggestionPopupProps) {
+  const listRef = useRef<HTMLDivElement>(null);
+
+  // Keep the highlighted row in view when arrow keys walk past the visible window.
+  useEffect(() => {
+    const list = listRef.current;
+    if (!list) return;
+    const row = list.children[selectedIndex] as HTMLElement | undefined;
+    row?.scrollIntoView({ block: 'nearest' });
+  }, [selectedIndex]);
+
+  if (items.length === 0) return null;
+
+  const s = {
+    root: {
+      position: 'absolute', left: position.left, top: position.top, zIndex: 50,
+      background: t.bgElevated, border: `1px solid ${t.border}`, borderRadius: 5,
+      boxShadow: t.shadowLg, overflow: 'hidden',
+      fontFamily: '"IBM Plex Sans", sans-serif', fontSize: 12, minWidth: 220,
+    } as CSSProperties,
+    list: {
+      maxHeight: ITEM_HEIGHT * MAX_VISIBLE, overflowY: 'auto',
+    } as CSSProperties,
+    row: (active: boolean): CSSProperties => ({
+      display: 'flex', alignItems: 'center', gap: 8,
+      padding: '6px 10px',
+      height: ITEM_HEIGHT, boxSizing: 'border-box',
+      background: active ? t.bgSelected : 'transparent',
+      borderLeft: active ? `2px solid ${t.accent}` : `2px solid transparent`,
+      cursor: 'pointer',
+    }),
+    label: (kind: SuggestionKind): CSSProperties => ({
+      color: kind === 'keyword' ? t.sqlKeyword : t.textPrimary,
+      fontFamily: '"JetBrains Mono", monospace',
+      fontWeight: kind === 'keyword' ? 600 : 400,
+    }),
+    detail: { color: t.textMuted, fontSize: 11, marginLeft: 'auto', maxWidth: 180, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' } as CSSProperties,
+    iconWrap: { width: 14, height: 14, display: 'inline-flex', alignItems: 'center', justifyContent: 'center', color: t.textMuted, flexShrink: 0 } as CSSProperties,
+    footer: { display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '4px 10px', borderTop: `1px solid ${t.borderSubtle}`, background: t.bgToolbar, color: t.textMuted, fontSize: 10 } as CSSProperties,
+  };
+
+  return (
+    <div style={s.root} role="listbox" onMouseDown={(e) => e.preventDefault()}>
+      <div ref={listRef} style={s.list}>
+        {items.map((item, i) => (
+          <div
+            key={`${item.kind}:${item.insert}:${i}`}
+            role="option"
+            aria-selected={i === selectedIndex}
+            style={s.row(i === selectedIndex)}
+            onMouseEnter={() => onHover(i)}
+            onMouseDown={(e) => { e.preventDefault(); onAccept(item); }}
+          >
+            <span style={s.iconWrap}><KindIcon kind={item.kind} /></span>
+            <span style={s.label(item.kind)}>{item.label}</span>
+            {item.detail && <span style={s.detail}>{item.detail}</span>}
+          </div>
+        ))}
+      </div>
+      <div style={s.footer}>
+        <span>↑↓ navigate</span>
+        <span>Tab / Enter accept</span>
+        <span>Esc close</span>
+      </div>
+    </div>
+  );
+}
+
+function KindIcon({ kind }: { kind: SuggestionKind }) {
+  if (kind === 'keyword') {
+    // Square brackets evoke the angle-bracket / keyword shorthand used in syntax docs.
+    return (
+      <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <polyline points="9 4 4 4 4 20 9 20"/><polyline points="15 4 20 4 20 20 15 20"/>
+      </svg>
+    );
+  }
+  if (kind === 'table') {
+    return (
+      <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <rect x="3" y="4" width="18" height="16" rx="2"/><line x1="3" y1="10" x2="21" y2="10"/><line x1="9" y1="4" x2="9" y2="20"/>
+      </svg>
+    );
+  }
+  if (kind === 'alias') {
+    return (
+      <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <path d="M4 7h16M4 12h10M4 17h16"/>
+      </svg>
+    );
+  }
+  // column
+  return (
+    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <rect x="4" y="4" width="6" height="16" rx="1"/><rect x="14" y="4" width="6" height="16" rx="1"/>
+    </svg>
+  );
+}

--- a/src/lib/caretPosition.ts
+++ b/src/lib/caretPosition.ts
@@ -1,0 +1,87 @@
+// Measures the pixel coordinates of the caret inside a textarea by rendering
+// a hidden mirror DIV with the same content + computed styles, terminating at
+// the caret with a marker span. The marker's offset is the caret's offset.
+//
+// Based on the well-known textarea-caret-position trick. The list of style
+// properties below is the minimum that affects glyph layout — font, padding,
+// border, sizing, and the few quirky bits like `tab-size` and `direction`.
+// Don't add unrelated styles (e.g. `color`); irrelevant copying just bloats
+// the temporary DOM.
+
+const STYLE_PROPS = [
+  'direction',
+  'boxSizing',
+  'width',
+  'height',
+  'overflowX',
+  'overflowY',
+  'borderTopWidth', 'borderRightWidth', 'borderBottomWidth', 'borderLeftWidth',
+  'borderStyle',
+  'paddingTop', 'paddingRight', 'paddingBottom', 'paddingLeft',
+  'fontStyle', 'fontVariant', 'fontWeight', 'fontStretch',
+  'fontSize', 'fontSizeAdjust', 'lineHeight', 'fontFamily',
+  'textAlign', 'textTransform', 'textIndent', 'textDecoration',
+  'letterSpacing', 'wordSpacing',
+  'tabSize',
+  'whiteSpace',
+] as const;
+
+export interface CaretCoordinates {
+  /** Caret x relative to the textarea's content box (i.e. inside its padding). */
+  left: number;
+  /** Caret y of the *top* of the line containing the caret. */
+  top: number;
+  /** Line-box height in CSS pixels (= line-height). */
+  height: number;
+}
+
+export function getCaretCoordinates(
+  el: HTMLTextAreaElement,
+  position: number,
+): CaretCoordinates {
+  const doc = el.ownerDocument;
+  const win = doc.defaultView ?? window;
+
+  const mirror = doc.createElement('div');
+  mirror.id = 'helix-caret-mirror';
+  const style = mirror.style;
+
+  // Take the textarea offscreen but keep it in-flow so width / borders measure
+  // the same as the original. Visibility hidden (not display:none) is required
+  // for layout to actually happen.
+  style.whiteSpace = 'pre-wrap';
+  style.wordWrap = 'break-word';
+  style.position = 'absolute';
+  style.visibility = 'hidden';
+  style.top = '0';
+  style.left = '-9999px';
+
+  const computed = win.getComputedStyle(el);
+  for (const prop of STYLE_PROPS) {
+    // Some props are read-only in CSSStyleDeclaration's typed surface; cast to
+    // any to assign. Setting an empty value (computed returns "") is a no-op.
+    (style as unknown as Record<string, string>)[prop] = computed[prop as never] as unknown as string;
+  }
+
+  // Firefox keeps overflowX/Y as 'visible' on a textarea — but it scrolls the
+  // contents anyway. Use 'auto' to match what the user actually sees.
+  if (style.overflowX === 'visible') style.overflowX = 'auto';
+  if (style.overflowY === 'visible') style.overflowY = 'auto';
+
+  mirror.textContent = el.value.substring(0, position);
+
+  // The marker is what we measure. Use a zero-width-joiner inside so the span
+  // has a non-zero height even at the start of an empty line.
+  const marker = doc.createElement('span');
+  marker.textContent = el.value.substring(position) || '.';
+  mirror.appendChild(marker);
+
+  doc.body.appendChild(mirror);
+  const coords: CaretCoordinates = {
+    left: marker.offsetLeft + parseInt(computed.borderLeftWidth, 10),
+    top: marker.offsetTop + parseInt(computed.borderTopWidth, 10),
+    height: parseInt(computed.lineHeight, 10) || parseInt(computed.fontSize, 10) * 1.4,
+  };
+  doc.body.removeChild(mirror);
+  return coords;
+}

--- a/src/lib/sqlContext.test.ts
+++ b/src/lib/sqlContext.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect } from 'vitest';
+import { extractTableRefs, contextAtCaret, expectedSlot } from './sqlContext';
+
+describe('extractTableRefs', () => {
+  it('returns a single bare table with table-name fallback alias', () => {
+    expect(extractTableRefs('SELECT * FROM users')).toEqual([
+      { table: 'users', alias: 'users' },
+    ]);
+  });
+
+  it('reads an implicit alias (no AS keyword)', () => {
+    expect(extractTableRefs('SELECT u.id FROM users u WHERE u.id = 1')).toEqual([
+      { table: 'users', alias: 'u' },
+    ]);
+  });
+
+  it('reads an explicit AS alias', () => {
+    expect(extractTableRefs('SELECT * FROM users AS u')).toEqual([
+      { table: 'users', alias: 'u' },
+    ]);
+  });
+
+  it('strips schema qualifier and keeps the table name', () => {
+    expect(extractTableRefs('SELECT * FROM `db`.`users` u')).toEqual([
+      { table: 'users', alias: 'u' },
+    ]);
+  });
+
+  it('unquotes backtick / double-quote / bracket identifiers', () => {
+    expect(extractTableRefs('SELECT * FROM `users` `u`')).toEqual([
+      { table: 'users', alias: 'u' },
+    ]);
+    expect(extractTableRefs('SELECT * FROM "users" "u"')).toEqual([
+      { table: 'users', alias: 'u' },
+    ]);
+    expect(extractTableRefs('SELECT * FROM [users] [u]')).toEqual([
+      { table: 'users', alias: 'u' },
+    ]);
+  });
+
+  it('captures every JOIN variant alongside the FROM', () => {
+    const sql = `
+      SELECT *
+      FROM users u
+      INNER JOIN orders o ON o.user_id = u.id
+      LEFT JOIN payments AS p ON p.order_id = o.id
+      CROSS JOIN coupons c
+    `;
+    expect(extractTableRefs(sql)).toEqual([
+      { table: 'users', alias: 'u' },
+      { table: 'orders', alias: 'o' },
+      { table: 'payments', alias: 'p' },
+      { table: 'coupons', alias: 'c' },
+    ]);
+  });
+
+  it('treats a SQL keyword in the alias slot as the next clause, not an alias', () => {
+    // The bare word `WHERE` after `users` is the WHERE clause keyword — it
+    // must not be captured as the table's alias.
+    expect(extractTableRefs('SELECT * FROM users WHERE id = 1')).toEqual([
+      { table: 'users', alias: 'users' },
+    ]);
+    expect(extractTableRefs('SELECT * FROM users LEFT JOIN orders ON true')).toEqual([
+      { table: 'users', alias: 'users' },
+      { table: 'orders', alias: 'orders' },
+    ]);
+  });
+
+  it('ignores FROM / JOIN tokens that appear inside string literals or comments', () => {
+    expect(extractTableRefs("SELECT 'FROM stash' FROM real_table")).toEqual([
+      { table: 'real_table', alias: 'real_table' },
+    ]);
+    expect(extractTableRefs('SELECT * /* FROM commented_out */ FROM real_table')).toEqual([
+      { table: 'real_table', alias: 'real_table' },
+    ]);
+    expect(extractTableRefs('-- FROM line_comment\nSELECT * FROM real_table')).toEqual([
+      { table: 'real_table', alias: 'real_table' },
+    ]);
+  });
+
+  it('is case-insensitive on the FROM / JOIN keywords', () => {
+    expect(extractTableRefs('select * from users u left join orders o on true')).toEqual([
+      { table: 'users', alias: 'u' },
+      { table: 'orders', alias: 'o' },
+    ]);
+  });
+
+  it('returns [] when there is no FROM clause', () => {
+    expect(extractTableRefs('SELECT 1 + 1')).toEqual([]);
+  });
+});
+
+describe('contextAtCaret', () => {
+  it('returns null on whitespace with no identifier under the caret', () => {
+    expect(contextAtCaret('SELECT ', 7)).toBeNull();
+  });
+
+  it('captures a bare identifier prefix and its start offset', () => {
+    const text = 'SELECT use';
+    expect(contextAtCaret(text, text.length)).toEqual({
+      prefix: 'use', start: 7, qualifier: null,
+    });
+  });
+
+  it('detects a qualified prefix like `alias.col`', () => {
+    const text = 'SELECT u.na';
+    expect(contextAtCaret(text, text.length)).toEqual({
+      prefix: 'na', start: 9, qualifier: 'u',
+    });
+  });
+
+  it('detects a bare qualifier with empty prefix (just typed the dot)', () => {
+    const text = 'SELECT u.';
+    expect(contextAtCaret(text, text.length)).toEqual({
+      prefix: '', start: 9, qualifier: 'u',
+    });
+  });
+
+  it('unwraps a backtick-quoted qualifier', () => {
+    const text = 'SELECT `users`.id';
+    expect(contextAtCaret(text, text.length)).toMatchObject({
+      prefix: 'id', qualifier: 'users',
+    });
+  });
+});
+
+describe('expectedSlot', () => {
+  // Helper: given a string with a `|` caret marker, return the slot at that pos.
+  function slot(textWithCaret: string) {
+    const i = textWithCaret.indexOf('|');
+    const text = textWithCaret.slice(0, i) + textWithCaret.slice(i + 1);
+    const ctx = contextAtCaret(text, i);
+    if (!ctx) throw new Error('contextAtCaret returned null — fix the test fixture');
+    return expectedSlot(text, ctx.start, ctx.qualifier);
+  }
+
+  it('at the start of a query expects only statement-starter keywords', () => {
+    expect(slot('SELE|')).toEqual({ keywords: 'statement', tables: false, columns: false });
+  });
+
+  it('right after a semicolon resets to statement-starters', () => {
+    expect(slot('SELECT 1; SEL|')).toEqual({ keywords: 'statement', tables: false, columns: false });
+  });
+
+  it('directly after FROM expects tables only — no columns or keywords', () => {
+    expect(slot('SELECT * FROM us|')).toEqual({ keywords: 'none', tables: true, columns: false });
+  });
+
+  it('directly after JOIN expects tables only', () => {
+    expect(slot('SELECT * FROM a JOIN b|')).toEqual({ keywords: 'none', tables: true, columns: false });
+  });
+
+  it('after WHERE expects columns plus expression keywords', () => {
+    expect(slot('SELECT * FROM users WHERE na|')).toEqual({ keywords: 'expr', tables: false, columns: true });
+  });
+
+  it('after GROUP expects only the BY continuation keyword', () => {
+    expect(slot('SELECT * FROM users GROUP x|')).toEqual({ keywords: 'by', tables: false, columns: false });
+  });
+
+  it('a qualified prefix is always column-only — even after FROM', () => {
+    expect(slot('SELECT * FROM users u WHERE u.na|')).toEqual({ keywords: 'none', tables: false, columns: true });
+  });
+
+  it('after a closing backtick of a table name falls into the permissive any-slot', () => {
+    // Matches the bug from the screenshot — typing `wh` on a new line right
+    // after `FROM \`tbl\`` should expose clause keywords (WHERE etc.).
+    expect(slot('SELECT *\nFROM `users`\nwh|')).toEqual({ keywords: 'any', tables: true, columns: true });
+  });
+});

--- a/src/lib/sqlContext.ts
+++ b/src/lib/sqlContext.ts
@@ -1,0 +1,256 @@
+// Light-weight SQL parsing used by the editor's autocomplete. None of this is
+// a real parser — it sniffs FROM / JOIN clauses well enough to feed column
+// suggestions back to the user. False positives are fine; we'd rather suggest
+// a column from a table the user happens to be typing about than miss it.
+
+export interface SqlTableRef {
+  /** Bare table identifier as the user typed it (no quotes). */
+  table: string;
+  /** Optional alias (`FROM users u`, `FROM users AS u`); falls back to the table name. */
+  alias: string;
+}
+
+/** Strip block & line comments + single-quoted string literals so identifier
+ *  matchers inside them can't fire. Double-quoted text is intentionally left
+ *  alone — Postgres (and MySQL in ANSI_QUOTES mode) uses `"users"` as an
+ *  identifier, and stripping it would prevent the parser from finding such
+ *  tables. The trade-off is that a Postgres double-quoted string containing
+ *  `FROM` could yield a false positive, but in practice strings use single
+ *  quotes in both dialects.
+ */
+function stripNoise(sql: string): string {
+  let out = sql.replace(/\/\*[\s\S]*?\*\//g, ' ');
+  out = out.replace(/--[^\n]*/g, ' ');
+  out = out.replace(/'(?:[^'\\]|\\.|'')*'/g, s => ' '.repeat(s.length));
+  return out;
+}
+
+// backtick-quoted, double-quoted, bracket-quoted, or bare identifier.
+// Each branch contributes one capturing group → four total per IDENT use.
+const IDENT = '(?:`([^`]+)`|"([^"]+)"|\\[([^\\]]+)\\]|([A-Za-z_][A-Za-z0-9_$]*))';
+
+function unquote(raw: string): string {
+  if (!raw) return raw;
+  const first = raw[0];
+  if (first === '`' || first === '"') return raw.slice(1, -1);
+  if (first === '[') return raw.slice(1, -1);
+  return raw;
+}
+
+const SQL_KEYWORDS = new Set([
+  'select', 'from', 'where', 'and', 'or', 'not', 'in', 'is', 'null', 'on',
+  'join', 'inner', 'outer', 'left', 'right', 'cross', 'full', 'natural',
+  'using', 'group', 'order', 'by', 'having', 'limit', 'offset', 'as',
+  'lateral', 'union', 'intersect', 'except', 'with', 'distinct', 'all',
+  'asc', 'desc', 'true', 'false', 'between', 'like', 'rlike', 'regexp',
+  'case', 'when', 'then', 'else', 'end', 'set', 'values', 'into', 'partition',
+  'window', 'over',
+]);
+
+/**
+ * Parse `FROM ... [WHERE | GROUP | ORDER | LIMIT | ...]` and any `JOIN`
+ * clauses, returning the referenced tables with their effective aliases.
+ *
+ * Examples handled:
+ *   FROM users
+ *   FROM users u
+ *   FROM users AS u
+ *   FROM `db`.`users` u
+ *   FROM users u JOIN orders AS o ON u.id = o.user_id
+ *   LEFT JOIN `pivot` p ON ...
+ */
+export function extractTableRefs(sql: string): SqlTableRef[] {
+  const clean = stripNoise(sql);
+  const refs: SqlTableRef[] = [];
+
+  // Match `FROM` or any flavour of `JOIN` followed by a (possibly schema-
+  // qualified) table identifier and an optional alias. We deliberately don't
+  // stop at sub-clauses — JOIN may itself follow another JOIN with no break,
+  // and the global regex catches each one independently.
+  //
+  // The schema-qualifier branch is `IDENT . IDENT`; we keep only the table
+  // (second part) because the suggestion list operates on the active schema's
+  // table set.
+  const re = new RegExp(
+    '(?:\\bFROM\\b|\\bJOIN\\b)\\s+' +
+    // optional schema. captured but unused; we only need the table
+    '(?:' + IDENT + '\\s*\\.\\s*)?' +
+    IDENT +
+    // optional alias: `AS foo` | `foo` (bare). Bare alias must not be a SQL keyword.
+    '(?:\\s+(?:AS\\s+)?' + IDENT + ')?',
+    'gi',
+  );
+
+  // Each IDENT contributes 4 capturing groups (backtick / double-quote /
+  // bracket / bare). With schema + table + alias that's 12 groups total.
+  // Indices in the match array: 1-4 = schema (unused), 5-8 = table, 9-12 = alias.
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(clean)) !== null) {
+    const tableRaw = m[5] || m[6] || m[7] || m[8];
+    if (!tableRaw) continue;
+    const table = unquote(tableRaw);
+    const aliasRaw = m[9] || m[10] || m[11] || m[12];
+    let alias = aliasRaw ? unquote(aliasRaw) : table;
+
+    // A bare-word "alias" that turns out to be a keyword like FROM/WHERE/ON is
+    // really the next clause, not an alias. Drop it and use the table name.
+    if (!aliasRaw?.startsWith('`') && !aliasRaw?.startsWith('"') && !aliasRaw?.startsWith('[')
+        && aliasRaw && SQL_KEYWORDS.has(aliasRaw.toLowerCase())) {
+      alias = table;
+    }
+    refs.push({ table, alias });
+  }
+
+  return refs;
+}
+
+/** What kinds of identifiers / keywords belong in a given caret position. */
+export interface ExpectedSlot {
+  /** Which group of keywords (if any) is appropriate at this position. */
+  keywords: 'none' | 'statement' | 'expr' | 'by' | 'any';
+  /** Whether the position naturally accepts a table name (FROM / JOIN / UPDATE / INTO …). */
+  tables: boolean;
+  /** Whether the position naturally accepts a column reference. */
+  columns: boolean;
+}
+
+interface PrevToken {
+  /** Identifier characters immediately before the prefix, or '' when none. */
+  word: string;
+  /** Single punctuation char immediately before the prefix, or null. */
+  punct: string | null;
+}
+
+function previousToken(text: string, start: number): PrevToken {
+  let i = start;
+  // Skip the dot we already consumed for qualified prefixes — callers pass the
+  // prefix's start, which is *after* the `.`. We still want to look past the
+  // qualifier to see what came before it.
+  while (i > 0 && /\s/.test(text[i - 1])) i--;
+  if (i === 0) return { word: '', punct: null };
+
+  // A quoted identifier (`tbl` / "tbl" / [tbl]) ends with a closing quote.
+  // Walk back to the opening quote and treat the enclosed text as a bare word
+  // so callers reading FROM/JOIN context don't bail at the closing punctuation.
+  const tail = text[i - 1];
+  if (tail === '`' || tail === '"' || tail === ']') {
+    const open = tail === ']' ? '[' : tail;
+    let j = i - 2;
+    while (j >= 0 && text[j] !== open) j--;
+    if (j >= 0) return { word: text.slice(j + 1, i - 1), punct: null };
+  }
+
+  const ch = text[i - 1];
+  if (/[(),.=<>!+\-*/%;]/.test(ch)) return { word: '', punct: ch };
+  let j = i;
+  while (j > 0 && /[A-Za-z0-9_]/.test(text[j - 1])) j--;
+  return { word: text.slice(j, i), punct: null };
+}
+
+const TABLE_INTRODUCERS = new Set([
+  'from', 'join', 'into', 'update', 'table', 'describe', 'desc', 'truncate',
+]);
+const EXPR_INTRODUCERS = new Set([
+  'select', 'where', 'on', 'and', 'or', 'having', 'when', 'then', 'else',
+  'by', 'distinct', 'in', 'like', 'between', 'using', 'set',
+]);
+const EXPR_PUNCT = new Set(['(', ',', '=', '<', '>', '+', '-', '*', '/', '%']);
+const HALF_KEYWORDS = new Set(['group', 'order']); // expect "BY" next
+
+/**
+ * Decide what suggestions belong at the caret. Used to suppress column names
+ * when the user is clearly typing a statement-starter (e.g. `SEL|`) and to
+ * suppress keywords when only an identifier makes sense (e.g. `FROM |`).
+ */
+export function expectedSlot(text: string, prefixStart: number, qualifier: string | null): ExpectedSlot {
+  // Qualified prefix (`alias.col|`) is always column-only — punctuation context
+  // before the alias is irrelevant.
+  if (qualifier) return { keywords: 'none', tables: false, columns: true };
+
+  const prev = previousToken(text, prefixStart);
+  const w = prev.word.toLowerCase();
+
+  // Top of file or just after a statement separator → statement-starters only.
+  if ((w === '' && prev.punct === null) || prev.punct === ';') {
+    return { keywords: 'statement', tables: false, columns: false };
+  }
+  if (TABLE_INTRODUCERS.has(w)) {
+    return { keywords: 'none', tables: true, columns: false };
+  }
+  if (HALF_KEYWORDS.has(w)) {
+    return { keywords: 'by', tables: false, columns: false };
+  }
+  if (EXPR_INTRODUCERS.has(w) || (prev.punct && EXPR_PUNCT.has(prev.punct))) {
+    return { keywords: 'expr', tables: false, columns: true };
+  }
+  // Unknown context — permissive so we never lock the user out of a useful hint.
+  return { keywords: 'any', tables: true, columns: true };
+}
+
+export interface ContextAtCaret {
+  /** What the user is typing — the partial identifier before the caret. */
+  prefix: string;
+  /** Caret index of where `prefix` started in the source (for replacement). */
+  start: number;
+  /** When set, the prefix is qualified — e.g. user typed `u.foo` and the caret
+   *  is on `foo`; suggestions should be restricted to columns of the table
+   *  that `u` resolves to. */
+  qualifier: string | null;
+}
+
+/**
+ * SQL keyword sets surfaced as autocomplete suggestions, grouped by where
+ * they're allowed. Order within each group reflects rough frequency so the
+ * popup leads with the most common pick.
+ */
+export const KEYWORD_GROUPS = {
+  statement: [
+    'SELECT', 'INSERT INTO', 'UPDATE', 'DELETE FROM', 'CREATE TABLE',
+    'ALTER TABLE', 'DROP TABLE', 'TRUNCATE TABLE', 'SHOW TABLES', 'DESCRIBE',
+    'EXPLAIN', 'WITH', 'USE', 'BEGIN', 'COMMIT', 'ROLLBACK',
+  ],
+  // Things that read naturally after a column / value in an expression.
+  expr: [
+    'AND', 'OR', 'NOT', 'IS NULL', 'IS NOT NULL', 'IN', 'NOT IN', 'LIKE',
+    'NOT LIKE', 'BETWEEN', 'EXISTS', 'CASE', 'WHEN', 'THEN', 'ELSE', 'END',
+    'DISTINCT', 'NULL', 'TRUE', 'FALSE',
+  ],
+  by: ['BY'],
+  // Clause keywords appropriate after a complete table/expression — used in
+  // the 'any' fallback alongside columns/tables.
+  clauses: [
+    'WHERE', 'GROUP BY', 'ORDER BY', 'HAVING', 'LIMIT', 'OFFSET', 'JOIN',
+    'LEFT JOIN', 'INNER JOIN', 'ON', 'AS', 'UNION', 'INTERSECT', 'EXCEPT',
+  ],
+} as const;
+
+/**
+ * Inspect the text up to the caret and decide what the user is editing.
+ * Returns null when the caret isn't inside an identifier (e.g. just after a
+ * space or punctuation other than `.`), so the caller can close the popup.
+ */
+export function contextAtCaret(text: string, caret: number): ContextAtCaret | null {
+  if (caret < 0 || caret > text.length) return null;
+
+  // Walk backwards to find the start of the current identifier prefix.
+  let i = caret;
+  while (i > 0 && /[A-Za-z0-9_$]/.test(text[i - 1])) i--;
+  const prefix = text.slice(i, caret);
+  const start = i;
+
+  // Look at the character before the prefix. A `.` means the prefix is
+  // qualified — back up further to find the qualifier identifier.
+  let qualifier: string | null = null;
+  if (i > 0 && text[i - 1] === '.') {
+    let j = i - 1;
+    while (j > 0 && /[A-Za-z0-9_$`"\][]/.test(text[j - 1])) j--;
+    const qRaw = text.slice(j, i - 1).trim();
+    qualifier = qRaw ? unquote(qRaw) : null;
+  }
+
+  // Empty prefix + no qualifier → user has nothing for us to filter on.
+  // Returning null keeps the popup closed; the caller can still call us again
+  // once a character is typed.
+  if (!prefix && !qualifier) return null;
+  return { prefix, start, qualifier };
+}


### PR DESCRIPTION
Closes #171.

## Summary
- The query editor now offers a context-aware suggestion popup as the user types. Anchors at the caret using a textarea-mirror to measure caret coordinates, so it tracks line / column wrapping, scroll, padding, and font without needing a heavier editor like Monaco.
- The popup classifies the slot at the caret before deciding what to suggest. Each branch is intentionally restrictive so the list reads "useful" rather than "everything in the schema":
  - **Start of statement / after `;`** → statement-starter keywords only (`SELECT`, `INSERT INTO`, `UPDATE`, `DELETE FROM`, `CREATE TABLE`, `ALTER TABLE`, `DROP TABLE`, `EXPLAIN`, `WITH`, `USE`, `BEGIN`, `COMMIT`, …).
  - **After `FROM` / `JOIN` / `INTO` / `UPDATE` / `TRUNCATE` / `DESCRIBE`** → table names only.
  - **After `WHERE` / `SELECT` / `ON` / `AND` / `OR` / `HAVING` / `,` / `=` / `<` / `>` / `(` / etc.** → columns of every table in the `FROM`/`JOIN` scope, mixed with expression keywords (`AND`, `OR`, `IS NULL`, `IN`, `LIKE`, `BETWEEN`, `DISTINCT`, `NULL`, `TRUE`, `FALSE`, `CASE`/`WHEN`/`THEN`/`ELSE`/`END`).
  - **After `GROUP` / `ORDER`** → `BY` only.
  - **Qualified prefix (`u.col`)** → columns of the table that `u` resolves to (alias-first, table-name fallback), bypassing slot inspection.
  - **Permissive fallback** (e.g. typing `wh` on a new line after `FROM \`tbl\``) → clause keywords like `WHERE`, `GROUP BY`, `ORDER BY`, `HAVING`, `LIMIT`, `JOIN`.
- Aliases are surfaced too — typing `o` after `FROM users u JOIN orders o ON …` shows `o` as an alias hint with its underlying table.
- Keyword rows are coloured with the editor's `sqlKeyword` theme token and rendered bold so they stand out from column/table identifiers. Each suggestion kind also has its own icon (square brackets for keywords, table grid, columns, list-lines for aliases).
- Keyboard: `↑ / ↓` navigate, `Tab` or `Enter` accept, `Esc` closes. Mouse hover updates the highlight; click accepts. Caret-moving keys (arrows / Home / End) and `mousedown` inside the textarea close the popup so it doesn't drift off a stale word. `onBlur` closes with a small delay so popup clicks still register.
- The FROM/JOIN parser intentionally **masks the prefix region being typed** before scanning refs. Without that, a partially-typed identifier directly after the FROM clause would get captured as an alias (so typing `wh` on a new line after `FROM users` previously made the parser think `wh` is the alias of `users`).
- MQL connections skip autocomplete entirely.

## Test plan
- [x] `npx tsc -b` — clean.
- [x] `npm test` — 76/76 pass (23 new tests in \`src/lib/sqlContext.test.ts\` covering the FROM parser, the caret-context detector, and the slot classifier; existing 53 untouched).
- [x] \`npm run build\` — succeeds.
- [x] Manual against a real MySQL:
  - Typing \`SEL\` at the top of a query → \`SELECT\` is the first item.
  - Typing \`us\` after \`FROM \` → table list filtered to those containing \`us\`.
  - Typing \`u.\` after \`FROM users u\` → user columns only.
  - Typing \`wh\` on a new line after \`FROM \`fi_transaction\`\` → \`WHERE\` leads the list, no spurious alias suggestion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)