### PR TITLE
chore: release 1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "helix",
   "private": true,
-  "version": "1.0.1",
+  "version": "1.1.0",
   "type": "module",
   "license": "AGPL-3.0-only",
   "main": "electron/main.cjs",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "helix-server",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "private": true,
   "type": "module",
   "license": "AGPL-3.0-only",


### PR DESCRIPTION
Version bump for the **v1.1.0** release. Bumps root and server `package.json` from 1.0.1 → 1.1.0.

A minor bump is warranted by the new user-facing features merged since v1.0.1 (EXPLAIN plan visualizer, SQL autocomplete).

## Included since v1.0.1

### Features
- Visualize `EXPLAIN FORMAT=JSON` plans (#172)
- Autocomplete column / table / keyword names in the SQL editor (#174)
- Classify driver errors into client/transient/server for accurate HTTP status codes (#170)

### Fixes
- Keep the query editor toolbar visible with large queries (#176, fixes #173)
- Single-click on a sidebar table only toggles columns instead of opening a new tab (#178, fixes #54)

### Internal
- Address EXPLAIN plan view review follow-ups (#175)

### Dependency / security updates
- Bump `qs` and `express` in `/server` (#169)
- Bump `ip-address` and `express-rate-limit` in `/server` (#168)

A **draft** GitHub release `v1.1.0` with the macOS Apple Silicon build attached will be created against this version; publish it once this PR is merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)