### PR TITLE
fix: single-click on sidebar table only toggles columns, not a new tab (#54)

### DIFF
--- a/src/components/SchemaBrowser.tsx
+++ b/src/components/SchemaBrowser.tsx
@@ -250,12 +250,17 @@ export function SchemaBrowser({ schema, activeTable, onTableSelect, onSchemaChan
               <div key={table.name}>
                 <div
                   style={{ ...s.tableRow, ...(activeTable === table.name ? s.tableRowActive : {}) }}
-                  onClick={() => { onTableSelect(table.name); toggleTable(table.name); }}
+                  // Single-click only expands/collapses the column list — it must
+                  // not steal the user's current editor tab. Opening a query tab
+                  // is a deliberate action: double-click, or the context menu's
+                  // "Query table". See #54.
+                  onClick={() => toggleTable(table.name)}
+                  onDoubleClick={() => onTableSelect(table.name)}
                   onContextMenu={(e) => {
                     e.preventDefault();
                     setContextMenu({ x: e.clientX, y: e.clientY, name: table.name, type: 'table' });
                   }}
-                  title={table.comment || undefined}
+                  title={table.comment ? `${table.comment} — double-click to query` : 'Double-click to query'}
                 >
                   <Chevron open={!!expandedTables[table.name]} color={t.textMuted}/>
                   <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke={activeTable === table.name ? t.accent : t.textMuted} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{flexShrink:0}}>
@@ -318,6 +323,12 @@ export function SchemaBrowser({ schema, activeTable, onTableSelect, onSchemaChan
           />
           {contextMenu.type === 'table' && (<>
             <div style={{ height: 1, background: t.borderSubtle, margin: '3px 0' }}/>
+            <CtxItem
+              t={t}
+              onClick={() => { onTableSelect(contextMenu.name); setContextMenu(null); }}
+              icon={<><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></>}
+              label="Query table"
+            />
             {onAlterTable && (
               <CtxItem
                 t={t}


### PR DESCRIPTION
## Problem

Closes #54. Single-clicking a table name in the schema browser both expanded/collapsed its column list **and** opened (or switched to) a `SELECT * FROM table LIMIT 100;` query tab. Users who just wanted to peek at column names were unintentionally navigated away from their current editor work.

## Fix

In `SchemaBrowser.tsx`, the table row's click handling is split:

- **Single-click** → toggles the column list expand/collapse only (`toggleTable`). It no longer touches the active tab or `onTableSelect`.
- **Double-click** → opens the query tab (`onTableSelect`), the deliberate action.
- **Right-click → "Query table"** → a new context-menu item, same deliberate `onTableSelect` path, for discoverability.

The hover tooltip now hints "double-click to query".

`onTableSelect` itself is unchanged, so the existing behaviour it drives is preserved: dedupe by `(schema, table)` so re-querying a table reuses its tab, and the PK-aware `SELECT` template (descending sort only for a single auto-increment PK).

## Notes

- Double-clicking fires two `onClick`s (toggle → toggle) before `onDoubleClick`, so expansion nets to its prior state while the tab opens — the standard tree-view trade-off, visually negligible.
- No behaviour test added: the repo has no component-test infra (no jsdom/RTL, vitest only matches `.test.ts`) and no existing SchemaBrowser tests. The change is pure handler rewiring; typecheck, lint, and the production build pass, and the existing 76 client tests are green.

> Per request, the app was not launched for manual verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)