### PR TITLE
fix: keep query editor toolbar visible with large queries (#173)

### DIFF
--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -86,6 +86,7 @@ export function QueryEditor({
 }: QueryEditorProps) {
   const isMql = queryMode === 'mql';
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const lineNumsRef = useRef<HTMLDivElement>(null);
 
   const [historyOpen, setHistoryOpen] = useState(false);
   const historyAnchorRef = useRef<HTMLDivElement>(null);
@@ -492,7 +493,7 @@ export function QueryEditor({
   };
 
   const s = {
-    root: { display: 'flex', flexDirection: 'column', background: t.bgSurface, borderBottom: `1px solid ${t.border}` } as CSSProperties,
+    root: { flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column', background: t.bgSurface, borderBottom: `1px solid ${t.border}` } as CSSProperties,
     toolbar: { display: 'flex', alignItems: 'center', gap: 2, padding: '5px 10px', borderBottom: `1px solid ${t.border}`, flexShrink: 0, background: t.bgToolbar } as CSSProperties,
     runBtn: { display: 'flex', alignItems: 'center', gap: 6, height: 28, padding: '0 12px', background: t.accent, color: t.textInverse, border: 'none', borderRadius: 5, fontSize: 12, fontWeight: 600, fontFamily: '"IBM Plex Sans", sans-serif', cursor: 'pointer' } as CSSProperties,
     explainBtn: { display: 'flex', alignItems: 'center', gap: 6, height: 28, padding: '0 10px', background: t.bgElevated, color: t.textPrimary, border: `1px solid ${t.border}`, borderRadius: 5, fontSize: 12, fontWeight: 500, fontFamily: '"IBM Plex Sans", sans-serif', cursor: 'pointer' } as CSSProperties,
@@ -908,7 +909,7 @@ export function QueryEditor({
         </div>
       )}
       <div style={{ ...s.editorWrap, position: 'relative' }}>
-        <div style={s.lineNums} aria-hidden="true">
+        <div ref={lineNumsRef} style={s.lineNums} aria-hidden="true">
           {value.split('\n').map((_, i) => (
             <div key={i} style={s.lineNum}>{i + 1}</div>
           ))}
@@ -932,6 +933,11 @@ export function QueryEditor({
             }
           }}
           onMouseDown={() => { if (suggestions) setSuggestions(null); }}
+          onScroll={e => {
+            // Keep the line-number gutter aligned with the textarea now that
+            // the textarea scrolls internally instead of the whole editor.
+            if (lineNumsRef.current) lineNumsRef.current.scrollTop = e.currentTarget.scrollTop;
+          }}
           onBlur={() => {
             // Defer so a click on the popup row (which calls acceptSuggestion)
             // gets a chance to run before we tear the popup down on blur.


### PR DESCRIPTION
## Problem

Closes #173.

When a query is tall, the editor toolbar (Run / Explain / Format buttons) scrolls out of view, so users can't trigger actions while at the bottom of a large query.

![issue](https://github.com/user-attachments/assets/dc8e426c-5fda-4df8-a308-12e69b389eba)

## Root cause

`QueryEditor`'s root container is a flex column but had **no height constraint**. Its parent in `App.tsx` is a fixed `flex: 0 0 240px` box with `overflow: hidden`. Because the root defaulted to `flex: 0 1 auto` (and flex items have `min-height: auto`, which prevents shrinking below content), a tall query grew the whole editor past 240px. Focusing the textarea near the bottom then made the browser scroll the `overflow:hidden` parent to reveal the caret — dragging the pinned toolbar off the top of the viewport. The textarea's own `overflowY: auto` never engaged because the textarea was never height-bounded.

## Fix

- Add `flex: 1; min-height: 0` to the editor root so it fills its fixed-height parent. The bounded `editorWrap` now constrains the textarea, whose existing `overflowY: auto` scrolls the query **internally** while the toolbar (`flex-shrink: 0`) stays pinned and always reachable.
- Sync the line-number gutter's `scrollTop` to the textarea on scroll. Previously the gutter and text scrolled together as one unit via the parent; now that the textarea scrolls on its own, this keeps line numbers aligned with the text.

## Testing

- `tsc --noEmit` passes; no new lint errors in the edited file; all 76 unit tests pass.
- Manual: paste a long query, scroll to the bottom — the Run/Explain toolbar stays fixed at the top and line numbers remain aligned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)