### PR TITLE
fix: driver-aware MCP toolset so MongoDB connections work (#180)

### DIFF
--- a/server/src/mcp.test.ts
+++ b/server/src/mcp.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('./db.js', () => ({
+  getDriver: vi.fn(),
+  getActiveConfig: vi.fn(),
+  isConnected: vi.fn(),
+}));
+vi.mock('./mcp-state.js', () => ({
+  isMcpWritesAllowed: vi.fn(),
+}));
+
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { getDriver, getActiveConfig, isConnected } from './db.js';
+import { isMcpWritesAllowed } from './mcp-state.js';
+import { buildMcpServer } from './mcp.js';
+
+async function connectClient() {
+  const server = buildMcpServer();
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const client = new Client({ name: 'test', version: '0' });
+  await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+  return { client, server };
+}
+
+function mockMongoDriver(query = vi.fn()) {
+  const driver = {
+    queryMode: 'mql' as const,
+    query,
+    getSchemas: vi.fn().mockResolvedValue(['shop']),
+    getSchema: vi.fn().mockResolvedValue({ tables: [{ name: 'users', rows: 3 }], views: [] }),
+    getTable: vi.fn().mockResolvedValue({ name: 'users', rows: 3, columns: [] }),
+    getCollectionInfo: vi.fn().mockResolvedValue({ validator: null, indexes: [] }),
+  };
+  vi.mocked(getDriver).mockReturnValue(driver as any);
+  return driver;
+}
+
+describe('MCP server – driver-aware toolset', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(isConnected).mockReturnValue(true);
+    vi.mocked(getActiveConfig).mockReturnValue({ type: 'mongodb', database: 'shop' } as any);
+    vi.mocked(isMcpWritesAllowed).mockReturnValue(false);
+  });
+
+  it('exposes MongoDB tools (not SQL tools) on a Mongo connection', async () => {
+    mockMongoDriver();
+    const { client } = await connectClient();
+    const names = (await client.listTools()).tools.map(t => t.name).sort();
+
+    expect(names).toContain('find_documents');
+    expect(names).toContain('aggregate_documents');
+    expect(names).toContain('count_documents');
+    expect(names).toContain('list_collections');
+    expect(names).not.toContain('execute_query');
+    expect(names).not.toContain('execute_write');
+  });
+
+  it('exposes SQL tools on a SQL connection', async () => {
+    vi.mocked(getActiveConfig).mockReturnValue({ type: 'postgres', database: 'shop' } as any);
+    vi.mocked(getDriver).mockReturnValue({ queryMode: 'sql' } as any);
+    const { client } = await connectClient();
+    const names = (await client.listTools()).tools.map(t => t.name).sort();
+
+    expect(names).toContain('execute_query');
+    expect(names).toContain('execute_write');
+    expect(names).not.toContain('find_documents');
+  });
+
+  it('server instructions tell the model it is MongoDB and not to write SQL', async () => {
+    mockMongoDriver();
+    const { client } = await connectClient();
+    const instructions = client.getInstructions() ?? '';
+
+    expect(instructions).toMatch(/mongodb/i);
+    expect(instructions).toMatch(/do not write sql/i);
+  });
+
+  it('find_documents assembles a JSON-encoded MQL request for the driver', async () => {
+    const query = vi.fn().mockResolvedValue({
+      rows: [{ _id: 'a1', email: 'x@y.z' }],
+      columnMeta: [{ name: '_id' }, { name: 'email' }],
+    });
+    mockMongoDriver(query);
+    const { client } = await connectClient();
+
+    const res: any = await client.callTool({
+      name: 'find_documents',
+      arguments: { collection: 'users', filter: { email: 'x@y.z' }, schema: 'shop' },
+    });
+
+    expect(res.isError).toBeFalsy();
+    const [sql, params, schema] = query.mock.calls[0];
+    expect(JSON.parse(sql)).toMatchObject({
+      collection: 'users',
+      operation: 'find',
+      filter: { email: 'x@y.z' },
+      limit: 100,
+    });
+    expect(params).toEqual([]);
+    expect(schema).toBe('shop');
+    expect(JSON.parse(res.content[0].text).documents).toEqual([{ _id: 'a1', email: 'x@y.z' }]);
+  });
+
+  it('blocks insert_document when writes are disabled', async () => {
+    const query = vi.fn();
+    mockMongoDriver(query);
+    const { client } = await connectClient();
+
+    const res: any = await client.callTool({
+      name: 'insert_document',
+      arguments: { collection: 'users', document: { email: 'x@y.z' } },
+    });
+
+    expect(res.isError).toBe(true);
+    expect(res.content[0].text).toMatch(/Allow MCP to modify data/);
+    expect(query).not.toHaveBeenCalled();
+  });
+
+  it('allows insert_document when writes are enabled', async () => {
+    vi.mocked(isMcpWritesAllowed).mockReturnValue(true);
+    const query = vi.fn().mockResolvedValue({ rows: [], columnMeta: [], affectedRows: 1 });
+    mockMongoDriver(query);
+    const { client } = await connectClient();
+
+    const res: any = await client.callTool({
+      name: 'insert_document',
+      arguments: { collection: 'users', document: { email: 'x@y.z' } },
+    });
+
+    expect(res.isError).toBeFalsy();
+    expect(JSON.parse(query.mock.calls[0][0])).toMatchObject({
+      collection: 'users',
+      operation: 'insertOne',
+      document: { email: 'x@y.z' },
+    });
+    expect(JSON.parse(res.content[0].text).insertedCount).toBe(1);
+  });
+
+  it('update_document requires a filter or id', async () => {
+    vi.mocked(isMcpWritesAllowed).mockReturnValue(true);
+    const query = vi.fn();
+    mockMongoDriver(query);
+    const { client } = await connectClient();
+
+    const res: any = await client.callTool({
+      name: 'update_document',
+      arguments: { collection: 'users', update: { $set: { active: true } } },
+    });
+
+    expect(res.isError).toBe(true);
+    expect(res.content[0].text).toMatch(/requires either "filter" or "id"/);
+    expect(query).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/mcp.ts
+++ b/server/src/mcp.ts
@@ -4,6 +4,7 @@ import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/
 import { z } from 'zod';
 import { getDriver, getActiveConfig, isConnected } from './db.js';
 import { isMcpWritesAllowed } from './mcp-state.js';
+import type { QueryResult } from './drivers/interface.js';
 
 const DEFAULT_ROW_LIMIT = 100;
 const MAX_ROW_LIMIT = 10_000;
@@ -32,20 +33,11 @@ function requireConnection(): string | null {
   return null;
 }
 
-export function buildMcpServer(): McpServer {
-  const server = new McpServer(
-    { name: 'helix-mcp', version: '0.1.0' },
-    {
-      capabilities: { tools: {} },
-      instructions: [
-        'Helix MCP exposes the database currently connected in the Helix UI.',
-        'Reads are always allowed. Writes (INSERT/UPDATE/DELETE/REPLACE) are only allowed',
-        'when the user has explicitly enabled them in the Helix UI top-right menu.',
-        'DDL (CREATE/DROP/ALTER/TRUNCATE/RENAME) is not supported in this version.',
-      ].join(' '),
-    },
-  );
+// ---------------------------------------------------------------------------
+// SQL tools (MySQL / Postgres — queryMode 'sql')
+// ---------------------------------------------------------------------------
 
+function registerSqlTools(server: McpServer): void {
   server.registerTool(
     'list_tables',
     {
@@ -202,6 +194,363 @@ export function buildMcpServer(): McpServer {
       }
     },
   );
+}
+
+// ---------------------------------------------------------------------------
+// MongoDB tools (queryMode 'mql')
+//
+// The Mongo driver speaks a JSON-encoded MQL request (see drivers/mongodb.ts).
+// Rather than make the model hand-author that JSON, each tool below exposes the
+// individual MQL fields as typed parameters and assembles the request itself.
+// ---------------------------------------------------------------------------
+
+const docSchema = z.record(z.string(), z.unknown());
+
+/** Build the JSON-encoded MQL request the Mongo driver's query() expects and run it. */
+function runMql(req: Record<string, unknown>, schema?: string): Promise<QueryResult> {
+  return getDriver().query(JSON.stringify(req), [], schema);
+}
+
+function registerMongoTools(server: McpServer): void {
+  server.registerTool(
+    'list_collections',
+    {
+      description:
+        'List collections (and views) in a MongoDB database. ' +
+        'If no database is given, lists the available databases.',
+      inputSchema: {
+        schema: z.string().optional().describe('Database name. Omit to list available databases.'),
+      },
+    },
+    async ({ schema }) => {
+      const err = requireConnection();
+      if (err) return toolError(err);
+
+      try {
+        const driver = getDriver();
+        if (!schema) {
+          const schemas = await driver.getSchemas();
+          return toolJson({ databases: schemas });
+        }
+        const info = await driver.getSchema(schema);
+        return toolJson({
+          database: schema,
+          collections: info.tables.map(t => ({ name: t.name, approxDocs: t.rows })),
+          views: info.views,
+        });
+      } catch (e) {
+        return toolError(e instanceof Error ? e.message : String(e));
+      }
+    },
+  );
+
+  server.registerTool(
+    'describe_collection',
+    {
+      description:
+        'Describe a MongoDB collection: field names and types inferred from a sample of documents ' +
+        '(schemaless — fields may vary per document), plus its indexes and JSON Schema validator if set.',
+      inputSchema: {
+        schema: z.string().describe('Database name.'),
+        collection: z.string().describe('Collection name.'),
+      },
+    },
+    async ({ schema, collection }) => {
+      const err = requireConnection();
+      if (err) return toolError(err);
+
+      try {
+        const driver = getDriver();
+        const info = await driver.getTable(schema, collection);
+        if (!info) {
+          return toolError(`Collection "${schema}"."${collection}" not found.`);
+        }
+        const collInfo = driver.getCollectionInfo
+          ? await driver.getCollectionInfo(schema, collection)
+          : null;
+        return toolJson({
+          database: schema,
+          collection,
+          approxDocs: info.rows,
+          fields: info.columns,
+          indexes: collInfo?.indexes ?? [],
+          validator: collInfo?.validator ?? null,
+        });
+      } catch (e) {
+        return toolError(e instanceof Error ? e.message : String(e));
+      }
+    },
+  );
+
+  server.registerTool(
+    'find_documents',
+    {
+      description:
+        'Find documents in a MongoDB collection (db.collection.find). ' +
+        `Returns up to ${DEFAULT_ROW_LIMIT} documents by default; pass "limit" (up to ${MAX_ROW_LIMIT}) to change. ` +
+        'Note: a string "_id" filter is matched literally and will not match an ObjectId — omit it or filter on other fields.',
+      inputSchema: {
+        collection: z.string().describe('Collection name.'),
+        filter: docSchema.optional().describe('MongoDB query filter, e.g. {"status": "active"}. Omit for all documents.'),
+        projection: docSchema.optional().describe('Fields to include/exclude, e.g. {"email": 1, "_id": 0}.'),
+        sort: docSchema.optional().describe('Sort spec, e.g. {"createdAt": -1}.'),
+        limit: z.number().int().positive().max(MAX_ROW_LIMIT).optional()
+          .describe(`Max documents returned (default ${DEFAULT_ROW_LIMIT}, max ${MAX_ROW_LIMIT}).`),
+        skip: z.number().int().nonnegative().optional().describe('Number of documents to skip.'),
+        schema: z.string().optional().describe('Database name. Omit to use the connected database.'),
+      },
+    },
+    async ({ collection, filter, projection, sort, limit, skip, schema }) => {
+      const err = requireConnection();
+      if (err) return toolError(err);
+
+      const cap = limit ?? DEFAULT_ROW_LIMIT;
+      try {
+        const start = Date.now();
+        const result = await runMql(
+          { collection, operation: 'find', filter, projection, sort, limit: cap, skip },
+          schema,
+        );
+        const executionTime = Date.now() - start;
+        return toolJson({
+          fields: result.columnMeta.map(c => c.name),
+          documents: result.rows,
+          docCount: result.rows.length,
+          limitApplied: cap,
+          executionTime,
+        });
+      } catch (e) {
+        return toolError(e instanceof Error ? e.message : String(e));
+      }
+    },
+  );
+
+  server.registerTool(
+    'aggregate_documents',
+    {
+      description:
+        'Run an aggregation pipeline on a MongoDB collection (db.collection.aggregate). ' +
+        `Results are capped at ${DEFAULT_ROW_LIMIT} documents by default; pass "limit" (up to ${MAX_ROW_LIMIT}) to change. ` +
+        'For large pipelines, add an explicit {"$limit": N} stage to bound work server-side.',
+      inputSchema: {
+        collection: z.string().describe('Collection name.'),
+        pipeline: z.array(docSchema).describe('Aggregation pipeline stages, e.g. [{"$match": {...}}, {"$group": {...}}].'),
+        limit: z.number().int().positive().max(MAX_ROW_LIMIT).optional()
+          .describe(`Max documents returned (default ${DEFAULT_ROW_LIMIT}, max ${MAX_ROW_LIMIT}).`),
+        schema: z.string().optional().describe('Database name. Omit to use the connected database.'),
+      },
+    },
+    async ({ collection, pipeline, limit, schema }) => {
+      const err = requireConnection();
+      if (err) return toolError(err);
+
+      const cap = limit ?? DEFAULT_ROW_LIMIT;
+      try {
+        const start = Date.now();
+        const result = await runMql({ collection, operation: 'aggregate', pipeline }, schema);
+        const executionTime = Date.now() - start;
+        const totalRows = result.rows.length;
+        const capped = result.rows.slice(0, cap);
+        return toolJson({
+          fields: result.columnMeta.map(c => c.name),
+          documents: capped,
+          docCount: capped.length,
+          totalDocs: totalRows,
+          truncated: totalRows > capped.length,
+          limitApplied: cap,
+          executionTime,
+        });
+      } catch (e) {
+        return toolError(e instanceof Error ? e.message : String(e));
+      }
+    },
+  );
+
+  server.registerTool(
+    'count_documents',
+    {
+      description: 'Count documents matching a filter in a MongoDB collection (db.collection.countDocuments).',
+      inputSchema: {
+        collection: z.string().describe('Collection name.'),
+        filter: docSchema.optional().describe('MongoDB query filter. Omit to count all documents.'),
+        schema: z.string().optional().describe('Database name. Omit to use the connected database.'),
+      },
+    },
+    async ({ collection, filter, schema }) => {
+      const err = requireConnection();
+      if (err) return toolError(err);
+
+      try {
+        const start = Date.now();
+        const result = await runMql({ collection, operation: 'count', filter }, schema);
+        const executionTime = Date.now() - start;
+        return toolJson({ count: result.rows[0]?.count ?? 0, executionTime });
+      } catch (e) {
+        return toolError(e instanceof Error ? e.message : String(e));
+      }
+    },
+  );
+
+  server.registerTool(
+    'insert_document',
+    {
+      description:
+        'Insert a single document into a MongoDB collection (db.collection.insertOne). ' +
+        'Requires the user to have enabled "Allow MCP to modify data" in the Helix UI.',
+      inputSchema: {
+        collection: z.string().describe('Collection name.'),
+        document: docSchema.describe('The document to insert.'),
+        schema: z.string().optional().describe('Database name. Omit to use the connected database.'),
+      },
+    },
+    async ({ collection, document, schema }) => {
+      const err = requireConnection();
+      if (err) return toolError(err);
+      if (!isMcpWritesAllowed()) {
+        return toolError(
+          'Writes are disabled. Ask the user to enable "Allow MCP to modify data" in the Helix UI (top-right menu).',
+        );
+      }
+
+      try {
+        const start = Date.now();
+        const result = await runMql({ collection, operation: 'insertOne', document }, schema);
+        const executionTime = Date.now() - start;
+        return toolJson({ insertedCount: result.affectedRows ?? 0, executionTime });
+      } catch (e) {
+        return toolError(e instanceof Error ? e.message : String(e));
+      }
+    },
+  );
+
+  server.registerTool(
+    'update_document',
+    {
+      description:
+        'Update a single document in a MongoDB collection (db.collection.updateOne). ' +
+        'Provide either "filter" or "id" to select the document, and "update" with operators like {"$set": {...}}. ' +
+        'Requires the user to have enabled "Allow MCP to modify data" in the Helix UI.',
+      inputSchema: {
+        collection: z.string().describe('Collection name.'),
+        update: docSchema.describe('Update document with operators, e.g. {"$set": {"status": "active"}}.'),
+        filter: docSchema.optional().describe('Filter selecting the document to update.'),
+        id: z.string().optional().describe('Convenience selector by _id (24-hex strings are matched as ObjectId, falling back to the raw value).'),
+        schema: z.string().optional().describe('Database name. Omit to use the connected database.'),
+      },
+    },
+    async ({ collection, update, filter, id, schema }) => {
+      const err = requireConnection();
+      if (err) return toolError(err);
+      if (!isMcpWritesAllowed()) {
+        return toolError(
+          'Writes are disabled. Ask the user to enable "Allow MCP to modify data" in the Helix UI (top-right menu).',
+        );
+      }
+      if (filter === undefined && id === undefined) {
+        return toolError('update_document requires either "filter" or "id" to select the document.');
+      }
+
+      try {
+        const start = Date.now();
+        const result = await runMql({ collection, operation: 'updateOne', update, filter, id }, schema);
+        const executionTime = Date.now() - start;
+        return toolJson({ matchedCount: result.affectedRows ?? 0, executionTime });
+      } catch (e) {
+        return toolError(e instanceof Error ? e.message : String(e));
+      }
+    },
+  );
+
+  server.registerTool(
+    'delete_document',
+    {
+      description:
+        'Delete a single document from a MongoDB collection (db.collection.deleteOne). ' +
+        'Provide either "filter" or "id" to select the document. ' +
+        'Requires the user to have enabled "Allow MCP to modify data" in the Helix UI.',
+      inputSchema: {
+        collection: z.string().describe('Collection name.'),
+        filter: docSchema.optional().describe('Filter selecting the document to delete.'),
+        id: z.string().optional().describe('Convenience selector by _id (24-hex strings are matched as ObjectId, falling back to the raw value).'),
+        schema: z.string().optional().describe('Database name. Omit to use the connected database.'),
+      },
+    },
+    async ({ collection, filter, id, schema }) => {
+      const err = requireConnection();
+      if (err) return toolError(err);
+      if (!isMcpWritesAllowed()) {
+        return toolError(
+          'Writes are disabled. Ask the user to enable "Allow MCP to modify data" in the Helix UI (top-right menu).',
+        );
+      }
+      if (filter === undefined && id === undefined) {
+        return toolError('delete_document requires either "filter" or "id" to select the document.');
+      }
+
+      try {
+        const start = Date.now();
+        const result = await runMql({ collection, operation: 'deleteOne', filter, id }, schema);
+        const executionTime = Date.now() - start;
+        return toolJson({ deletedCount: result.affectedRows ?? 0, executionTime });
+      } catch (e) {
+        return toolError(e instanceof Error ? e.message : String(e));
+      }
+    },
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Server assembly
+// ---------------------------------------------------------------------------
+
+/**
+ * The active query language for the connected database. Defaults to 'sql' when
+ * nothing is connected so the (backward-compatible) SQL toolset is advertised.
+ * The transport is stateless, so `tools/list` is re-evaluated on every request
+ * and always reflects the database connected at that moment.
+ */
+function activeQueryMode(): 'sql' | 'mql' {
+  return isConnected() ? getDriver().queryMode : 'sql';
+}
+
+function buildInstructions(mode: 'sql' | 'mql'): string {
+  const cfg = getActiveConfig();
+  const dbType = cfg?.type ?? 'none';
+  const base = [
+    'Helix MCP exposes the database currently connected in the Helix UI.',
+    `The connected database is ${isConnected() ? `a ${dbType} database` : 'not connected yet'}.`,
+  ];
+  if (mode === 'mql') {
+    base.push(
+      'This is a MongoDB (document) database — use the MongoDB tools (find_documents, aggregate_documents, count_documents, ...).',
+      'Do NOT write SQL: there are no SELECT/SHOW statements here, only collections and documents.',
+      'Writes (insert/update/delete) are only allowed when the user has enabled "Allow MCP to modify data" in the Helix UI top-right menu.',
+    );
+  } else {
+    base.push(
+      'This is a SQL database — use SQL via execute_query (reads) and execute_write (writes).',
+      'Writes (INSERT/UPDATE/DELETE/REPLACE) are only allowed when the user has enabled "Allow MCP to modify data" in the Helix UI top-right menu.',
+      'DDL (CREATE/DROP/ALTER/TRUNCATE/RENAME) is not supported in this version.',
+    );
+  }
+  return base.join(' ');
+}
+
+export function buildMcpServer(): McpServer {
+  const mode = activeQueryMode();
+  const server = new McpServer(
+    { name: 'helix-mcp', version: '0.1.0' },
+    {
+      capabilities: { tools: {} },
+      instructions: buildInstructions(mode),
+    },
+  );
+
+  if (mode === 'mql') {
+    registerMongoTools(server);
+  } else {
+    registerSqlTools(server);
+  }
 
   return server;
 }


### PR DESCRIPTION
Fixes #180.

## Problem

When Helix is connected to MongoDB, the MCP server is unusable for AI agents — no query returns a single row. The tools were hard-coded to be SQL-shaped regardless of the connected driver, and the SQL keyword gate (`firstKeyword`) and the MQL driver impose mutually-exclusive requirements:

- SQL in → passes the keyword gate → driver rejects with *"expects a JSON-encoded MQL request"*
- MQL JSON in → rejected by the keyword gate (*"Got: unknown"* / *"Got: DB."*) before reaching the driver

See #180 for the full write-up and an agent transcript hitting the dead-end.

## Fix

`buildMcpServer()` now branches on `getDriver().queryMode` and registers one of two mutually-exclusive tool sets:

| mode | tools |
|------|-------|
| `sql` | `execute_query`, `execute_write`, `list_tables`, `describe_table` (unchanged) |
| `mql` | reads: `find_documents`, `aggregate_documents`, `count_documents`, `list_collections`, `describe_collection` · writes (gated): `insert_document`, `update_document`, `delete_document` |

The MongoDB tools expose MQL fields (`filter`, `projection`, `sort`, `pipeline`, `document`, `update`, …) as **typed parameters** and assemble the JSON-encoded request the driver already parses — the model never hand-authors MQL JSON. `describe_collection` also surfaces indexes + the JSON Schema validator via the driver's existing `getCollectionInfo()`.

**Agents know SQL vs NoSQL upfront** two ways: (1) the wrong tools aren't registered (an agent on Mongo never sees `execute_query`), and (2) the MCP `instructions` are mode-aware and name the connected DB type, e.g. *"This is a MongoDB (document) database… Do NOT write SQL."*

This slots into the existing architecture cleanly: the transport is stateless and `buildMcpServer()` already runs per request, so `tools/list` reflects the currently-connected database.

## Tests

New `server/src/mcp.test.ts` (7 tests, via the SDK in-memory transport):
- Mongo connection exposes Mongo tools and **not** `execute_query`/`execute_write`
- SQL connection exposes SQL tools and not the Mongo tools
- mode-aware instructions say MongoDB / don't-write-SQL
- `find_documents` assembles the correct `{collection, operation:'find', filter, limit}` JSON and passes schema through
- `insert_document` blocked when writes disabled, allowed when enabled
- `update_document` requires a `filter` or `id`

All 169 server tests pass; `mcp.ts` and `mcp.test.ts` are type-clean and `mcp.ts` is lint-clean. (3 pre-existing `tsc` errors in unrelated driver test files are untouched.)

## Known follow-ups (out of scope)
- `_id` ObjectId matching in `find`/`count` filters (string `_id` matched literally; relates to existing TODO #107). An `id` convenience param is exposed on update/delete.
- Stateless transport: a client that cached the tool list won't get a `tools/list_changed` push if the user switches DB type mid-session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
