### PR TITLE
feat: per-query timeout that cancels over-running queries (#22)

### DIFF
--- a/server/src/drivers/interface.ts
+++ b/server/src/drivers/interface.ts
@@ -84,13 +84,19 @@ export interface DbDriver {
    * accept a MQL request object. Routes branch on this to validate the body shape.
    */
   readonly queryMode: 'sql' | 'mql';
-  /** Run a query, optionally switching schema first (atomically on one connection). */
-  query(sql: string, params?: unknown[], schema?: string): Promise<QueryResult>;
+  /**
+   * Run a query, optionally switching schema first (atomically on one connection).
+   * When `timeoutMs` is set the driver cancels the statement on the server after
+   * that many ms (MySQL `KILL QUERY`, Postgres `pg_cancel_backend`, MongoDB
+   * `maxTimeMS`) and rejects with a `transient` DriverError.
+   */
+  query(sql: string, params?: unknown[], schema?: string, timeoutMs?: number): Promise<QueryResult>;
   /**
    * Run one or more semicolon-separated statements and return a result per statement.
-   * Implemented by sql-mode drivers; mql-mode drivers can omit it.
+   * Implemented by sql-mode drivers; mql-mode drivers can omit it. `timeoutMs` has
+   * the same cancel-on-deadline semantics as {@link query}.
    */
-  queryAll?(sql: string, schema?: string): Promise<QueryResult[]>;
+  queryAll?(sql: string, schema?: string, timeoutMs?: number): Promise<QueryResult[]>;
   getSchemas(): Promise<string[]>;
   getSchema(schema: string): Promise<SchemaInfo>;
   /** Targeted lookup for a single table — returns null if it doesn't exist. */

--- a/server/src/drivers/mongodb.test.ts
+++ b/server/src/drivers/mongodb.test.ts
@@ -235,7 +235,7 @@ describe('MongoDBDriver.query – find', () => {
     );
     expect(mockClient.db).toHaveBeenCalledWith('app');
     expect(mockDb.collection).toHaveBeenCalledWith('users');
-    expect(mockCollection.find).toHaveBeenCalledWith({ active: true });
+    expect(mockCollection.find).toHaveBeenCalledWith({ active: true }, {});
     expect(r.rows).toEqual([
       { _id: '507f1f77bcf86cd799439011', name: 'Alice', when: '2024-01-02 03:04:05' },
     ]);
@@ -402,7 +402,7 @@ describe('MongoDBDriver.query – findOne / aggregate / count', () => {
     );
     expect(mockCollection.aggregate).toHaveBeenCalledWith([
       { $group: { _id: '$status', n: { $sum: 1 } } },
-    ]);
+    ], {});
     expect(r.rows).toEqual([{ _id: 'A', n: 2 }]);
   });
 
@@ -411,7 +411,7 @@ describe('MongoDBDriver.query – findOne / aggregate / count', () => {
     const r = await makeDriver().query(
       JSON.stringify({ collection: 'users', operation: 'count', filter: { active: true } }),
     );
-    expect(mockCollection.countDocuments).toHaveBeenCalledWith({ active: true });
+    expect(mockCollection.countDocuments).toHaveBeenCalledWith({ active: true }, {});
     expect(r.rows).toEqual([{ count: 42 }]);
   });
 });

--- a/server/src/drivers/mongodb.ts
+++ b/server/src/drivers/mongodb.ts
@@ -1,6 +1,7 @@
 import { MongoClient, ObjectId, MongoNetworkError, MongoServerSelectionError, MongoParseError } from 'mongodb';
 import type { Db, Document } from 'mongodb';
 import { DriverError } from './interface.js';
+import { timeoutError } from './timeout.js';
 import type {
   DbDriver,
   ConnectionConfig,
@@ -253,7 +254,15 @@ export class MongoDBDriver implements DbDriver {
     }
   }
 
-  async query(sql: string, _params?: unknown[], schema?: string): Promise<QueryResult> {
+  async query(sql: string, _params?: unknown[], schema?: string, timeoutMs?: number): Promise<QueryResult> {
+    // MongoDB has no out-of-band "kill query" like SQL's KILL/pg_cancel_backend;
+    // `maxTimeMS` is the idiomatic equivalent — the server aborts the operation
+    // itself once the deadline passes. Only the read operations honour it; the
+    // single-document writes return promptly.
+    const maxTimeMS = timeoutMs && timeoutMs > 0 ? timeoutMs : undefined;
+    // Spread into the read operations' options; empty (no `maxTimeMS` key) when
+    // no timeout is armed, so the deadline is opt-in per query.
+    const readOpts = maxTimeMS ? { maxTimeMS } : {};
     try {
       await this.ensureConnected();
       const req = parseRequest(sql);
@@ -262,7 +271,7 @@ export class MongoDBDriver implements DbDriver {
 
       switch (req.operation) {
         case 'find': {
-          let cursor = coll.find(req.filter ?? {});
+          let cursor = coll.find(req.filter ?? {}, readOpts);
           if (req.projection) cursor = cursor.project(req.projection) as typeof cursor;
           if (req.sort) cursor = cursor.sort(req.sort);
           if (typeof req.skip === 'number') cursor = cursor.skip(req.skip);
@@ -274,15 +283,16 @@ export class MongoDBDriver implements DbDriver {
           const doc = await coll.findOne(req.filter ?? {}, {
             projection: req.projection,
             sort: req.sort as Document | undefined,
+            ...readOpts,
           });
           return this.toQueryResult(doc ? [doc] : []);
         }
         case 'aggregate': {
-          const docs = await coll.aggregate(req.pipeline ?? []).toArray();
+          const docs = await coll.aggregate(req.pipeline ?? [], readOpts).toArray();
           return this.toQueryResult(docs);
         }
         case 'count': {
-          const n = await coll.countDocuments(req.filter ?? {});
+          const n = await coll.countDocuments(req.filter ?? {}, readOpts);
           return {
             rows: [{ count: n }],
             columnMeta: [
@@ -343,6 +353,11 @@ export class MongoDBDriver implements DbDriver {
       }
     } catch (err) {
       if (err instanceof DriverError) throw err;
+      // MaxTimeMSExpired (code 50) means our deadline fired server-side; surface
+      // it with the same wording the SQL drivers use for a timed-out query.
+      if (maxTimeMS && (err as { code?: number }).code === 50) {
+        throw timeoutError(maxTimeMS, err);
+      }
       throw classifyMongoError(err);
     }
   }

--- a/server/src/drivers/mysql.ts
+++ b/server/src/drivers/mysql.ts
@@ -1,6 +1,7 @@
 import mysql from 'mysql2/promise';
 import type { RowDataPacket, FieldPacket, ResultSetHeader } from 'mysql2/promise';
 import type { DbDriver, ConnectionConfig, QueryResult, ColumnMeta, ColumnInfo, SchemaInfo, TableInfo } from './interface.js';
+import { withQueryTimeout } from './timeout.js';
 
 function buildMysqlPoolOptions(config: ConnectionConfig): mysql.PoolOptions {
   return {
@@ -162,14 +163,49 @@ export class MysqlDriver implements DbDriver {
     await this.pool.end();
   }
 
-  async query(sql: string, params?: unknown[], schema?: string): Promise<QueryResult> {
+  /**
+   * `KILL QUERY` aborts the statement running on `threadId` without dropping the
+   * connection. Issued on a separate pooled connection because the one running
+   * the timed-out query is busy. Best-effort: the statement may have already
+   * finished, or no pool slot may be free — the timeout error surfaces either way.
+   */
+  private async killQuery(threadId: number): Promise<void> {
+    let conn: mysql.PoolConnection | undefined;
+    try {
+      conn = await this.pool.getConnection();
+      await conn.query(`KILL QUERY ${threadId}`);
+    } catch {
+      /* best-effort cancel */
+    } finally {
+      conn?.release();
+    }
+  }
+
+  /**
+   * Return `conn` to the pool, but `destroy` it instead when the query timed out:
+   * the `KILL`ed statement is still draining on that socket, and a released
+   * connection could be handed to the next caller mid-interrupt with a stale
+   * result set. mysql2 opens a fresh connection on the next request.
+   */
+  private finishConnection(conn: mysql.PoolConnection, timedOut: boolean): void {
+    if (timedOut) conn.destroy();
+    else conn.release();
+  }
+
+  async query(sql: string, params?: unknown[], schema?: string, timeoutMs?: number): Promise<QueryResult> {
     const conn = await this.pool.getConnection();
+    const threadId = conn.threadId;
+    let timedOut = false;
     try {
       if (schema) {
         await conn.query(`USE \`${schema.replace(/`/g, '')}\``);
       }
 
-      const [rows, fields] = await conn.query(sql, params) as [RowDataPacket[] | ResultSetHeader, FieldPacket[]];
+      const work = conn.query(sql, params) as Promise<[RowDataPacket[] | ResultSetHeader, FieldPacket[]]>;
+      const [rows, fields] = await withQueryTimeout(work, timeoutMs, () => {
+        timedOut = true;
+        if (threadId != null) void this.killQuery(threadId);
+      });
       // With multipleStatements enabled, mysql2 returns arrays-of-arrays when
       // the SQL contains more than one statement. Internal callers (insertRow,
       // updateCell, deleteRow, …) only ever pass single statements, so flatten
@@ -182,20 +218,26 @@ export class MysqlDriver implements DbDriver {
       }
       return buildMysqlResult(rows, fields);
     } finally {
-      conn.release();
+      this.finishConnection(conn, timedOut);
     }
   }
 
-  async queryAll(sql: string, schema?: string): Promise<QueryResult[]> {
+  async queryAll(sql: string, schema?: string, timeoutMs?: number): Promise<QueryResult[]> {
     const conn = await this.pool.getConnection();
+    const threadId = conn.threadId;
+    let timedOut = false;
     try {
       if (schema) {
         await conn.query(`USE \`${schema.replace(/`/g, '')}\``);
       }
-      const [rawRows, rawFields] = await conn.query(sql) as [
+      const work = conn.query(sql) as Promise<[
         RowDataPacket[] | ResultSetHeader | (RowDataPacket[] | ResultSetHeader)[],
         FieldPacket[] | FieldPacket[][],
-      ];
+      ]>;
+      const [rawRows, rawFields] = await withQueryTimeout(work, timeoutMs, () => {
+        timedOut = true;
+        if (threadId != null) void this.killQuery(threadId);
+      });
       // Single statement: mysql2 returns the result directly. Multi-statement: it
       // returns parallel arrays — one rowset and one fields array per statement.
       const isMulti = Array.isArray(rawRows) && rawRows.length > 0 && Array.isArray((rawRows as unknown[])[0]);
@@ -206,7 +248,7 @@ export class MysqlDriver implements DbDriver {
       const fieldSets = rawFields as FieldPacket[][];
       return rowSets.map((r, i) => buildMysqlResult(r, fieldSets[i] ?? []));
     } finally {
-      conn.release();
+      this.finishConnection(conn, timedOut);
     }
   }
 

--- a/server/src/drivers/postgres.ts
+++ b/server/src/drivers/postgres.ts
@@ -1,6 +1,7 @@
 import pg from 'pg';
 import { DriverError } from './interface.js';
 import type { DbDriver, ConnectionConfig, QueryResult, ColumnMeta, ColumnInfo, SchemaInfo, TableInfo } from './interface.js';
+import { withQueryTimeout } from './timeout.js';
 
 // Return DATE / TIME / TIMESTAMP / TIMESTAMPTZ / TIMETZ as raw strings rather
 // than JS Dates. pg's default parsers route through `new Date(...)`, which
@@ -142,10 +143,29 @@ export class PostgresDriver implements DbDriver {
     await this.pool.end();
   }
 
-  async query(sql: string, params?: unknown[], schema?: string): Promise<QueryResult> {
+  /**
+   * `pg_cancel_backend` cancels the statement running on `pid` without dropping
+   * the connection. Run on a separate pooled client because the one running the
+   * timed-out query is busy. Best-effort — the timeout error surfaces regardless.
+   */
+  private async cancelBackend(pid: number): Promise<void> {
+    let client: pg.PoolClient | undefined;
+    try {
+      client = await this.pool.connect();
+      await client.query('SELECT pg_cancel_backend($1)', [pid]);
+    } catch {
+      /* best-effort cancel */
+    } finally {
+      client?.release();
+    }
+  }
+
+  async query(sql: string, params?: unknown[], schema?: string, timeoutMs?: number): Promise<QueryResult> {
     try {
       const client = await this.pool.connect();
+      const pid = (client as { processID?: number }).processID;
       let searchPathSet = false;
+      let timedOut = false;
       try {
         if (schema) {
           await client.query(`SET search_path TO ${this.escapeIdent(schema)}`);
@@ -159,7 +179,11 @@ export class PostgresDriver implements DbDriver {
           let n = 0;
           pgSql = sql.replace(/\?/g, () => `$${++n}`);
         }
-        const result = await client.query({ text: pgSql, values: params?.length ? params : undefined });
+        const work = client.query({ text: pgSql, values: params?.length ? params : undefined });
+        const result = await withQueryTimeout(work, timeoutMs, () => {
+          timedOut = true;
+          if (typeof pid === 'number') void this.cancelBackend(pid);
+        });
         // node-pg's simple query protocol returns an array of results when the SQL
         // contains multiple statements. `query()` keeps the legacy single-result
         // contract — `queryAll` is the multi-statement entry point — so collapse
@@ -167,12 +191,7 @@ export class PostgresDriver implements DbDriver {
         const single = Array.isArray(result) ? (result as pg.QueryResult[])[result.length - 1] : result;
         return buildPgResult(single);
       } finally {
-        // pg.Pool reuses clients without resetting session state, so search_path
-        // would leak to the next caller on this same client.
-        if (searchPathSet) {
-          try { await client.query('SET search_path TO DEFAULT'); } catch { /* fall through to release */ }
-        }
-        client.release();
+        await this.finishClient(client, searchPathSet, timedOut);
       }
     } catch (err) {
       if (err instanceof DriverError) throw err;
@@ -180,10 +199,12 @@ export class PostgresDriver implements DbDriver {
     }
   }
 
-  async queryAll(sql: string, schema?: string): Promise<QueryResult[]> {
+  async queryAll(sql: string, schema?: string, timeoutMs?: number): Promise<QueryResult[]> {
     try {
       const client = await this.pool.connect();
+      const pid = (client as { processID?: number }).processID;
       let searchPathSet = false;
+      let timedOut = false;
       try {
         if (schema) {
           await client.query(`SET search_path TO ${this.escapeIdent(schema)}`);
@@ -191,19 +212,38 @@ export class PostgresDriver implements DbDriver {
         }
         // Always go through the simple query protocol (no values) so multi-statement
         // SQL fans out to one result per statement.
-        const raw = await client.query(sql);
+        const work = client.query(sql);
+        const raw = await withQueryTimeout(work, timeoutMs, () => {
+          timedOut = true;
+          if (typeof pid === 'number') void this.cancelBackend(pid);
+        });
         const results = Array.isArray(raw) ? (raw as pg.QueryResult[]) : [raw];
         return results.map(buildPgResult);
       } finally {
-        if (searchPathSet) {
-          try { await client.query('SET search_path TO DEFAULT'); } catch { /* fall through to release */ }
-        }
-        client.release();
+        await this.finishClient(client, searchPathSet, timedOut);
       }
     } catch (err) {
       if (err instanceof DriverError) throw err;
       throw classifyPgError(err);
     }
+  }
+
+  /**
+   * Reset session state and return the client to the pool — but on timeout, skip
+   * the reset (it would queue behind the statement still being cancelled) and
+   * `release(true)` to discard the client so the pool never reuses it mid-cancel.
+   * pg.Pool reuses clients without resetting state, so search_path would
+   * otherwise leak to the next caller on this same client.
+   */
+  private async finishClient(client: pg.PoolClient, searchPathSet: boolean, timedOut: boolean): Promise<void> {
+    if (timedOut) {
+      client.release(true);
+      return;
+    }
+    if (searchPathSet) {
+      try { await client.query('SET search_path TO DEFAULT'); } catch { /* fall through to release */ }
+    }
+    client.release();
   }
 
   async getSchemas(): Promise<string[]> {

--- a/server/src/drivers/timeout.test.ts
+++ b/server/src/drivers/timeout.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi } from 'vitest';
+import { withQueryTimeout, timeoutError, timeoutLabel } from './timeout.js';
+import { DriverError } from './interface.js';
+
+describe('timeoutLabel', () => {
+  it.each([
+    [500, '500ms'],
+    [1000, '1s'],
+    [1500, '2s'],
+    [30_000, '30s'],
+    [60_000, '1m'],
+    [300_000, '5m'],
+    [90_000, '90s'], // not a whole number of minutes → seconds
+  ])('renders %dms as %s', (ms, label) => {
+    expect(timeoutLabel(ms)).toBe(label);
+  });
+});
+
+describe('timeoutError', () => {
+  it('is a transient DriverError carrying the timeout in its message', () => {
+    const err = timeoutError(5000);
+    expect(err).toBeInstanceOf(DriverError);
+    expect(err.errorClass).toBe('transient');
+    expect(err.message).toBe('Query cancelled: exceeded the 5s timeout.');
+  });
+});
+
+describe('withQueryTimeout', () => {
+  it('returns the work result when it settles before the deadline', async () => {
+    const onTimeout = vi.fn();
+    const result = await withQueryTimeout(Promise.resolve('ok'), 1000, onTimeout);
+    expect(result).toBe('ok');
+    expect(onTimeout).not.toHaveBeenCalled();
+  });
+
+  it('returns the work promise untouched when timeout is falsy or non-positive', async () => {
+    const onTimeout = vi.fn();
+    await expect(withQueryTimeout(Promise.resolve(1), 0, onTimeout)).resolves.toBe(1);
+    await expect(withQueryTimeout(Promise.resolve(2), undefined, onTimeout)).resolves.toBe(2);
+    await expect(withQueryTimeout(Promise.resolve(3), -5, onTimeout)).resolves.toBe(3);
+    expect(onTimeout).not.toHaveBeenCalled();
+  });
+
+  it('propagates the work rejection (not a timeout) when work fails first', async () => {
+    const onTimeout = vi.fn();
+    const boom = new Error('boom');
+    await expect(withQueryTimeout(Promise.reject(boom), 1000, onTimeout)).rejects.toBe(boom);
+    expect(onTimeout).not.toHaveBeenCalled();
+  });
+
+  it('fires onTimeout and rejects with a transient DriverError when the deadline wins', async () => {
+    vi.useFakeTimers();
+    try {
+      const onTimeout = vi.fn();
+      // A promise that never settles on its own — only the deadline can resolve the race.
+      const pending = new Promise<string>(() => {});
+      const raced = withQueryTimeout(pending, 5000, onTimeout);
+      const assertion = expect(raced).rejects.toMatchObject({
+        errorClass: 'transient',
+        message: 'Query cancelled: exceeded the 5s timeout.',
+      });
+      await vi.advanceTimersByTimeAsync(5000);
+      await assertion;
+      expect(onTimeout).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('does not leave the late work rejection unhandled after a timeout', async () => {
+    vi.useFakeTimers();
+    const unhandled = vi.fn();
+    process.on('unhandledRejection', unhandled);
+    try {
+      let rejectWork!: (e: unknown) => void;
+      const work = new Promise<string>((_, reject) => { rejectWork = reject; });
+      const raced = withQueryTimeout(work, 1000, () => { /* would KILL here */ });
+      const assertion = expect(raced).rejects.toBeInstanceOf(DriverError);
+      await vi.advanceTimersByTimeAsync(1000);
+      await assertion;
+      // The statement's error arrives only after the timeout already won the race.
+      rejectWork(new Error('query interrupted'));
+      await vi.advanceTimersByTimeAsync(0);
+      await Promise.resolve();
+      expect(unhandled).not.toHaveBeenCalled();
+    } finally {
+      process.off('unhandledRejection', unhandled);
+      vi.useRealTimers();
+    }
+  });
+});

--- a/server/src/drivers/timeout.ts
+++ b/server/src/drivers/timeout.ts
@@ -1,0 +1,46 @@
+import { DriverError } from './interface.js';
+
+/** Human-readable rendering of a timeout used in the surfaced error message. */
+export function timeoutLabel(timeoutMs: number): string {
+  if (timeoutMs >= 60_000 && timeoutMs % 60_000 === 0) return `${timeoutMs / 60_000}m`;
+  if (timeoutMs >= 1000) return `${Math.round(timeoutMs / 1000)}s`;
+  return `${timeoutMs}ms`;
+}
+
+/** The error surfaced to the client when a query is cancelled for exceeding its deadline. */
+export function timeoutError(timeoutMs: number, cause?: unknown): DriverError {
+  return new DriverError(
+    `Query cancelled: exceeded the ${timeoutLabel(timeoutMs)} timeout.`,
+    'transient',
+    cause === undefined ? undefined : { cause },
+  );
+}
+
+/**
+ * Race a query promise against a deadline. When the timer wins, `onTimeout` is
+ * invoked — drivers use it to cancel the in-flight statement on the server
+ * (MySQL `KILL QUERY`, Postgres `pg_cancel_backend`) — and the returned promise
+ * rejects with a `transient` DriverError carrying the reason. A falsy or
+ * non-positive `timeoutMs` disables the timeout and `work` is returned as-is.
+ *
+ * `Promise.race` keeps a rejection handler attached to `work`, so the statement's
+ * eventual error (it settles shortly after `onTimeout` cancels it) is consumed
+ * here and never surfaces as an unhandled rejection.
+ */
+export function withQueryTimeout<T>(
+  work: Promise<T>,
+  timeoutMs: number | undefined,
+  onTimeout: () => void,
+): Promise<T> {
+  if (!timeoutMs || timeoutMs <= 0) return work;
+
+  let timer: ReturnType<typeof setTimeout>;
+  const deadline = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => {
+      try { onTimeout(); } catch { /* best-effort cancel — the timeout still surfaces */ }
+      reject(timeoutError(timeoutMs));
+    }, timeoutMs);
+  });
+
+  return Promise.race([work, deadline]).finally(() => clearTimeout(timer));
+}

--- a/server/src/routes/query.test.ts
+++ b/server/src/routes/query.test.ts
@@ -39,7 +39,7 @@ describe('postQuery – driver delegation (sql mode)', () => {
       .send({ sql: 'SELECT * FROM users', schema: 'mydb' });
 
     expect(res.status).toBe(200);
-    expect(mockDriver.query).toHaveBeenCalledWith('SELECT * FROM users', [], 'mydb');
+    expect(mockDriver.query).toHaveBeenCalledWith('SELECT * FROM users', [], 'mydb', undefined);
     expect(res.body.columns).toEqual(['id', 'name']);
     expect(res.body.rows).toEqual([{ id: 1, name: 'Alice' }]);
     expect(res.body.columnMeta[0]).toMatchObject({ name: 'id', pk: true });
@@ -61,7 +61,7 @@ describe('postQuery – driver delegation (sql mode)', () => {
       .send({ sql: 'SELECT 1 AS one' });
 
     expect(res.status).toBe(200);
-    expect(mockDriver.query).toHaveBeenCalledWith('SELECT 1 AS one', [], undefined);
+    expect(mockDriver.query).toHaveBeenCalledWith('SELECT 1 AS one', [], undefined, undefined);
   });
 
   it('returns affectedRows and insertId for DML (empty columnMeta)', async () => {
@@ -102,7 +102,7 @@ describe('postQuery – driver delegation (sql mode)', () => {
       .send({ sql: 'SELECT 1 AS a; SELECT 2 AS b', schema: 'mydb' });
 
     expect(res.status).toBe(200);
-    expect(mockDriver.queryAll).toHaveBeenCalledWith('SELECT 1 AS a; SELECT 2 AS b', 'mydb');
+    expect(mockDriver.queryAll).toHaveBeenCalledWith('SELECT 1 AS a; SELECT 2 AS b', 'mydb', undefined);
     expect(mockDriver.query).not.toHaveBeenCalled();
     // Legacy fields mirror the first statement so old clients keep working.
     expect(res.body.columns).toEqual(['a']);
@@ -171,6 +171,78 @@ describe('postQuery – driver delegation (sql mode)', () => {
 
     expect(res.status).toBe(500);
     expect(res.body.error).toBe('something unexpected');
+  });
+});
+
+describe('postQuery – timeout forwarding', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('forwards a positive timeoutMs to driver.queryAll', async () => {
+    const mockDriver = {
+      queryMode: 'sql' as const,
+      query: vi.fn(),
+      queryAll: vi.fn().mockResolvedValue([{ rows: [], columnMeta: [] }]),
+    };
+    vi.mocked(getDriver).mockReturnValue(mockDriver as any);
+
+    await request(makeApp())
+      .post('/api/query')
+      .send({ sql: 'SELECT 1', schema: 'mydb', timeoutMs: 5000 });
+
+    expect(mockDriver.queryAll).toHaveBeenCalledWith('SELECT 1', 'mydb', 5000);
+  });
+
+  it('forwards a positive timeoutMs to driver.query in mql mode', async () => {
+    const mockDriver = {
+      queryMode: 'mql' as const,
+      query: vi.fn().mockResolvedValue({ rows: [], columnMeta: [] }),
+    };
+    vi.mocked(getDriver).mockReturnValue(mockDriver as any);
+
+    await request(makeApp())
+      .post('/api/query')
+      .send({ mql: { collection: 'c', operation: 'find' }, timeoutMs: 1500 });
+
+    const [, , , timeoutArg] = mockDriver.query.mock.calls[0];
+    expect(timeoutArg).toBe(1500);
+  });
+
+  it.each([
+    ['absent', undefined],
+    ['zero', 0],
+    ['negative', -1],
+    ['non-numeric', 'soon'],
+  ])('passes undefined when timeoutMs is %s', async (_label, value) => {
+    const mockDriver = {
+      queryMode: 'sql' as const,
+      query: vi.fn(),
+      queryAll: vi.fn().mockResolvedValue([{ rows: [], columnMeta: [] }]),
+    };
+    vi.mocked(getDriver).mockReturnValue(mockDriver as any);
+
+    await request(makeApp())
+      .post('/api/query')
+      .send({ sql: 'SELECT 1', timeoutMs: value });
+
+    expect(mockDriver.queryAll).toHaveBeenCalledWith('SELECT 1', undefined, undefined);
+  });
+
+  it('surfaces a transient timeout DriverError as HTTP 503', async () => {
+    const mockDriver = {
+      queryMode: 'sql' as const,
+      query: vi.fn(),
+      queryAll: vi.fn().mockRejectedValue(
+        new DriverError('Query cancelled: exceeded the 5s timeout.', 'transient'),
+      ),
+    };
+    vi.mocked(getDriver).mockReturnValue(mockDriver as any);
+
+    const res = await request(makeApp())
+      .post('/api/query')
+      .send({ sql: 'SELECT SLEEP(99)', timeoutMs: 5000 });
+
+    expect(res.status).toBe(503);
+    expect(res.body.error).toMatch(/exceeded the 5s timeout/i);
   });
 });
 

--- a/server/src/routes/query.ts
+++ b/server/src/routes/query.ts
@@ -4,11 +4,18 @@ import { DriverError } from '../drivers/interface.js';
 
 export const postQuery: RequestHandler = async (req, res) => {
   const driver = getDriver();
-  const { sql, mql, schema } = req.body as {
+  const { sql, mql, schema, timeoutMs: rawTimeout } = req.body as {
     sql?: unknown;
     mql?: unknown;
     schema?: string;
+    timeoutMs?: unknown;
   };
+
+  // A positive, finite number arms the per-query deadline; anything else
+  // (absent, 0, NaN, the client's "no timeout" choice) leaves it disarmed.
+  const timeoutMs = typeof rawTimeout === 'number' && Number.isFinite(rawTimeout) && rawTimeout > 0
+    ? rawTimeout
+    : undefined;
 
   let queryText: string;
 
@@ -47,8 +54,8 @@ export const postQuery: RequestHandler = async (req, res) => {
     // sql-mode drivers expose `queryAll` for multi-statement support; mql-mode
     // payloads are always a single request and use `query`.
     const resultList = driver.queryMode === 'sql' && driver.queryAll
-      ? await driver.queryAll(queryText, schema)
-      : [await driver.query(queryText, [], schema)];
+      ? await driver.queryAll(queryText, schema, timeoutMs)
+      : [await driver.query(queryText, [], schema, timeoutMs)];
     const executionTime = Date.now() - start;
 
     const results = resultList.map(r => ({

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -65,6 +65,20 @@ function readStoredTheme(): ThemeName {
   }
 }
 
+// Per-query timeout in seconds; 0 means "no timeout". Sent to the server, which
+// cancels an over-running query (KILL QUERY / pg_cancel_backend / maxTimeMS).
+const QUERY_TIMEOUT_KEY = 'helix.queryTimeoutSec';
+const DEFAULT_QUERY_TIMEOUT_SEC = 30;
+
+function readStoredQueryTimeout(): number {
+  try {
+    const v = Number(localStorage.getItem(QUERY_TIMEOUT_KEY));
+    return Number.isFinite(v) && v >= 0 ? v : DEFAULT_QUERY_TIMEOUT_SEC;
+  } catch {
+    return DEFAULT_QUERY_TIMEOUT_SEC;
+  }
+}
+
 export default function App() {
   const [themeName, setThemeName] = useState<ThemeName>(readStoredTheme);
   const t = themeName === 'dark' ? DARK : LIGHT;
@@ -73,6 +87,11 @@ export default function App() {
     document.documentElement.setAttribute('data-theme', themeName);
     try { localStorage.setItem(THEME_KEY, themeName); } catch { /* quota or disabled storage */ }
   }, [themeName]);
+
+  const [queryTimeoutSec, setQueryTimeoutSec] = useState<number>(readStoredQueryTimeout);
+  useEffect(() => {
+    try { localStorage.setItem(QUERY_TIMEOUT_KEY, String(queryTimeoutSec)); } catch { /* quota or disabled storage */ }
+  }, [queryTimeoutSec]);
 
   const [connected, setConnected] = useState(false);
   const [queryMode, setQueryMode] = useState<QueryMode>('sql');
@@ -327,10 +346,11 @@ export default function App() {
     updateTab(targetTab, { isRunning: true, results: null, resultSets: undefined, activeResultIndex: 0, queryError: null, execTime: null, explainPlan: null, explainSql: null, explainError: null });
 
     const started = Date.now();
+    const timeoutMs = queryTimeoutSec > 0 ? queryTimeoutSec * 1000 : undefined;
     try {
       const res = queryMode === 'mql'
-        ? await api.queryMql(mqlPayload, activeSchema)
-        : await api.query(text, activeSchema);
+        ? await api.queryMql(mqlPayload, activeSchema, timeoutMs)
+        : await api.query(text, activeSchema, timeoutMs);
       // The route always emits the legacy fields from the first statement; `results`
       // is the new array (one entry per statement). Old responses without it are
       // synthesised into a single-element array so the rest of the app stays uniform.
@@ -593,6 +613,8 @@ export default function App() {
               onDeleteSavedQuery={handleDeleteSavedQuery}
               onRenameSavedQuery={handleRenameSavedQuery}
               onReopenSavedQuery={handleReopenSavedQuery}
+              queryTimeoutSec={queryTimeoutSec}
+              onChangeQueryTimeout={setQueryTimeoutSec}
               t={t}
             />
           </div>

--- a/src/api.ts
+++ b/src/api.ts
@@ -145,17 +145,19 @@ export const api = {
     return request<{ ddl: string }>(`/api/table-ddl?schema=${encodeURIComponent(schema)}&table=${encodeURIComponent(name)}${t}`);
   },
 
-  query(sql: string, schema: string) {
+  // `timeoutMs`, when > 0, asks the server to cancel the query (KILL QUERY /
+  // pg_cancel_backend / maxTimeMS) after that many ms. Omit or pass 0 for none.
+  query(sql: string, schema: string, timeoutMs?: number) {
     return request<QueryResponse>(
       '/api/query',
-      { method: 'POST', body: JSON.stringify({ sql, schema }) }
+      { method: 'POST', body: JSON.stringify({ sql, schema, timeoutMs }) }
     );
   },
 
-  queryMql(mql: unknown, schema: string) {
+  queryMql(mql: unknown, schema: string, timeoutMs?: number) {
     return request<QueryResponse>(
       '/api/query',
-      { method: 'POST', body: JSON.stringify({ mql, schema }) }
+      { method: 'POST', body: JSON.stringify({ mql, schema, timeoutMs }) }
     );
   },
 

--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -48,8 +48,20 @@ interface QueryEditorProps {
   onDeleteSavedQuery?: (id: string) => void;
   onRenameSavedQuery?: (id: string, name: string) => void;
   onReopenSavedQuery?: (query: SavedQuery) => void;
+  /** Per-query timeout in seconds; 0 means no timeout. */
+  queryTimeoutSec?: number;
+  onChangeQueryTimeout?: (sec: number) => void;
   t: Theme;
 }
+
+// Options for the toolbar timeout picker. 0 = no timeout.
+const TIMEOUT_OPTIONS: { sec: number; label: string }[] = [
+  { sec: 0, label: 'No timeout' },
+  { sec: 10, label: '10s' },
+  { sec: 30, label: '30s' },
+  { sec: 60, label: '1m' },
+  { sec: 300, label: '5m' },
+];
 
 function formatRelative(ts: number, now: number): string {
   const s = Math.max(0, Math.round((now - ts) / 1000));
@@ -82,6 +94,7 @@ export function QueryEditor({
   value, onChange, onRun, isRunning, onExplain, isExplaining = false, queryMode = 'sql', activeSchema, schemaData, runtimeError,
   history = [], onReopenHistory, onDeleteHistoryEntry, onClearHistory,
   savedQueries = [], onSaveQuery, onDeleteSavedQuery, onRenameSavedQuery, onReopenSavedQuery,
+  queryTimeoutSec = 0, onChangeQueryTimeout,
   t,
 }: QueryEditorProps) {
   const isMql = queryMode === 'mql';
@@ -498,6 +511,8 @@ export function QueryEditor({
     explainBtn: { display: 'flex', alignItems: 'center', gap: 6, height: 28, padding: '0 10px', background: t.bgElevated, color: t.textPrimary, border: `1px solid ${t.border}`, borderRadius: 5, fontSize: 12, fontWeight: 500, fontFamily: '"IBM Plex Sans", sans-serif', cursor: 'pointer' } as CSSProperties,
     sep: { width: 1, height: 18, background: t.border, margin: '0 4px' } as CSSProperties,
     schemaPill: { display: 'flex', alignItems: 'center', gap: 5, fontSize: 11, color: t.textSecondary, fontFamily: 'monospace', background: t.bgElevated, border: `1px solid ${t.border}`, padding: '3px 9px', borderRadius: 4 } as CSSProperties,
+    timeoutPill: { display: 'flex', alignItems: 'center', gap: 4, color: t.textSecondary, background: t.bgElevated, border: `1px solid ${t.border}`, padding: '2px 6px', borderRadius: 4 } as CSSProperties,
+    timeoutSelect: { background: 'transparent', color: t.textSecondary, border: 'none', outline: 'none', fontSize: 11, fontFamily: '"IBM Plex Sans", sans-serif', cursor: 'pointer' } as CSSProperties,
     editorWrap: { flex: 1, display: 'flex', overflow: 'hidden', minHeight: 0 } as CSSProperties,
     lineNums: { background: t.bgToolbar, borderRight: `1px solid ${t.borderSubtle}`, padding: '12px 0', minWidth: 40, textAlign: 'right', userSelect: 'none', flexShrink: 0, overflowY: 'hidden' } as CSSProperties,
     lineNum: { padding: '0 10px', fontSize: 11, lineHeight: '21px', color: t.textMuted, fontFamily: '"JetBrains Mono", monospace' } as CSSProperties,
@@ -784,6 +799,26 @@ export function QueryEditor({
         </div>
 
         <div style={{ flex: 1 }}/>
+        {onChangeQueryTimeout && (
+          <label
+            style={s.timeoutPill}
+            data-tooltip={queryTimeoutSec > 0 ? 'Cancel queries that run longer than this' : 'Queries run with no time limit'}
+          >
+            <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <circle cx="12" cy="13" r="8"/><path d="M12 9v4l2 2"/><path d="M9 2h6"/>
+            </svg>
+            <select
+              aria-label="Query timeout"
+              value={String(queryTimeoutSec)}
+              onChange={e => onChangeQueryTimeout(Number(e.target.value))}
+              style={s.timeoutSelect}
+            >
+              {TIMEOUT_OPTIONS.map(o => (
+                <option key={o.sec} value={o.sec} style={{ color: t.textPrimary, background: t.bgElevated }}>{o.label}</option>
+              ))}
+            </select>
+          </label>
+        )}
         <span style={s.schemaPill}>
           <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
             <ellipse cx="12" cy="5" rx="9" ry="3"/><path d="M21 12c0 1.66-4 3-9 3s-9-1.34-9-3"/><path d="M3 5v14c0 1.66 4 3 9 3s9-1.34 9-3V5"/>


### PR DESCRIPTION
## Problem

Closes #22. Long-running queries couldn't be cancelled — once a slow query was running there was no way to abort it from the UI.

## What this does

Adds a user-configurable **per-query timeout**, shown as a compact picker in the query editor toolbar (No timeout / 10s / 30s / 1m / 5m) and persisted in `localStorage` (default **30s**).

The client sends `timeoutMs` with each `/api/query` request. When the deadline passes, the driver cancels the statement **on the server** using its idiomatic mechanism, and rejects with a `transient` `DriverError` whose message — `Query cancelled: exceeded the Ns timeout.` — surfaces in the existing results error banner (HTTP 503).

| Driver | Cancellation mechanism |
|--------|------------------------|
| MySQL | `KILL QUERY <threadId>` on a separate pooled connection |
| Postgres | `SELECT pg_cancel_backend(<pid>)` on a separate pooled client |
| MongoDB | `maxTimeMS` on the read ops (`find`/`findOne`/`aggregate`/`count`) |

A separate connection is used for the SQL cancel because the one running the timed-out query is busy.

### Connection hygiene on timeout

On timeout the SQL drivers **discard** the connection (`mysql2` `destroy()` / `pg` `release(true)`) rather than returning it to the pool: the `KILL`ed/cancelled statement is still draining on that socket, and a reused connection could hand the next caller a half-read result set. The pool opens a fresh connection on the next request.

### No unhandled rejections

A shared `withQueryTimeout` helper races the work promise against the deadline. `Promise.race` keeps a handler attached to the work promise, so the statement's eventual rejection (arriving just after the cancel) is consumed and never surfaces as an unhandled rejection. A falsy/zero/negative timeout disables the deadline entirely, so internal callers (insert/update/delete/explain) are unaffected.

## Scope

The timeout applies only to the user-facing `/api/query` path. Internal CRUD/DDL routes call the drivers without a timeout (unchanged 3-arg behavior).

## Testing

- New `server/src/drivers/timeout.test.ts` (13 tests): label/error formatting, work-wins, no-timeout passthrough, work-rejection passthrough, deadline-wins fires `onTimeout` + transient error, and the late-rejection-is-not-unhandled case (fake timers).
- New route tests: `timeoutMs` forwarding to `query`/`queryAll`, disarming on absent/0/negative/non-numeric, and 503 mapping for a transient timeout error.
- Updated existing route + mongodb assertions for the new argument shape.
- All suites green: **182 server / 76 client**. Client `tsc` + production build clean.

> [!NOTE]
> I could not run a full live end-to-end check (slow query → cancel) — the backend on this machine had no active DB connection and the browser-automation extension wasn't connected. The logic is covered by unit tests; a manual `SELECT SLEEP(10)` with a 5s timeout against a real MySQL/Postgres is worth a smoke test before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)